### PR TITLE
Fix image rendering for zenodo link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Requirements:
 
 Preferably at least one of:
 `pyfits <http://www.stsci.edu/resources/software_hardware/pyfits/Download>`_
-`atpy <http://atpy.github.com/>`_
+`atpy <http://atpy.readthedocs.org/>`_
 `asciitable <http://cxc.harvard.edu/contrib/asciitable/>`_
 
 Optional:
@@ -51,7 +51,7 @@ Authors:
 (or both of us at pyspeckit@gmail.com)
 
 The PySpecKit logo uses the Voyager 1 image of Earth known as the "Pale Blue Dot"
-[ `original source <http://visibleearth.nasa.gov/view_rec.php?id=601>`_ |  `reprocessed image <http://instructors.cwrl.utexas.edu/mcginnis/sites/instructors.cwrl.utexas.edu.mcginnis/files/pale_blue_dot2.jpg>`_ ]
+[ `original source <http://visibleearth.nasa.gov/view_rec.php?id=601>`_ |  `reprocessed image <http://instructors.dwrl.utexas.edu/mcginnis/sites/instructors.cwrl.utexas.edu.mcginnis/files/pale_blue_dot2.jpg>`_ ]
 
 
 .. image:: https://zenodo.org/badge/6907/pyspeckit/pyspeckit.png


### PR DESCRIPTION
Fixed image in target link by using two lines.

This problem seems to be related to this issue:
https://github.com/travis-ci/travis-web/issues/263
