### PR TITLE
xarr offset and flip when loading/plotting 1D spectra

### DIFF
--- a/pyspeckit/spectrum/readers/fits_reader.py
+++ b/pyspeckit/spectrum/readers/fits_reader.py
@@ -136,7 +136,8 @@ will run into errors.""")
         # http://iram.fr/IRAMFR/GILDAS/doc/html/class-html/node84.html
         # F(n) = RESTFREQ + CRVALi + ( n - CRPIXi ) * CDELTi
         if verbose: print("Loading a CLASS .fits spectrum")
-        dv = -1*hdr.get('CDELT1')
+        # there is no reason to assume CDELT is wrong dv = -1*hdr.get('CDELT1')
+        dv = hdr.get('CDELT1')
         if hdr.get('RESTFREQ'):
             v0 = hdr.get('RESTFREQ') + hdr.get('CRVAL1')
         elif hdr.get('RESTF'):


### PR DESCRIPTION
I have been experiencing an issue with pyspeckit v0.1.14, in which loading a 1D FITS spectrum results in a xarr which is offset from the expected xarr by a factor of the xarr.refX and the associated data values are flipped L-R. 

E.g., the corect spectrum should appear as: in this image 
![correct spectrum](http://privon.com/upload/demo.png)

But after issuing the the following pyspeckit commands,
```
import pyspeckit
sp = pyspeckit.Spectrum('demo.fits')
sp.plotter()
```
Appears as so: 
![flipped / offset spectrum](http://privon.com/upload/flipped.png)

The FITS file I used to demonstrate this behavior: http://privon.com/upload/demo.fits

The FITS fine in question was written out using pyfits (using sp.write() ), after calibration and processing. I assume something could be wrong with the FITS headers that would lead to this behavior, but if that's the case it might also suggest an issue with the way pyspeckit writes out FITS files?

Unfortunately I haven't had the chance to dig into the code and try to find the source. It's on my list, but I may not get to it until at least after the ALMA deadline on the 23rd.