### PR TITLE
Add documentation to cubes

### DIFF
--- a/docs/cubes.rst
+++ b/docs/cubes.rst
@@ -29,16 +29,22 @@ or from arrays:
    >>> myxaxis = np.linspace(-100,100,250)
    >>> pcube = pyspeckit.Cube(cube=mycube, xarr=myxaxis, xunit='km/s')
 
-The most interesting features of the `Cube` object are the `fiteach` method,
-which fits a model spectrum to each element of the cube, and `mapplot`, which
-plots up various projections of the cube.
+The most interesting features of the
+:class:`~pyspeckit.cubes.SpectralCube.Cube` object are the
+:meth:`~pyspeckit.cubes.SpectralCube.Cube.fiteach` method, which fits a model
+spectrum to each element of the cube, and
+:class:`mapplot <pyspeckit.cubes.mapplot.MapPlotter>`, which plots up various
+projections of the cube.
 
-`~pyspeckit.cube.SpectralCube.mapplot` will create an interactive plot window.
+:class:`Cube.mapplot <pyspeckit.cubes.mapplot.MapPlotter>` will create an interactive plot window.
 You can click on any pixel shown in that window and pull up a second window
 showing the spectrum at that pixel.  If you've fitted the cube, the associated
 best-fit model will also be shown.
 This interactive setup can be a bit fragile, though, so please report bugs
 aggressively so we can weed them out!
+
+The interactive viewer has a few button interactions described :meth:`here
+<pyspeckit.cubes.mapplot.MapPlotter.mapplot>`.
 
 
 .. automodule:: pyspeckit.cubes.SpectralCube

--- a/docs/cubes.rst
+++ b/docs/cubes.rst
@@ -1,6 +1,35 @@
 Cubes
 -----
 
+Pyspeckit can do a few things with spectral cubes.  The most interesting is the
+spectral line fitting. 
+
+:class:`~pyspeckit.cubes.SpectralCube.Cube` objects have a
+:meth:`~pyspeckit.cubes.SpectralCube.Cube.fiteach` method that will fit each
+spectral line within a cube.  It can be made to do this in parallel with the
+``multicore`` option.
+
+As of version 0.16, pyspeckit cubes can be read from SpectralCube_ objects:
+
+.. code::
+
+   >>> pcube = pyspeckit.Cube(cube=mySpectralCube)
+
+Otherwise, they can be created from FITS cubes on disk:
+
+.. code::
+
+   >>> pcube = pyspeckit.Cube(filename="mycube.fits")
+
+or from arrays:
+
+.. code::
+
+   >>> mycube = np.random.randn(250,50,50)
+   >>> myxaxis = np.linspace(-100,100,250)
+   >>> pcube = pyspeckit.Cube(cube=mycube, xarr=myxaxis, xunit='km/s')
+
+
 .. automodule:: pyspeckit.cubes.SpectralCube
 .. autoclass:: Cube
     :show-inheritance:
@@ -20,3 +49,5 @@ Cubes
 
 .. automodule:: pyspeckit.cubes.cubes
     :members:
+
+.. _SpectralCube: http://spectral-cube.readthedocs.org/en/latest/

--- a/docs/cubes.rst
+++ b/docs/cubes.rst
@@ -29,6 +29,17 @@ or from arrays:
    >>> myxaxis = np.linspace(-100,100,250)
    >>> pcube = pyspeckit.Cube(cube=mycube, xarr=myxaxis, xunit='km/s')
 
+The most interesting features of the `Cube` object are the `fiteach` method,
+which fits a model spectrum to each element of the cube, and `mapplot`, which
+plots up various projections of the cube.
+
+`~pyspeckit.cube.SpectralCube.mapplot` will create an interactive plot window.
+You can click on any pixel shown in that window and pull up a second window
+showing the spectrum at that pixel.  If you've fitted the cube, the associated
+best-fit model will also be shown.
+This interactive setup can be a bit fragile, though, so please report bugs
+aggressively so we can weed them out!
+
 
 .. automodule:: pyspeckit.cubes.SpectralCube
 .. autoclass:: Cube

