### PR TITLE
Cubes with different specaxes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ install:
     - source activate test
 
     # CORE DEPENDENCIES
-    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION pytest pip Cython matplotlib scipy jinja2; fi
+    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION pytest pip Cython matplotlib scipy jinja2 spectral-cube; fi
     - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL pytest-xdist; fi
 
     # ASTROPY

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ install:
     - source activate test
 
     # CORE DEPENDENCIES
-    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION pytest pip Cython matplotlib scipy jinja2 spectral-cube; fi
+    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION pytest pip Cython matplotlib scipy jinja2; fi
     - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL pytest-xdist; fi
 
     # ASTROPY
@@ -104,7 +104,7 @@ install:
     # packages. You should leave the `numpy=$NUMPY_VERSION` in the `conda`
     # install since this ensures Numpy does not get automatically upgraded.
     # - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION ... ; fi
-    # - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL ...; fi
+    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL spectral-cube; fi
 
     # DOCUMENTATION DEPENDENCIES
     # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that

--- a/REQUIREMENTS
+++ b/REQUIREMENTS
@@ -3,4 +3,4 @@ numpydoc
 matplotlib
 ordereddict
 astropy
-spectral_cube
+spectral-cube

--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -31,6 +31,7 @@ from pyspeckit.spectrum import history
 from astropy.io import fits
 import cubes
 from astropy import log
+from astropy import wcs
 
 class Cube(spectrum.Spectrum):
 
@@ -90,7 +91,8 @@ class Cube(spectrum.Spectrum):
 
         if filename is not None:
             try:
-                self.cube,self.xarr,self.header,self.fitsfile = readers.open_3d_fits(filename, **kwargs)
+                self.cube,self.xarr,self.header,self.fitsfile =\
+                        readers.open_3d_fits(filename, **kwargs)
                 self.errorcube = errorcube
                 self.data = self.cube[:,y0,x0]
                 self.error = None
@@ -158,10 +160,16 @@ class Cube(spectrum.Spectrum):
         self.plot_special_kwargs = {}
         self._modelcube = None
 
