### PR TITLE
Fix the NH3 multifit test

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -494,7 +494,8 @@ class Cube(spectrum.Spectrum):
 
         """
         if 'multifit' in fitkwargs:
-            log.warn("The multifit keyword is no longer required.  All fits allow for multiple components.", log.DeprecationWarning)
+            log.warn("The multifit keyword is no longer required.  All fits "
+                     "allow for multiple components.", DeprecationWarning)
 
         if not hasattr(self.mapplot,'plane'):
             self.mapplot.makeplane()

--- a/pyspeckit/spectrum/classes.py
+++ b/pyspeckit/spectrum/classes.py
@@ -181,12 +181,14 @@ class Spectrum(object):
                 self.data = np.ma.masked_where(np.isnan(self.data) + np.isinf(self.data), self.data)
                 self.error = np.ma.masked_where(np.isnan(self.data) + np.isinf(self.data), self.error)
 
+        # it is very important that this be done BEFORE the spectofit is set!
+        self._sort()
+
         self.plotter = plotters.Plotter(self)
         self._register_fitters()
         self.specfit = fitters.Specfit(self,Registry=self.Registry)
         self.baseline = baseline.Baseline(self)
         self.speclines = speclines
-        self._sort()
 
         # Special.  This needs to be modified to be more flexible; for now I need it to work for nh3
         self.plot_special = None
@@ -403,7 +405,8 @@ class Spectrum(object):
                 self.header['CRPIX1'] = self.header.get('CRPIX1') - x1pix
                 history.write_history(self.header,"CROP: Changed CRPIX1 from %f to %f" % (self.header.get('CRPIX1')+x1pix,self.header.get('CRPIX1')))
 
-    def slice(self, start=None, stop=None, units='pixel', copy=True, preserve_fits=False):
+    def slice(self, start=None, stop=None, units='pixel', copy=True,
+              preserve_fits=False):
         """Slicing the spectrum
 
         .. WARNING:: this is the same as cropping right now, but it returns a

--- a/pyspeckit/wrappers/fitnh3.py
+++ b/pyspeckit/wrappers/fitnh3.py
@@ -58,7 +58,9 @@ def fitnh3tkin(input_dict, dobaseline=True, baselinekwargs={}, crop=False, guess
         for sp in splist:
             sp.smooth(smooth)
 
-    spdict[guessline].specfit(fittype='gaussian', negamp=False, vheight=False)
+    height, amp, cen, width = spdict[guessline].specfit.moments(fittype='gaussian')
+    spdict[guessline].specfit(fittype='gaussian', negamp=False, vheight=False,
+                              guesses=[amp, cen, width])
     ampguess,vguess,widthguess = spdict[guessline].specfit.modelpars
     if widthguess < 0:
         raise ValueError("Width guess was < 0.  This is impossible.")


### PR DESCRIPTION
And add a regression test for a newly discovered bug in which `_sort()` was happening after instead of before the instantiation of specfit.  `specfit.crop` was also not resetting the `spectofit`.