--- a/pyspeckit/cubes/mapplot.py
+++ b/pyspeckit/cubes/mapplot.py
@@ -49,6 +49,9 @@ except ImportError:
 class MapPlotter(object):
     """
     Class to plot a spectrum
+
+    See `mapplot` for use documentation; this docstring is only for
+    initialization.
     """
 
     def __init__(self, Cube=None, figure=None, doplot=False, **kwargs):
@@ -92,10 +95,43 @@ class MapPlotter(object):
         The map to be plotted is selected using `makeplane`.
         The `estimator` keyword argument is passed to that function.
 
-        `kwargs` are passed to aplpy.show_colorscale or
-        matplotlib.pyplot.imshow (depending on whether aplpy is installed)
+        The plotted map, once shown, is interactive.  You can click on it with any 
+        of the three mouse buttons. 
 
-        .. todo: Allow mapplot in subfigure
+        Button 1 or keyboard '1':
+            Plot the selected pixel's spectrum in another window.  Mark the
+            clicked pixel with an 'x'
+        Button 2 or keyboard 'o':
+            Overplot a second (or third, fourth, fifth...) spectrum in the
+            external plot window
+        Button 3:
+            Disconnect the interactive viewer
+
+        You can also click-and-drag with button 1 to average over a circular
+        region.  This same effect can be achieved by using the 'c' key to
+        set the /c/enter of a circle and the 'r' key to set its /r/adius (i.e.,
+        hover over the center and press 'c', then hover some distance away and
+        press 'r').
+
+
+        Parameters
+        ----------
+        convention : 'calabretta' or 'griesen'
+            The default projection to assume for Galactic data when plotting
+            with aplpy.
+        colorbar : bool
+            Whether to show a colorbar
+        plotkwargs : dict, optional
+            A dictionary of keyword arguments to pass to aplpy.show_colorscale
+            or matplotlib.pyplot.imshow
+        useaplpy : bool
+            Use aplpy if a FITS header is available
+        vmin, vmax: float or None
+            Override values for the vmin/vmax values.  Will be automatically
+            determined if left as None
+
+        .. todo:
+            Allow mapplot in subfigure
         """
         if self.figure is None:
             self.figure = matplotlib.pyplot.figure()
@@ -159,11 +195,13 @@ class MapPlotter(object):
 
     def makeplane(self, estimator=np.mean):
         """
+        Create a "plane" view of the cube, either by slicing or projecting it
+        or by showing a slice from the best-fit model parameter cube.
 
         Parameters
         ----------
 
-        *estimator* [ function | 'max' | 'int' | FITS filename | integer | slice ]
+        estimator : [ function | 'max' | 'int' | FITS filename | integer | slice ]
             A non-pythonic, non-duck-typed variable.  If it's a function, apply that function
             along the cube's spectral axis to obtain an estimate (e.g., mean, min, max, etc.).
             'max' will do the same thing as passing np.max

--- a/pyspeckit/spectrum/classes.py
+++ b/pyspeckit/spectrum/classes.py
@@ -292,10 +292,10 @@ class Spectrum(object):
         xtype = Table.data.dtype.names[Table.xaxcol]
         if xtype in units.xtype_dict.values():
             self.xarr.xtype = xtype
-            self.xarr.units = Table.columns[xtype].unit
+            self.xarr.unit = Table.columns[xtype].unit
         elif xtype in units.xtype_dict:
             self.xarr.xtype = units.xtype_dict[xtype]
-            self.xarr.units = Table.columns[xtype].unit
+            self.xarr.unit = Table.columns[xtype].unit
         else:
             warn( "Warning: Invalid xtype in text header - this may mean no text header was available.  X-axis units will be pixels unless you set them manually (e.g., sp.xarr.unit='angstroms')")
             self.xarr.xtype = 'pixels'
