### PR TITLE
Add guesses='moments'

### DIFF
--- a/examples/ammonia_fit_example.py
+++ b/examples/ammonia_fit_example.py
@@ -70,7 +70,8 @@ print "Best fit: ", sp.specfit.modelpars
 # Run the ammonia spec fitter with a reasonable guess 
 # Parameters are Tkin, Tex, column, width, centroid, ortho fraction
 sp.specfit(fittype='ammonia',
-        multifit=None,guesses=[5.9,4.45,8.3e14,0.84,96.2,0.43],quiet=False)
+           guesses=[5.9,4.45,8.3e14,0.84,96.2,0.43],
+           quiet=False)
 
 # plot up the residuals in a different window.  The residuals strongly suggest
 # the presence of a second velocity component.
@@ -88,7 +89,7 @@ sp.specfit.plot_fit()
 sp.plotter.figure.savefig('nh3_ammonia_fit_zoom.png')
 
 # refit with two components
-sp.specfit(fittype='ammonia',multifit=None,
+sp.specfit(fittype='ammonia',
         guesses=[4,3.5,5e14,0.68,97.3,0.5]+[15,4.2,7e14,0.52,95.8,0.35],
         quiet=False)
 sp.specfit.plotresiduals()

--- a/examples/ammonia_fit_example.py
+++ b/examples/ammonia_fit_example.py
@@ -1,7 +1,7 @@
 import pyspeckit
 
 # Grab a .fits spectrum with a legitimate header
-sp = pyspeckit.Spectrum('../tests/G031.947+00.076_nh3_11_Tastar.fits')
+sp = pyspeckit.Spectrum('../pyspeckit/tests/G031.947+00.076_nh3_11_Tastar.fits')
 """ HEADER:
 SIMPLE  =                    T / Written by IDL:  Tue Aug 31 18:17:01 2010
 BITPIX  = -64
@@ -59,7 +59,7 @@ sp.plotter(xmin=-100,xmax=300)
 # picking up the centroid, bad at getting the width right)
 # negamp=False forces the fitter to search for a positive peak, not the
 # negatives created in this spectrum by frequency switching
-sp.specfit(negamp=False)
+sp.specfit(negamp=False, guesses='moments')
 # Save the fit...
 sp.plotter.figure.savefig('nh3_gaussfit.png')
 # and print some information to screen

--- a/examples/ammonia_fit_example.py
+++ b/examples/ammonia_fit_example.py
@@ -59,6 +59,7 @@ sp.plotter(xmin=-100,xmax=300)
 # picking up the centroid, bad at getting the width right)
 # negamp=False forces the fitter to search for a positive peak, not the
 # negatives created in this spectrum by frequency switching
+sp.specfit.selectregion(xmin=60,xmax=120,xtype='wcs')
 sp.specfit(negamp=False, guesses='moments')
 # Save the fit...
 sp.plotter.figure.savefig('nh3_gaussfit.png')

--- a/examples/ammonia_vtau_fit_example.py
+++ b/examples/ammonia_vtau_fit_example.py
@@ -69,7 +69,8 @@ print "Best fit: ", sp.specfit.modelpars
 
 # Run the ammonia spec fitter with a reasonable guess 
 sp.specfit(fittype='ammonia_tau',
-        multifit=None,guesses=[5.9,4.45,4.5,0.84,96.2,0.43],quiet=False)
+           guesses=[5.9,4.45,4.5,0.84,96.2,0.43],
+           quiet=False)
 
 # plot up the residuals in a different window.  The residuals strongly suggest
 # the presence of a second velocity component.
@@ -87,7 +88,7 @@ sp.specfit.plot_fit()
 sp.plotter.figure.savefig('nh3_ammonia_fit_vtau_zoom.png')
 
 # refit with two components
-sp.specfit(fittype='ammonia_tau',multifit=None,
+sp.specfit(fittype='ammonia_tau',
         guesses=[4,3.5,4.5,0.68,97.3,0.5]+[15,4.2,4.5,0.52,95.8,0.35],
         quiet=False)
 sp.specfit.plotresiduals()

--- a/examples/ammonia_vtau_fit_example.py
+++ b/examples/ammonia_vtau_fit_example.py
@@ -1,7 +1,7 @@
 import pyspeckit
 
 # Grab a .fits spectrum with a legitimate header
-sp = pyspeckit.Spectrum('../tests/G031.947+00.076_nh3_11_Tastar.fits')
+sp = pyspeckit.Spectrum('../pyspeckit/tests/G031.947+00.076_nh3_11_Tastar.fits')
 """ HEADER:
 SIMPLE  =                    T / Written by IDL:  Tue Aug 31 18:17:01 2010
 BITPIX  = -64
@@ -59,7 +59,7 @@ sp.plotter(xmin=-100,xmax=300)
 # picking up the centroid, bad at getting the width right)
 # negamp=False forces the fitter to search for a positive peak, not the
 # negatives created in this spectrum by frequency switching
-sp.specfit(negamp=False)
+sp.specfit(negamp=False, guesses='moments')
 # Save the fit...
 sp.plotter.figure.savefig('nh3_gaussfit.png')
 # and print some information to screen

--- a/examples/ammonia_vtau_fit_example.py
+++ b/examples/ammonia_vtau_fit_example.py
@@ -59,6 +59,7 @@ sp.plotter(xmin=-100,xmax=300)
 # picking up the centroid, bad at getting the width right)
 # negamp=False forces the fitter to search for a positive peak, not the
 # negatives created in this spectrum by frequency switching
+sp.specfit.selectregion(xmin=60,xmax=120,xtype='wcs')
 sp.specfit(negamp=False, guesses='moments')
 # Save the fit...
 sp.plotter.figure.savefig('nh3_gaussfit.png')

--- a/examples/doublet_example.py
+++ b/examples/doublet_example.py
@@ -1,7 +1,7 @@
 import pyspeckit
 
 # Read in J000002.09+155254.1 spectrum, a nice emission-line galaxy
-sp = pyspeckit.Spectrum('../tests/SIIdoublet.fits')
+sp = pyspeckit.Spectrum('../pyspeckit/tests/SIIdoublet.fits')
 
 # Read in rest wavelengths of SII lines.  If you didn't know the names already, 
 # you could do sp.speclines.optical.lines.keys() to see what is available.
@@ -14,12 +14,12 @@ offset = SIIb - SIIa
 # Let's have a look at the spectrum
 sp.plotter()
 
-raw_input('Let\'s do a simple continuum subtraction (continue)')
+# raw_input('Let\'s do a simple continuum subtraction (continue)')
 
 # Plot the baseline fit
 sp.baseline(subtract = False)
 
-raw_input('Let\'s zoom in on the SII doublet (continue)')
+# raw_input('Let\'s zoom in on the SII doublet (continue)')
 
 # Subtract the baseline fit and save
 sp.baseline(subtract = True)
@@ -40,7 +40,7 @@ tied = ['', '', '', '', 'p[1] + %g' % offset, '']
 sp.specfit(guesses = guesses, tied = tied, quiet = False)
 sp.plotter.savefig('doublet_example_SII.png')
               
-raw_input('Hooray! The doublet has been fit. ')
+# raw_input('Hooray! The doublet has been fit. ')
 
 SIIb_obs = sp.specfit.modelpars[-2]
 

--- a/examples/hcn_cube_test.py
+++ b/examples/hcn_cube_test.py
@@ -6,7 +6,7 @@ except ImportError:
 import numpy as np
 
 # Load the spectrum
-sp = pyspeckit.Cube('../pyspeckit/tests/data/region5_hcn_crop.fits',scale_keyword='ETAMB')
+sp = pyspeckit.Cube('../pyspeckit/tests/data/region5_hcn_crop.fits',)
 errmap = pyfits.getdata('../pyspeckit/tests/data/region5.hcn.errmap.fits')
 
 # Register the fitter
@@ -25,8 +25,8 @@ sp.mapplot()
 #s.plotter()
 #s.Registry = sp.Registry
 #s.specfit.Registry = sp.Registry
-#s.specfit(fittype='hcn_amp',multifit=None,guesses=[2.5,-5.6,1.5],show_components=True,debug=True,quiet=False)
-#s.specfit(fittype='hcn_amp',multifit=None,guesses=[2.5,-5.6,1.5],show_components=True,debug=True,quiet=False)
+#s.specfit(fittype='hcn_amp',guesses=[2.5,-5.6,1.5],show_components=True,debug=True,quiet=False)
+#s.specfit(fittype='hcn_amp',guesses=[2.5,-5.6,1.5],show_components=True,debug=True,quiet=False)
 #sp.error = s.specfit.errspec
 
 
@@ -35,13 +35,13 @@ sp.mapplot()
 # there are bad pixels
 sp.momenteach(vheight=False, verbose=False)
 sp.momentcube[2,:,:] /= 2.5 # the HCN line profile makes the fitter assume a 2.5x too large line
-sp.fiteach(fittype='hcn_amp', errmap=errmap, multifit=None,
+sp.fiteach(fittype='hcn_amp', errmap=errmap,
         guesses=[1.0,-5.6,1.5], verbose_level=2, signal_cut=4,
         usemomentcube=True, blank_value=np.nan, verbose=False,
         direct=True, multicore=4)
 
 # steal the header from the error map
-f = pyfits.open('region5.hcn.errmap.fits')
+f = pyfits.open('../pyspeckit/tests/data/region5.hcn.errmap.fits')
 # start replacing components of the pyfits object
 f[0].data = np.concatenate([sp.parcube,sp.errcube,sp.integralmap])
 f[0].header.update('PLANE1','amplitude')

--- a/examples/hcn_cube_test.py
+++ b/examples/hcn_cube_test.py
@@ -6,8 +6,8 @@ except ImportError:
 import numpy as np
 
 # Load the spectrum
-sp = pyspeckit.Cube('region5_hcn_crop.fits',scale_keyword='ETAMB')
-errmap = pyfits.getdata('region5.hcn.errmap.fits')
+sp = pyspeckit.Cube('../pyspeckit/tests/data/region5_hcn_crop.fits',scale_keyword='ETAMB')
+errmap = pyfits.getdata('../pyspeckit/tests/data/region5.hcn.errmap.fits')
 
 # Register the fitter
 # The N2H+ fitter is 'built-in' but is not registered by default; this example

--- a/examples/voigt.py
+++ b/examples/voigt.py
@@ -7,26 +7,42 @@ from pyspeckit.spectrum.models import inherited_voigtfitter
 # in practice, however, you need to fit the background independently except for
 # gaussians.  I don't know why this is.
 
-xarr = pyspeckit.spectrum.units.SpectroscopicAxis(np.linspace(-100,100,500),unit='km/s',refX=1e9,refX_units='Hz')
+xarr = pyspeckit.spectrum.units.SpectroscopicAxis(np.linspace(-100,100,500),
+                                                  unit='km/s',
+                                                  refX=1e9,
+                                                  refX_units='Hz')
 VF = inherited_voigtfitter.voigt_fitter()
 
-sp1 = pyspeckit.Spectrum(xarr=xarr, data=VF.n_modelfunc((1,0,2.5,2.5))(xarr) + np.random.randn(xarr.shape[0])/20., error=np.ones(xarr.shape[0])/20.)
+sp1 = pyspeckit.Spectrum(xarr=xarr,
+                         data=(VF.n_modelfunc((1,0,2.5,2.5))(xarr) +
+                               np.random.randn(xarr.shape[0])/20.),
+                         error=np.ones(xarr.shape[0])/20.)
 sp1.plotter()
-sp1.specfit(fittype='gaussian',composite_fit_color='b',clear=False,annotate=False)
-sp1.specfit(fittype='lorentzian',composite_fit_color='g',clear=False,annotate=False)
-sp1.specfit(fittype='voigt',composite_fit_color='r',clear=False,annotate=True)
-sp1.baseline.annotate()
+sp1.specfit(fittype='gaussian', composite_fit_color='b', clear=False,
+            annotate=False, guesses='moments')
+sp1.specfit(fittype='lorentzian', composite_fit_color='g', clear=False,
+            annotate=False, guesses='moments')
+sp1.specfit(fittype='voigt', composite_fit_color='r', clear=False,
+            annotate=True, guesses='moments')
 
-sp2 = pyspeckit.Spectrum(xarr=xarr, data=VF.n_modelfunc((1,0,2.5,5.0))(xarr) + np.random.randn(xarr.shape[0])/20., error=np.ones(xarr.shape[0])/20.)
+sp2 = pyspeckit.Spectrum(xarr=xarr, data=VF.n_modelfunc((1,0,2.5,5.0))(xarr) +
+                         np.random.randn(xarr.shape[0])/20.,
+                         error=np.ones(xarr.shape[0])/20.)
 sp2.plotter()
-sp2.specfit(fittype='gaussian',composite_fit_color='b',clear=False,annotate=False)
-sp2.specfit(fittype='lorentzian',composite_fit_color='g',clear=False,annotate=False)
-sp2.specfit(fittype='voigt',composite_fit_color='r',clear=False,annotate=True)
-sp2.baseline.annotate()
+sp2.specfit(fittype='gaussian', composite_fit_color='b', clear=False,
+            annotate=False, guesses='moments')
+sp2.specfit(fittype='lorentzian', composite_fit_color='g', clear=False,
+            annotate=False, guesses='moments')
+sp2.specfit(fittype='voigt', composite_fit_color='r', clear=False,
+            annotate=True, guesses='moments')
 
-sp3 = pyspeckit.Spectrum(xarr=xarr, data=VF.n_modelfunc((1,0,2.5,5.0))(xarr) + np.random.randn(xarr.shape[0])/50., error=np.ones(xarr.shape[0])/50.)
+sp3 = pyspeckit.Spectrum(xarr=xarr, data=VF.n_modelfunc((1,0,2.5,5.0))(xarr) +
+                         np.random.randn(xarr.shape[0])/50.,
+                         error=np.ones(xarr.shape[0])/50.)
 sp3.plotter()
-sp3.specfit(fittype='gaussian',composite_fit_color='b',clear=False,annotate=False)
-sp3.specfit(fittype='lorentzian',composite_fit_color='g',clear=False,annotate=False)
-sp3.specfit(fittype='voigt',composite_fit_color='r',clear=False,annotate=True)
-sp3.baseline.annotate()
+sp3.specfit(fittype='gaussian', composite_fit_color='b', clear=False,
+            annotate=False, guesses='moments')
+sp3.specfit(fittype='lorentzian', composite_fit_color='g', clear=False,
+            annotate=False, guesses='moments')
+sp3.specfit(fittype='voigt', composite_fit_color='r', clear=False,
+            annotate=True, guesses='moments')

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -512,6 +512,8 @@ class Specfit(interactive.Interactive):
 
         if guesses is None:
             guesses = self.guesses
+        elif guesses in ('moment','moments'):
+            guesses = self.moments(vheight=False)
 
         if parinfo is not None:
             guesses = parinfo.values

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -175,7 +175,7 @@ class Specfit(interactive.Interactive):
             [passed to fitting codes; defaults to gaussian]
             The model to use.  Model must be registered in self.Registry.
             gaussian, lorentzian, and voigt profiles are registered by default
-        guesses : list
+        guesses : list or 'moments'
             A list of guesses.  Guesses must have length = n*number of parameters
             in model.  Guesses are *required* for multifit fits (there is no
             automated guessing for most models)
@@ -183,6 +183,8 @@ class Specfit(interactive.Interactive):
             guesses = [height,amplitude,center,width]
             for multi-fit gaussian, it is
             [amplitude, center, width]
+            You can also pass the keyword string 'moments' to have the moments
+            be used to automatically determine the guesses for a *single* peak
         parinfo : `pyspeckit.spectrum.parinfo.ParinfoList`
             An alternative way to specify guesses.  Supercedes guesses.
         use_lmfit : boolean
@@ -498,6 +500,10 @@ class Specfit(interactive.Interactive):
             closer to 1 (scales by the median) so that the fit converges better
         parinfo : `~parinfo` structure
             Guess structure; supercedes ``guesses``
+        guesses : list or 'moments'
+            Either a list of guesses matching the number of parameters * the
+            number of peaks for the model, or 'moments' to fit a single
+            spectrum with the moments as guesses
 
         """
         if reset_fitspec:
@@ -513,7 +519,7 @@ class Specfit(interactive.Interactive):
         if guesses is None:
             guesses = self.guesses
         elif guesses in ('moment','moments'):
-            guesses = self.moments(vheight=False)
+            guesses = self.moments(vheight=False, **kwargs)
 
         if parinfo is not None:
             guesses = parinfo.values
@@ -1214,6 +1220,7 @@ class Specfit(interactive.Interactive):
             self.residuals = self.residuals[::factor]
         self.spectofit = self.spectofit[::factor]
         self.errspec = self.errspec[::factor]
+        self.includemask = self.includemask[::factor]
 
     def crop(self,x1pix,x2pix):
         """

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -696,19 +696,25 @@ class Specfit(interactive.Interactive):
         elif usemoments: # this can be done within gaussfit but I want to save them
             # use this INDEPENDENT of fittype for now (voigt and gauss get same guesses)
             log.debug("Using moment-based guesses.")
-            self.guesses = self.Registry.peakbgfitters[self.fittype].moments(
-                    self.Spectrum.xarr[self.xmin:self.xmax],
-                    self.spectofit[self.xmin:self.xmax], vheight=vheight,
-                    negamp=negamp, nsigcut=nsigcut_moments, **kwargs)
-            #if vheight is False: self.guesses = [height]+self.guesses
+            moments_f = self.Registry.peakbgfitters[self.fittype].moments
+            self.guesses = moments_f(self.Spectrum.xarr[self.xmin:self.xmax],
+                                     self.spectofit[self.xmin:self.xmax],
+                                     vheight=vheight,
+                                     negamp=negamp,
+                                     nsigcut=nsigcut_moments,
+                                     **kwargs)
         else:
-            if negamp: self.guesses = [height,-1,0,1]
-            else:  self.guesses = [height,1,0,1]
+            if negamp:
+                self.guesses = [height,-1,0,1]
+            else:
+                self.guesses = [height,1,0,1]
 
         # If we're fitting anything but a simple Gaussian, we need the length
         # of guesses to be right so we pad with appended zeros
-        if NP > 3:
-            for ii in xrange(3,NP):
+        # BUT, if the guesses from the moments have the right number of
+        # parameters, we don't need to do this.
+        if NP > len(self.guesses):
+            for ii in xrange(len(self.guesses),NP):
                 self.guesses += [0.0]
 
         self.fitter = self.Registry.peakbgfitters[self.fittype]

--- a/pyspeckit/spectrum/interactive.py
+++ b/pyspeckit/spectrum/interactive.py
@@ -375,9 +375,12 @@ class Interactive(object):
               startpoint and endpoint
             * None: No exclusion
         """
-        if debug or self._debug: print "selectregion kwargs: ",kwargs," use_window_limits: ",use_window_limits," reset: ",reset," xmin: ",xmin, " xmax: ",xmax
+        if debug or self._debug:
+            print "selectregion kwargs: ",kwargs," use_window_limits: ",use_window_limits," reset: ",reset," xmin: ",xmin, " xmax: ",xmax
+
         if xmin is not None and xmax is not None:
-            if verbose or debug or self._debug: print "Setting xmin,xmax from keywords %g,%g" % (xmin,xmax)
+            if verbose or debug or self._debug:
+                print "Setting xmin,xmax from keywords %g,%g" % (xmin,xmax)
             if xtype.lower() in ('wcs',) or xtype in pyspeckit.spectrum.units.xtype_dict:
                 self.xmin = numpy.floor(self.Spectrum.xarr.x_to_pix(xmin))
                 # End-inclusive!
@@ -417,11 +420,13 @@ class Interactive(object):
             self.xmin = 0
             # End-inclusive
             self.xmax = self.Spectrum.data.shape[0]
-            if debug or self._debug: print "Reset to full range because the endpoints were equal"
+            if debug or self._debug:
+                print "Reset to full range because the endpoints were equal"
         elif self.xmin>self.xmax: 
             # Swap endpoints if the axis has a negative delta-X
             self.xmin,self.xmax = self.xmax,self.xmin
-            if debug or self._debug: print "Swapped endpoints because the left end was greater than the right"
+            if debug or self._debug:
+                print "Swapped endpoints because the left end was greater than the right"
 
         self.includemask[:self.xmin] = False
         self.includemask[self.xmax:] = False

--- a/pyspeckit/spectrum/models/ammonia.py
+++ b/pyspeckit/spectrum/models/ammonia.py
@@ -492,9 +492,11 @@ class ammonia_model(model.SpectralModel):
             log.info("Fit error message: {0}".format(mp.errmsg))
             log.info("Final fit values: ")
             for i,p in enumerate(mpp):
-                log.info(" ".join((parinfo[i]['parname'],p," +/- ",mpperr[i])))
-            log.info(" ".join("Chi2: ",mp.fnorm," Reduced Chi2: ",
-                              mp.fnorm/len(data)," DOF:",len(data)-len(mpp)))
+                log.info(" ".join((parinfo[i]['parname'], str(p), " +/- ",
+                                   str(mpperr[i]))))
+            log.info(" ".join(("Chi2: ", str(mp.fnorm)," Reduced Chi2: ",
+                               str(mp.fnorm/len(data)), " DOF:",
+                               str(len(data)-len(mpp)))))
 
         self.mp = mp
 

--- a/pyspeckit/spectrum/models/inherited_voigtfitter.py
+++ b/pyspeckit/spectrum/models/inherited_voigtfitter.py
@@ -5,6 +5,8 @@ Voigt Profile Fitter
 """
 import model
 import numpy as np
+from pyspeckit.spectrum.moments import moments
+import types
 try:
     import scipy.special
     scipyOK = True
@@ -79,6 +81,14 @@ def voigt_fwhm(sigma, gamma):
     """
     return 0.5346 * 2 * gamma + np.sqrt(0.2166*(2*gamma)**2 + sigma**2*8*np.log(2))
 
+def voigt_moments(self, *args, **kwargs):
+    """
+    Get the spectral moments from the moments package.  Use the gaussian width
+    for the lorentzian width (not a great guess!)
+    """
+    m = moments(*args,**kwargs)
+    return list(m) + [m[-1]]
+
 def voigt_fitter():
     """
     Generator for voigt fitter class
@@ -94,5 +104,7 @@ def voigt_fitter():
             fwhm_pars=['gwidth','lwidth'],
             )
     myclass.__name__ = "voigt"
+    myclass.moments = types.MethodType(voigt_moments, myclass,
+                                       myclass.__class__)
     
     return myclass

--- a/pyspeckit/spectrum/models/model.py
+++ b/pyspeckit/spectrum/models/model.py
@@ -171,7 +171,8 @@ class SpectralModel(fitter.SimpleFitter):
         # the height / parvalue popping needs to be done before the temp_pardict is set in order to make sure
         # that the height guess isn't assigned to the amplitude
         self.vheight = vheight
-        if vheight and len(self.parinfo) == self.default_npars and len(parvalues) == self.default_npars + 1:
+        if (vheight and len(self.parinfo) == self.default_npars and
+            len(parvalues) == self.default_npars + 1):
             # if the right number of parameters are passed, the first is the height
             self.parinfo = [ {'n':0, 'value':parvalues.pop(0), 'limits':(0,0),
                 'limited': (False,False), 'fixed':False, 'parname':'HEIGHT',
@@ -419,7 +420,7 @@ class SpectralModel(fitter.SimpleFitter):
         return self.mpp,self.model,self.mpperr,chi2
 
     def fitter(self, xax, data, err=None, quiet=True, veryverbose=False,
-            debug=False, parinfo=None, **kwargs):
+               debug=False, parinfo=None, **kwargs):
         """
         Run the fitter using mpfit.
         

--- a/pyspeckit/wrappers/fitnh3.py
+++ b/pyspeckit/wrappers/fitnh3.py
@@ -58,9 +58,8 @@ def fitnh3tkin(input_dict, dobaseline=True, baselinekwargs={}, crop=False, guess
         for sp in splist:
             sp.smooth(smooth)
 
-    height, amp, cen, width = spdict[guessline].specfit.moments(fittype='gaussian')
     spdict[guessline].specfit(fittype='gaussian', negamp=False, vheight=False,
-                              guesses=[amp, cen, width])
+                              guesses='moments')
     ampguess,vguess,widthguess = spdict[guessline].specfit.modelpars
     if widthguess < 0:
         raise ValueError("Width guess was < 0.  This is impossible.")


### PR DESCRIPTION
Since we have removed `peakbgfit` and `singlefit`, whose purpose was to automatically fit a single-peaked spectrum with an optional background, we still should have a way to input "reasonable" guesses automatically.  So the `specfit` call should accept `guesses='moment'` and should cal the appropriate moment tool to set up the guesses.  In order for this to work, a given model must have a `moments` method defined.

cc @dinossimpson - you have enough to deal with already, but this should be a relatively straightforward enhancement.

Affected tools from the removal of `peakbgfit` include at least:
 * `wrappers/fitnh3.py`
 * `tests/test_nh3_multi.py`