+        self.wcs = wcs.WCS(self.header)
+        self.wcs.wcs.fix()
+        self._spectral_axis_number = self.wcs.wcs.spec+1
+        self._first_cel_axis_num = np.where(self.wcs.wcs.axis_types // 1000 == 2)
+
         # TODO: improve this!!!
         self.system = ('galactic'
-                       if ('CTYPE1' in self.header and 'GLON' in
-                           self.header['CTYPE1'])
+                       if ('CTYPE{0}'.format(self._first_cel_axis_num)
+                           in self.header and 'GLON' in
+                           self.header['CTYPE{0}'.format(self._first_cel_axis_num)])
                        else 'celestial')
 
         self.mapplot = mapplot.MapPlotter(self)
@@ -372,12 +380,13 @@ class Cube(spectrum.Spectrum):
         Returns a SpectroscopicAxis instance
         """
 
+        ct = 'CTYPE{0}'.format(self._first_cel_axis_num)
         header = cubes.speccen_header(fits.Header(cards=[(k,v) for k,v in
                                                          self.header.iteritems()
                                                          if k != 'HISTORY']),
                                       lon=x, lat=y, system=self.system,
-                                      proj=(self.header['CTYPE1'][-3:]
-                                            if 'CTYPE1' in self.header else
+                                      proj=(self.header[ct][-3:]
+                                            if ct in self.header else
                                             'CAR'))
 
         sp = pyspeckit.Spectrum( xarr=self.xarr.copy(), data=self.cube[:,y,x],
@@ -446,13 +455,14 @@ class Cube(spectrum.Spectrum):
         else:
             error = None
 
+        ct = 'CTYPE{0}'.format(self._first_cel_axis_num)
         header = cubes.speccen_header(fits.Header(cards=[(k,v) for k,v in
                                                          self.header.iteritems()
                                                          if k != 'HISTORY']),
                                       lon=aperture[0],
                                       lat=aperture[1],
                                       system=self.system,
-                                      proj=self.header['CTYPE1'][-3:])
+                                      proj=self.header[ct][-3:])
         if len(aperture) == 3:
             header['APRADIUS'] = aperture[2]
         if len(aperture) == 5:
@@ -478,9 +488,13 @@ class Cube(spectrum.Spectrum):
 
         import cubes
         if coordsys is not None:
-            self.data = cubes.extract_aperture( self.cube, aperture , coordsys=coordsys , wcs=self.mapplot.wcs, method=method )
+            self.data = cubes.extract_aperture( self.cube, aperture,
+                                               coordsys=coordsys,
+                                               wcs=self.mapplot.wcs,
+                                               method=method )
         else:
-            self.data = cubes.extract_aperture( self.cube, aperture , coordsys=None, method=method)
+            self.data = cubes.extract_aperture(self.cube, aperture,
+                                               coordsys=None, method=method)
 
     def get_modelcube(self, update=False):
         if self._modelcube is None or update:
@@ -643,7 +657,8 @@ class Cube(spectrum.Spectrum):
             sp.specfit.Registry = self.Registry # copy over fitter registry
             
             if use_nearest_as_guess and self.has_fit.sum() > 0:
-                if verbose_level > 1 and ii == 0 or verbose_level > 4: log.info("Using nearest fit as guess")
+                if verbose_level > 1 and ii == 0 or verbose_level > 4:
+                    log.info("Using nearest fit as guess")
                 d = np.roll( np.roll( distance, x, 0), y, 1)
                 # If there's no fit, set its distance to be unreasonably large
                 nearest_ind = np.argmin(d+1e10*(True-self.has_fit))
@@ -664,7 +679,8 @@ class Cube(spectrum.Spectrum):
 
             if np.all(np.isfinite(gg)):
                 try:
-                    sp.specfit(guesses=gg, quiet=verbose_level<=3, verbose=verbose_level>3, **fitkwargs)
+                    sp.specfit(guesses=gg, quiet=verbose_level<=3,
+                               verbose=verbose_level>3, **fitkwargs)
                 except Exception as ex:
                     log.exception("Fit number %i at %i,%i failed on error %s" % (ii,x,y, str(ex)))
                     log.exception("Guesses were: {0}".format(str(gg)))
@@ -673,7 +689,9 @@ class Cube(spectrum.Spectrum):
                         raise ex
                 self.parcube[:,y,x] = sp.specfit.modelpars
                 self.errcube[:,y,x] = sp.specfit.modelerrs
-                if integral: self.integralmap[:,y,x] = sp.specfit.integral(direct=direct,return_error=True)
+                if integral:
+                    self.integralmap[:,y,x] = sp.specfit.integral(direct=direct,
+                                                                  return_error=True)
                 self.has_fit[y,x] = True
             else:
                 self.has_fit[y,x] = False
@@ -696,7 +714,8 @@ class Cube(spectrum.Spectrum):
                              (self._counter, npix, x, y, snmsg, time.time()-t0, pct))
 
             if integral:
-                return ((x,y), sp.specfit.modelpars, sp.specfit.modelerrs, self.integralmap[:,y,x])
+                return ((x,y), sp.specfit.modelpars, sp.specfit.modelerrs,
+                        self.integralmap[:,y,x])
             else:
                 return ((x,y), sp.specfit.modelpars, sp.specfit.modelerrs)
 
@@ -750,7 +769,8 @@ class Cube(spectrum.Spectrum):
             # individual result can be None (I guess?) but apparently (and this
             # part I don't believe) any individual *fit* result can be None as
             # well (apparently the x,y pairs can also be None?)
-            merged_result = [core_result for core_result in result if core_result is not None]
+            merged_result = [core_result for core_result in result if
+                             core_result is not None]
             # for some reason, every other time I run this code, merged_result
             # ends up with a different intrinsic shape.  This is an attempt to
             # force it to maintain a sensible shape.
@@ -761,7 +781,8 @@ class Cube(spectrum.Spectrum):
                     ((x,y), m1, m2) = merged_result[0]
             except ValueError:
                 if verbose > 1:
-                    log.exception("ERROR: merged_result[0] is {0} which has the wrong shape".format(merged_result[0]))
+                    log.exception("ERROR: merged_result[0] is {0} which has the"
+                                  " wrong shape".format(merged_result[0]))
                 merged_result = itertools.chain.from_iterable(merged_result)
             for TEMP in merged_result:
                 if TEMP is None:
@@ -782,7 +803,9 @@ class Cube(spectrum.Spectrum):
                     continue
                 if ((len(modelpars) != len(modelerrs)) or
                     (len(modelpars) != len(self.parcube))):
-                    raise ValueError("There was a serious problem; modelpar and error shape don't match that of the parameter cubes")
+                    raise ValueError("There was a serious problem; modelpar and"
+                                     " error shape don't match that of the "
+                                     "parameter cubes")
                 if np.any(np.isnan(modelpars)) or np.any(np.isnan(modelerrs)):
                     self.parcube[:,y,x] = np.nan
                     self.errcube[:,y,x] = np.nan
@@ -807,7 +830,8 @@ class Cube(spectrum.Spectrum):
         self.specfit.parinfo = sp.specfit.parinfo
 
         if verbose:
-            log.info("Finished final fit %i.  Elapsed time was %0.1f seconds" % (ii, time.time()-t0))
+            log.info("Finished final fit %i.  "
+                     "Elapsed time was %0.1f seconds" % (ii, time.time()-t0))
 
 
     def momenteach(self, verbose=True, verbose_level=1, multicore=0, **kwargs):
@@ -843,14 +867,17 @@ class Cube(spectrum.Spectrum):
             self.momentcube[:,y,x] = sp.moments(**kwargs)
             if verbose:
                 if ii % 10**(3-verbose_level) == 0:
-                    log.info("Finished moment %i.  Elapsed time is %0.1f seconds" % (ii, time.time()-t0))
+                    log.info("Finished moment %i.  "
+                             "Elapsed time is %0.1f seconds" % (ii, time.time()-t0))
 
             return ((x,y), self.momentcube[:,y,x])
 
         if multicore > 0:
             sequence = [(ii,x,y) for ii,(x,y) in tuple(enumerate(valid_pixels))]
             result = parallel_map(moment_a_pixel, sequence, numcores=multicore)
-            merged_result = [core_result for core_result in result if core_result is not None]
+            merged_result = [core_result
+                             for core_result in result
+                             if core_result is not None]
             for mr in merged_result:
                 for TEMP in mr:
                     ((x,y), moments) = TEMP
@@ -860,7 +887,8 @@ class Cube(spectrum.Spectrum):
                 moment_a_pixel((ii,x,y))
 
         if verbose:
-            log.info("Finished final moment %i.  Elapsed time was %0.1f seconds" % (ii, time.time()-t0))
+            log.info("Finished final moment %i.  "
+                     "Elapsed time was %0.1f seconds" % (ii, time.time()-t0))
 
     def show_moment(self, momentnumber, **kwargs):
         """
@@ -1102,8 +1130,17 @@ class CubeStack(Cube):
             for key,value in cube.header.items():
                 self.header[key] = value
 
+        self.wcs = wcs.WCS(self.header)
+        self.wcs.wcs.fix()
+        self._spectral_axis_number = self.wcs.wcs.spec+1
+        self._first_cel_axis_num = np.where(self.wcs.wcs.axis_types // 1000 == 2)
+
         # TODO: Improve this!!!
-        self.system = 'galactic' if 'GLON' in self.header['CTYPE1'] else 'celestial'
+        self.system = ('galactic'
+                       if ('CTYPE{0}'.format(self._first_cel_axis_num)
+                           in self.header and 'GLON' in
+                           self.header['CTYPE{0}'.format(self._first_cel_axis_num)])
+                       else 'celestial')
         
         self.unit = cubelist[0].unit
         for cube in cubelist: 

--- a/pyspeckit/cubes/cubes.py
+++ b/pyspeckit/cubes/cubes.py
@@ -184,7 +184,8 @@ def flatten_header(header,delete=False):
 
     return newheader
 
-def speccen_header(header, lon=None, lat=None, proj='TAN', system='celestial'):
+def speccen_header(header, lon=None, lat=None, proj='TAN', system='celestial',
+                   spectral_axis=3, celestial_axes=[1,2]):
     """
     Turn a cube header into a spectrum header, retaining RA/Dec vals where possible
     (speccen is like flatten; spec-ify would be better but, specify?  nah)
@@ -192,20 +193,26 @@ def speccen_header(header, lon=None, lat=None, proj='TAN', system='celestial'):
     Assumes 3rd axis is velocity
     """
     newheader = header.copy()
-    newheader['CRVAL1'] = header.get('CRVAL3')
-    newheader['CRPIX1'] = header.get('CRPIX3')
-    if 'CD1_1' in header: newheader.rename_keyword('CD1_1','OLDCD1_1')
-    elif 'CDELT1' in header: newheader.rename_keyword('CDELT1','OLDCDEL1')
-    if 'CD3_3' in header: newheader['CDELT1'] = header.get('CD3_3')
-    elif 'CDELT3' in header: newheader['CDELT1'] = header.get('CDELT3')
-    newheader['CTYPE1'] = 'VRAD'
-    if header.get('CUNIT3'):
-        newheader['CUNIT1'] = header.get('CUNIT3')
+    new_spectral_axis = 1
+    newheader['CRVAL{0}'.format(new_spectral_axis)] = header.get('CRVAL{0}'.format(spectral_axis))
+    newheader['CRPIX{0}'.format(new_spectral_axis)] = header.get('CRPIX{0}'.format(spectral_axis))
+    if 'CD{0}_{0}'.format(new_spectral_axis) in header:
+        newheader.rename_keyword('CD{0}_{0}'.format(new_spectral_axis),
+                                 'OLDCD{0}_{0}'.format(new_spectral_axis))
+    elif 'CDELT{0}'.format(new_spectral_axis) in header:
+        newheader.rename_keyword('CDELT{0}'.format(new_spectral_axis),'OLDCDEL{0}'.format(new_spectral_axis))
+    if 'CD{0}_{0}'.format(spectral_axis) in header:
+        newheader['CDELT{0}'.format(new_spectral_axis)] = header.get('CD{0}_{0}'.format(spectral_axis))
+    elif 'CDELT{0}'.format(spectral_axis) in header:
+        newheader['CDELT{0}'.format(new_spectral_axis)] = header.get('CDELT{0}'.format(spectral_axis))
+    newheader['CTYPE{0}'.format(new_spectral_axis)] = 'VRAD'
+    if header.get('CUNIT{0}'.format(spectral_axis)):
+        newheader['CUNIT{0}'.format(new_spectral_axis)] = header.get('CUNIT{0}'.format(spectral_axis))
     else: 
         print "Assuming CUNIT3 is km/s in speccen_header"
-        newheader['CUNIT1'] = 'km/s'
+        newheader['CUNIT{0}'.format(new_spectral_axis)] = 'km/s'
     newheader['CRPIX2'] = 1
-    newheader['CRPIX3'] = 1
+    newheader['CRPIX{0}'.format(spectral_axis)] = 1
     if system == 'celestial':
         c2 = 'RA---'
         c3 = 'DEC--'
@@ -213,17 +220,18 @@ def speccen_header(header, lon=None, lat=None, proj='TAN', system='celestial'):
         c2 = 'GLON-'
         c3 = 'GLAT-'
     newheader['CTYPE2'] = c2+proj
-    newheader['CTYPE3'] = c3+proj
+    newheader['CTYPE{0}'.format(spectral_axis)] = c3+proj
 
     if lon is not None:
         newheader['CRVAL2'] = lon
     if lat is not None:
-        newheader['CRVAL3'] = lat
+        newheader['CRVAL{0}'.format(spectral_axis)] = lat
 
     if 'CD2_2' in header:
         newheader.rename_keyword('CD2_2','OLDCD2_2')
-    if 'CD3_3' in header:
-        newheader.rename_keyword('CD3_3','OLDCD3_3')
+    if 'CD{0}_{0}'.format(spectral_axis) in header:
+        newheader.rename_keyword('CD{0}_{0}'.format(spectral_axis),
+                                 'OLDCD{0}_{0}'.format(spectral_axis))
     if 'CROTA2' in header:
         newheader.rename_keyword('CROTA2','OLDCROT2')
 

--- a/pyspeckit/spectrum/classes.py
+++ b/pyspeckit/spectrum/classes.py
@@ -347,7 +347,8 @@ class Spectrum(object):
 
         if hdr.get('BUNIT'):
             self.unit = hdr.get('BUNIT').strip()
-        else:
+        elif not hasattr(self, 'unit') or (hasattr(self,'unit') and self.unit
+                                           is None):
             self.unit = 'undefined'
             
         if hdr.get('BTYPE'):

--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -476,11 +476,13 @@ class SpectroscopicAxis(np.ndarray):
         """
         if self.xtype is None:
             OK = False
+        elif self.unit not in unit_type_dict:
+            raise KeyError("Unit {0} is not recognized.".format(self.unit))
         else:
-            OK = self.xtype.lower() == unit_type_dict[self.units]
+            OK = self.xtype.lower() == unit_type_dict[self.unit]
 
         if not OK:
-            raise InconsistentTypeError("Units: %s Type[units]: %s in %r" % (self.units,unit_type_dict[self.units],self) )
+            raise InconsistentTypeError("Units: %s Type[units]: %s in %r" % (self.unit,unit_type_dict[self.unit],self) )
 
     def _fix_type(self):
         try:

--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -469,11 +469,32 @@ class SpectroscopicAxis(np.ndarray):
             selfstr += "Reference is %g %s" % (self.refX, self.refX_units)
         return selfstr
 
+    @property
+    def unit(self):
+        return self._unit
+
+    @unit.setter
+    def unit(self, value):
+        self._unit = value
+
+    @property
+    def units(self):
+        return self.unit
+
+    @units.setter
+    def units(self, value):
+        self.unit = value
+
+    def _plural_sanity_check(self):
+        if hasattr(self,'unit') and hasattr(self,'units'):
+            assert self.unit == self.units
+
     def _check_consistent_type(self):
         """
         Make sure self.xtype is unit_type_dict[units]
         if this is NOT true, can cause significant errors
         """
+        self._plural_sanity_check()
         if self.xtype is None:
             OK = False
         elif self.unit not in unit_type_dict:
@@ -968,8 +989,8 @@ class SpectroscopicAxis(np.ndarray):
         https://github.com/numpy/numpy/blob/master/numpy/ma/core.py)
         """
 
-        for attr in ('frame', 'redshift', 'refX', 'refX_units', 'units',
-                'velocity_convention', 'wcshead', 'xtype'):
+        for attr in ('frame', 'redshift', 'refX', 'refX_units', '_unit',
+                     'velocity_convention', 'wcshead', 'xtype'):
             self.__dict__[attr] = obj.__dict__[attr]
 
 

--- a/pyspeckit/wrappers/fitnh3.py
+++ b/pyspeckit/wrappers/fitnh3.py
@@ -44,8 +44,10 @@ def fitnh3tkin(input_dict, dobaseline=True, baselinekwargs={}, crop=False, guess
     Given a dictionary of filenames and lines, fit them together
     e.g. {'oneone':'G000.000+00.000_nh3_11.fits'}
     """
-    spdict = dict([ (linename,pyspeckit.Spectrum(value, scale_keyword=scale_keyword)) 
-        if type(value) is str else (linename,value) for linename, value in input_dict.iteritems() ])
+    spdict = dict([ (linename,pyspeckit.Spectrum(value,
+                                                 scale_keyword=scale_keyword))
+                   if type(value) is str else (linename,value)
+                   for linename, value in input_dict.iteritems() ])
     splist = spdict.values()
 
     for sp in splist: # required for plotting, cropping
@@ -90,12 +92,20 @@ def fitnh3tkin(input_dict, dobaseline=True, baselinekwargs={}, crop=False, guess
 
     if tau is not None:
         if guesses is None:
-            guesses = [a for i in xrange(npeaks) for a in (tkin+random.random()*i,tex,tau+random.random()*i,widthguess+random.random()*i,vguess+random.random()*i,fortho)]
-        spectra.specfit(fittype='ammonia_tau',quiet=quiet,multifit=None,guesses=guesses, thin=thin, **kwargs)
+            guesses = [a for i in xrange(npeaks) for a in
+                       (tkin+random.random()*i, tex, tau+random.random()*i,
+                        widthguess+random.random()*i, vguess+random.random()*i,
+                        fortho)]
+        spectra.specfit(fittype='ammonia_tau',quiet=quiet,multifit=None,guesses=guesses,
+                        thin=thin, **kwargs)
     else:
         if guesses is None:
-            guesses = [a for i in xrange(npeaks) for a in (tkin+random.random()*i,tex,column+random.random()*i,widthguess+random.random()*i,vguess+random.random()*i,fortho)]
-        spectra.specfit(fittype='ammonia',quiet=quiet,multifit=None,guesses=guesses, thin=thin, **kwargs)
+            guesses = [a for i in xrange(npeaks) for a in
+                       (tkin+random.random()*i, tex, column+random.random()*i,
+                        widthguess+random.random()*i, vguess+random.random()*i,
+                        fortho)]
+        spectra.specfit(fittype='ammonia',quiet=quiet,multifit=None,guesses=guesses,
+                        thin=thin, **kwargs)
 
     if doplot:
         plot_nh3(spdict,spectra,fignum=fignum)
@@ -129,10 +139,23 @@ def plot_nh3(spdict,spectra,fignum=1, show_components=False, residfignum=None, *
     if len(splist) == 2:
         axdict = { 'oneone':pyplot.subplot(211), 'twotwo':pyplot.subplot(212) }
     elif len(splist) == 3:
-        axdict = { 'oneone':pyplot.subplot(211), 'twotwo':pyplot.subplot(223), 'threethree':pyplot.subplot(224), 'fourfour':pyplot.subplot(224) }
+        axdict = { 'oneone':pyplot.subplot(211), 'twotwo':pyplot.subplot(223),
+                  'threethree':pyplot.subplot(224),
+                  'fourfour':pyplot.subplot(224) }
     elif len(splist) == 4:
-        axdict = { 'oneone':pyplot.subplot(221), 'twotwo':pyplot.subplot(222), 'threethree':pyplot.subplot(223), 'fourfour':pyplot.subplot(224) }
+        axdict = { 'oneone':pyplot.subplot(221), 'twotwo':pyplot.subplot(222),
+                  'threethree':pyplot.subplot(223),
+                  'fourfour':pyplot.subplot(224) }
+    else:
+        raise NotImplementedError("Plots with {0} subplots are not yet "
+                                  "implemented.  Pull requests are "
+                                  "welcome!".format(len(splist)))
+
     for linename,sp in spdict.iteritems():
+        if linename not in axdict:
+            raise NotImplementedError("Plot windows for {0} cannot "
+                                      "be automatically arranged (yet)."
+                                      .format(linename))
         sp.plotter.axis=axdict[linename] # permanent
         sp.plotter(axis=axdict[linename],title=title_dict[linename], **plotkwargs)
         sp.specfit.Spectrum.plotter = sp.plotter


### PR DESCRIPTION
Cubes can have the spectra on axes other than the third (though why would you do that? it's insane?!!?!)

This is a quick workaround for such cubes, though the long-term better solution is to use `SpectralCube.read` as the only cube reader (just like we want to use specutils to read 1D spectra)