@@ -311,7 +311,7 @@ class Spectrum(object):
         self._update_header()
 
     def _update_header(self):
-        self.header['CUNIT1'] = self.xarr.units
+        self.header['CUNIT1'] = self.xarr.unit
         self.header['CTYPE1'] = self.xarr.xtype
         self.header['BUNIT'] = self.unit
         self.header['BTYPE'] = self.ytype
@@ -326,11 +326,11 @@ class Spectrum(object):
         """    
         
         self.xarr.xtype = hdr['xtype']
-        self.xarr.xunits = hdr['xunits']
+        self.xarr.xunit = hdr['xunit']
         self.ytype = hdr['ytype']
-        self.unit = hdr['yunits']
+        self.unit = hdr['yunit']
         self.header = pyfits.Header()
-        self.header['CUNIT1'] = self.xarr.xunits
+        self.header['CUNIT1'] = self.xarr.xunit
         self.header['CTYPE1'] = self.xarr.xtype
         self.header['BUNIT'] = self.ytype
         self.header['BTYPE'] = self.unit
@@ -372,7 +372,7 @@ class Spectrum(object):
                 fluxnorm=fluxnorm, miscline=miscline, misctol=misctol,
                 ignore=ignore, derive=derive, **kwargs)
 
-    def crop(self, x1, x2, units=None, **kwargs):
+    def crop(self, x1, x2, unit=None, **kwargs):
         """
         Replace the current spectrum with a subset from x1 to x2 in current
         units
@@ -381,13 +381,13 @@ class Spectrum(object):
 
         """
         # do slice (this code is redundant... need to figure out how to fix that)
-        x1pix = np.argmin(np.abs(x1-self.xarr.as_unit(units)))
-        x2pix = np.argmin(np.abs(x2-self.xarr.as_unit(units)))
+        x1pix = np.argmin(np.abs(x1-self.xarr.as_unit(unit)))
+        x2pix = np.argmin(np.abs(x2-self.xarr.as_unit(unit)))
         if x1pix > x2pix: x1pix,x2pix = x2pix,x1pix
         if x1pix == x2pix:
             raise IndexError("ERROR: Trying to crop to zero size.")
 
-        self = self.slice(x1pix, x2pix, units='pixels', copy=False, **kwargs)
+        self = self.slice(x1pix, x2pix, unit='pixels', copy=False, **kwargs)
         # a baseline spectrum is always defined, even if it is all zeros
         # this is needed to prevent size mismatches.  There may be a more
         # elegant way to do this...
@@ -403,7 +403,7 @@ class Spectrum(object):
                 self.header['CRPIX1'] = self.header.get('CRPIX1') - x1pix
                 history.write_history(self.header,"CROP: Changed CRPIX1 from %f to %f" % (self.header.get('CRPIX1')+x1pix,self.header.get('CRPIX1')))
 
-    def slice(self, start=None, stop=None, units='pixel', copy=True, preserve_fits=False):
+    def slice(self, start=None, stop=None, unit='pixel', copy=True, preserve_fits=False):
         """Slicing the spectrum
 
         .. WARNING:: this is the same as cropping right now, but it returns a
@@ -415,7 +415,7 @@ class Spectrum(object):
             start of slice
         stop :  numpy.float or int
             stop of slice
-        units : str
+        unit : str
             allowed values are any supported physical unit, 'pixel'
         copy : bool
             Return a 'view' of the data or a copy?
@@ -423,11 +423,11 @@ class Spectrum(object):
             Save the fitted parameters from self.fitter?
         """
         
-        if units in ('pixel','pixels'):
+        if unit in ('pixel','pixels'):
             start_ind = start
             stop_ind  = stop
         else:
-            x_in_units = self.xarr.as_unit(units)
+            x_in_units = self.xarr.as_unit(unit)
             start_ind = x_in_units.x_to_pix(start)
             stop_ind  = x_in_units.x_to_pix(stop)
         if start_ind > stop_ind: start_ind,stop_ind = stop_ind,start_ind
@@ -575,7 +575,7 @@ class Spectrum(object):
         else:
             name = ""
         return r'<Spectrum object%s over spectral range %6.5g : %6.5g %s and flux range = [%2.1f, %2.1f] %s at %s>' % \
-                (name, self.xarr.min(), self.xarr.max(), self.xarr.units,
+                (name, self.xarr.min(), self.xarr.max(), self.xarr.unit,
                         self.data.min(), self.data.max(), self.unit,
                         str(hex(self.__hash__())))
     
@@ -717,12 +717,12 @@ class Spectrum(object):
         return self._arithmetic_threshold_value
 
     @_arithmetic_threshold.setter
-    def _arithmetic_threshold(self, value, units=None):
+    def _arithmetic_threshold(self, value, unit=None):
         self._arithmetic_threshold_value = value
-        if units is None:
-            self._arithmetic_threshold_units = self.xarr.units
+        if unit is None:
+            self._arithmetic_threshold_units = self.xarr.unit
         else:
-            self._arithmetic_threshold_units = units
+            self._arithmetic_threshold_units = unit
 
     _arithmetic_threshold_value = 'exact'
     _arithmetic_threshold_units = None
@@ -747,7 +747,7 @@ class Spectra(Spectrum):
     X array is forcibly sorted in increasing order
     """
 
-    def __init__(self, speclist, xunits='GHz', **kwargs):
+    def __init__(self, speclist, xunit='GHz', **kwargs):
         print "Creating spectra"
         speclist = list(speclist)
         for ii,spec in enumerate(speclist):
@@ -758,9 +758,9 @@ class Spectra(Spectrum):
         self.speclist = speclist
 
         print "Concatenating data"
-        self.xarr = units.SpectroscopicAxes([sp.xarr.as_unit(xunits) for sp in speclist])
-        self.xarr.units = xunits 
-        self.xarr.xtype = units.unit_type_dict[xunits]
+        self.xarr = units.SpectroscopicAxes([sp.xarr.as_unit(xunit) for sp in speclist])
+        self.xarr.unit = xunit
+        self.xarr.xtype = units.unit_type_dict[xunit]
         self.data = np.ma.concatenate([sp.data for sp in speclist])
         self.error = np.ma.concatenate([sp.error for sp in speclist])
         self._sort()
@@ -778,10 +778,10 @@ class Spectra(Spectrum):
         self.specfit = fitters.Specfit(self,Registry=self.Registry)
         self.baseline = baseline.Baseline(self)
         
-        self.unit = speclist[0].units
+        self.unit = speclist[0].unit
         for spec in speclist:
             if spec.unit != self.unit:
-                raise ValueError("Mismatched units")
+                raise ValueError("Mismatched unit")
 
         # Special.  This needs to be modified to be more flexible; for now I need it to work for nh3
         self.plot_special = None
@@ -797,11 +797,11 @@ class Spectra(Spectrum):
         elif type(other) is Spectrum:
             self.speclist += [other.speclist]
         if other.unit != self.unit:
-            raise ValueError("Mismatched units")
+            raise ValueError("Mismatched unit")
 
-        if other.xarr.units != self.xarr.units:
-            # convert all inputs to same units
-            spec.xarr.convert_to_units(self.xarr.units,**kwargs)
+        if other.xarr.unit != self.xarr.unit:
+            # convert all inputs to same unit
+            spec.xarr.convert_to_units(self.xarr.unit,**kwargs)
         self.xarr = units.SpectroscopicAxes([self.xarr,spec.xarr])
         self.data = np.concatenate([self.data,spec.data])
         self.error = np.concatenate([self.error,spec.error])
@@ -845,24 +845,26 @@ class Spectra(Spectrum):
             self.fittable = atpy.Table()
             self.fittable.add_column('name',[sp.specname for sp in self.speclist])
             self.fittable.add_column('amplitude',[sp.specfit.modelpars[0] for sp in self.speclist],unit=self.unit)
-            self.fittable.add_column('center',[sp.specfit.modelpars[1] for sp in self.speclist],unit=self.xarr.units)
-            self.fittable.add_column('width',[sp.specfit.modelpars[2] for sp in self.speclist],unit=self.xarr.units)
+            self.fittable.add_column('center',[sp.specfit.modelpars[1] for sp in self.speclist],unit=self.xarr.unit)
+            self.fittable.add_column('width',[sp.specfit.modelpars[2] for sp in self.speclist],unit=self.xarr.unit)
             self.fittable.add_column('amplitudeerr',[sp.specfit.modelerrs[0] for sp in self.speclist],unit=self.unit)
-            self.fittable.add_column('centererr',[sp.specfit.modelerrs[1] for sp in self.speclist],unit=self.xarr.units)
-            self.fittable.add_column('widtherr',[sp.specfit.modelerrs[2] for sp in self.speclist],unit=self.xarr.units)
+            self.fittable.add_column('centererr',[sp.specfit.modelerrs[1] for sp in self.speclist],unit=self.xarr.unit)
+            self.fittable.add_column('widtherr',[sp.specfit.modelerrs[2] for sp in self.speclist],unit=self.xarr.unit)
 
-    def ploteach(self, xunits=None, inherit_fit=False, plot_fit=True, plotfitkwargs={}, **plotkwargs):
+    def ploteach(self, xunit=None, inherit_fit=False, plot_fit=True,
+                 plotfitkwargs={}, **plotkwargs):
         """
         Plot each spectrum in its own window
         inherit_fit - if specified, will grab the fitter & fitter properties from Spectra
         """
         for sp in self.speclist:
-            if xunits is not None:
-                sp.xarr.convert_to_unit(xunits,quiet=True)
+            if xunit is not None:
+                sp.xarr.convert_to_unit(xunit,quiet=True)
             if inherit_fit:
                 sp.specfit.fitter = self.specfit.fitter
                 sp.specfit.modelpars = self.specfit.modelpars
-                sp.specfit.model = np.interp(sp.xarr.as_unit(self.xarr.units),self.xarr,self.specfit.fullmodel)
+                sp.specfit.model = np.interp(sp.xarr.as_unit(self.xarr.unit),
+                                             self.xarr, self.specfit.fullmodel)
 
             sp.plotter(**plotkwargs)
             

--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -417,6 +417,8 @@ class SpectroscopicAxis(np.ndarray):
         else:
             subarr.velocity_convention = velocity_convention
 
+        subarr.unit = subarr.units
+
         return subarr
 
     def __array_finalize__(self,obj):
@@ -425,7 +427,7 @@ class SpectroscopicAxis(np.ndarray):
         around, e.g.:
         xarr = self[1:20]
         """
-        self.units = getattr(obj, 'units', None)
+        self.unit = self.units = getattr(obj, 'unit', None) or getattr(obj, 'units', None)
         self.frame = getattr(obj, 'frame', None)
         self.xtype = getattr(obj, 'xtype', None)
         self.refX = getattr(obj, 'refX', None)

--- a/pyspeckit/wrappers/fitnh3.py
+++ b/pyspeckit/wrappers/fitnh3.py
@@ -58,6 +58,7 @@ def fitnh3tkin(input_dict, dobaseline=True, baselinekwargs={}, crop=False, guess
         for sp in splist:
             sp.smooth(smooth)
 
+    #TODO: add guesses = moments here
     spdict[guessline].specfit(fittype='gaussian', negamp=False, vheight=False)
     ampguess,vguess,widthguess = spdict[guessline].specfit.modelpars
     if widthguess < 0:


### PR DESCRIPTION
The Cube component of pyspeckit was nearly undocumented.  This PR adds documentation.  In the process, I also refactored some of the unit/units stuff so that the singular is preferred (but the plural is still allowed, for now).