### PR TITLE
fixes refX_unit initialization in SpectroscopicAxis

### DIFF
--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -1536,6 +1536,8 @@ class Specfit(interactive.Interactive):
         .. todo:: Add a button in the navbar that makes this window pop up
         http://stackoverflow.com/questions/4740988/add-new-navigate-modes-in-matplotlib
         """
+        log.warn("These are not unit-tested!  Use at your own risk.  Please"+
+                 " report issues, because we almost certainly don't know about them!")
         import widgets
 
         if parlimitdict is None:

--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -361,21 +361,20 @@ class Plotter(object):
                     yminval = np.nanmin(self.Spectrum.data[xpixmin:xpixmax])
                 # Increase the range fractionally.  This means dividing a positive #, multiplying a negative #
                 if yminval < 0:
-                    self.ymin = u.Quantity(float(yminval)*float(ypeakscale), validate_unit(self.Spectrum.unit))
+                    self.ymin = float(yminval) * float(ypeakscale)
                 else:
-                    self.ymin = u.Quantity(float(yminval)/float(ypeakscale), validate_unit(self.Spectrum.unit))
+                    self.ymin = float(yminval) / float(ypeakscale)
 
             if ymax is not None: self.ymax = ymax
             elif self.ymax is None:
-                print type(self.ymin)
                 if hasattr(self.Spectrum.data, 'mask'):
                     ymaxval = ((self.Spectrum.data[xpixmin:xpixmax]).max()-self.ymin.value)
                 else:
                     ymaxval = (np.nanmax(self.Spectrum.data[xpixmin:xpixmax])-self.ymin.value)
                 if ymaxval > 0:
-                    self.ymax = u.Quantity(float(ymaxval)*float(ypeakscale)+self.ymin.value, validate_unit(self.Spectrum.unit))
+                    self.ymax = float(ymaxval)*float(ypeakscale) + self.ymin.value
                 else:
-                    self.ymax = u.Quantity(float(ymaxval)/float(ypeakscale)+self.ymin.value, validate_unit(self.Spectrum.unit))
+                    self.ymax = float(ymaxval)/float(ypeakscale) + self.ymin.value
 
             self.ymin += u.Quantity(self.offset, self.ymin.unit)
             self.ymax += u.Quantity(self.offset, self.ymax.unit)

--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -13,6 +13,7 @@ from ..config import *
 import numpy as np
 import astropy.units as u
 from pyspeckit.specwarnings import warn
+from pyspeckit.spectrum.units import validate_unit
 import copy
 import widgets
 import inspect
@@ -360,20 +361,21 @@ class Plotter(object):
                     yminval = np.nanmin(self.Spectrum.data[xpixmin:xpixmax])
                 # Increase the range fractionally.  This means dividing a positive #, multiplying a negative #
                 if yminval < 0:
-                    self.ymin = float(yminval)*float(ypeakscale)
+                    self.ymin = u.Quantity(float(yminval)*float(ypeakscale), validate_unit(self.Spectrum.unit))
                 else:
-                    self.ymin = float(yminval)/float(ypeakscale)
+                    self.ymin = u.Quantity(float(yminval)/float(ypeakscale), validate_unit(self.Spectrum.unit))
 
             if ymax is not None: self.ymax = ymax
             elif self.ymax is None:
+                print type(self.ymin)
                 if hasattr(self.Spectrum.data, 'mask'):
                     ymaxval = ((self.Spectrum.data[xpixmin:xpixmax]).max()-self.ymin.value)
                 else:
                     ymaxval = (np.nanmax(self.Spectrum.data[xpixmin:xpixmax])-self.ymin.value)
                 if ymaxval > 0:
-                    self.ymax = float(ymaxval) * float(ypeakscale) + self.ymin.value
+                    self.ymax = u.Quantity(float(ymaxval)*float(ypeakscale)+self.ymin.value, validate_unit(self.Spectrum.unit))
                 else:
-                    self.ymax = float(ymaxval) / float(ypeakscale) + self.ymin.value
+                    self.ymax = u.Quantity(float(ymaxval)/float(ypeakscale)+self.ymin.value, validate_unit(self.Spectrum.unit))
 
             self.ymin += u.Quantity(self.offset, self.ymin.unit)
             self.ymax += u.Quantity(self.offset, self.ymax.unit)

--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -361,9 +361,11 @@ class Plotter(object):
                     yminval = np.nanmin(self.Spectrum.data[xpixmin:xpixmax])
                 # Increase the range fractionally.  This means dividing a positive #, multiplying a negative #
                 if yminval < 0:
-                    self.ymin = float(yminval) * float(ypeakscale)
+                    # self.ymin = float(yminval) * float(ypeakscale)
+                    self.ymin = u.Quantity(float(yminval)*float(ypeakscale), validate_unit(self.Spectrum.unit))
                 else:
-                    self.ymin = float(yminval) / float(ypeakscale)
+                    # self.ymin = float(yminval) / float(ypeakscale)
+                    self.ymin = u.Quantity(float(yminval)/float(ypeakscale), validate_unit(self.Spectrum.unit))
 
             if ymax is not None: self.ymax = ymax
             elif self.ymax is None:
@@ -372,9 +374,11 @@ class Plotter(object):
                 else:
                     ymaxval = (np.nanmax(self.Spectrum.data[xpixmin:xpixmax])-self.ymin.value)
                 if ymaxval > 0:
-                    self.ymax = float(ymaxval)*float(ypeakscale) + self.ymin.value
+                    # self.ymax = float(ymaxval)*float(ypeakscale) + self.ymin.value
+                    self.ymax = u.Quantity(float(ymaxval)*float(ypeakscale)+self.ymin.value, validate_unit(self.Spectrum.unit))
                 else:
-                    self.ymax = float(ymaxval)/float(ypeakscale) + self.ymin.value
+                    # self.ymax = float(ymaxval)/float(ypeakscale) + self.ymin.value
+                    self.ymax = u.Quantity(float(ymaxval)/float(ypeakscale)+self.ymin.value, validate_unit(self.Spectrum.unit))
 
             self.ymin += u.Quantity(self.offset, self.ymin.unit)
             self.ymax += u.Quantity(self.offset, self.ymax.unit)

--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -348,9 +348,9 @@ class SpectroscopicAxis(u.Quantity):
             if not refX_unit:
                 if subarr._unit in frequency_dict:
                     refX_unit = subarr.unit
-                else:
-                    raise ValueError("refX must be either an astropy.units.Quantity"+
-                                     " or a float with a respective refX_unit.")
+                # else:
+                    # raise ValueError("refX must be either an astropy.units.Quantity"+
+                                     # " or a float with a respective refX_unit.")
             subarr.refX = u.Quantity(refX, refX_unit)
             subarr.refX_unit = refX_unit
         else:

--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -340,7 +340,8 @@ class SpectroscopicAxis(u.Quantity):
         print 'refX_unit:', refX_unit
         if hasattr(refX, 'unit'):
             if refX_unit and refX_unit != refX.unit:
-                raise ValueError("If refX is a Quantity then refX_unit must be None or the same as refX.unit.")
+                raise ValueError("If refX is a Quantity then refX_unit must be"+
+                                 " None or the same as refX.unit.")
             subarr.refX = refX
             refX_unit = refX.unit 
         if refX:
@@ -348,12 +349,14 @@ class SpectroscopicAxis(u.Quantity):
                 if subarr._unit in frequency_dict:
                     refX_unit = subarr.unit
                 else:
-                    raise ValueError("refX must be either an astropy.units.Quantity or a float with a respective refX_unit.")
+                    raise ValueError("refX must be either an astropy.units.Quantity"+
+                                     " or a float with a respective refX_unit.")
             subarr.refX = u.Quantity(refX, refX_unit)
             subarr.refX_unit = refX_unit
         else:
             if refX_unit:
-                raise ValueError("If you specify the refX_unit then you must specify the refX too.")
+                raise ValueError("If you specify the refX_unit then you must "+
+                                    "specify the refX too.")
 
         subarr.redshift = redshift
         subarr.wcshead = {}

--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -271,6 +271,7 @@ def validate_unit(unit, bad_unit_response='raise'):
         if type(unit) is str:
             unit = unit.replace('angstroms', 'angstrom')
             unit = unit.replace('ergs', 'erg')    
+            unit = unit.replace('Counts', 'count')
         unit = u.Unit(unit)
     except ValueError:
         if bad_unit_response == "pixel":
@@ -336,8 +337,6 @@ class SpectroscopicAxis(u.Quantity):
 
         subarr._unit = validate_unit(unit, bad_unit_response)
 
-        print 'refX:', refX
-        print 'refX_unit:', refX_unit
         if hasattr(refX, 'unit'):
             if refX_unit and refX_unit != refX.unit:
                 raise ValueError("If refX is a Quantity then refX_unit must be"+

--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -338,14 +338,17 @@ class SpectroscopicAxis(u.Quantity):
         subarr._unit = validate_unit(unit, bad_unit_response)
         subarr.refX = refX
 
+        if hasattr(refX, 'unit'):
+            if refX_unit != refX.unit:
+                raise ValueError("If refX is a Quantity then refX_unit must be None or the same as refX.unit")
+            refX_unit = refX.unit 
         if refX_unit is None:
             if subarr._unit in frequency_dict:
                 refX_unit = subarr.unit
             else:
                 refX_unit = 'Hz'
-            subarr.refX_unit = refX_unit
-        else:
-            subarr.refX_unit = refX_unit
+        subarr.refX_unit = refX_unit
+
         subarr.redshift = redshift
         subarr.wcshead = {}
         subarr.velocity_convention = velocity_convention

--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -271,7 +271,6 @@ def validate_unit(unit, bad_unit_response='raise'):
         if type(unit) is str:
             unit = unit.replace('angstroms', 'angstrom')
             unit = unit.replace('ergs', 'erg')    
-        # if unit == 'angstroms': unit = 'angstrom'
         unit = u.Unit(unit)
     except ValueError:
         if bad_unit_response == "pixel":
@@ -336,18 +335,25 @@ class SpectroscopicAxis(u.Quantity):
         subarr = subarr.view(self)
 
         subarr._unit = validate_unit(unit, bad_unit_response)
-        subarr.refX = refX
 
+        print 'refX:', refX
+        print 'refX_unit:', refX_unit
         if hasattr(refX, 'unit'):
-            if refX_unit != refX.unit:
-                raise ValueError("If refX is a Quantity then refX_unit must be None or the same as refX.unit")
+            if refX_unit and refX_unit != refX.unit:
+                raise ValueError("If refX is a Quantity then refX_unit must be None or the same as refX.unit.")
+            subarr.refX = refX
             refX_unit = refX.unit 
-        if refX_unit is None:
-            if subarr._unit in frequency_dict:
-                refX_unit = subarr.unit
-            else:
-                refX_unit = 'Hz'
-        subarr.refX_unit = refX_unit
+        if refX:
+            if not refX_unit:
+                if subarr._unit in frequency_dict:
+                    refX_unit = subarr.unit
+                else:
+                    raise ValueError("refX must be either an astropy.units.Quantity or a float with a respective refX_unit.")
+            subarr.refX = u.Quantity(refX, refX_unit)
+            subarr.refX_unit = refX_unit
+        else:
+            if refX_unit:
+                raise ValueError("If you specify the refX_unit then you must specify the refX too.")
 
         subarr.redshift = redshift
         subarr.wcshead = {}
@@ -385,7 +391,7 @@ class SpectroscopicAxis(u.Quantity):
         selfstr =  "SpectroscopicAxis with units %s and range %g:%g." % (
                 self.unit,self.umin().value,self.umax().value)
         if self.refX is not None:
-            selfstr += "Reference is %g %s" % (self.refX, self.refX_unit)
+            selfstr += "Reference is %g %s" % (self.refX.value, self.refX.unit)
         return selfstr
 
     @property


### PR DESCRIPTION
This contains a small fix in the refX_unit initialization. While working on the ammonia test suite, I passed to refX a Quantity when creating a SpectroscopicAxis, and noticed that I forgot to check the case that refX already has a unit. I should mention that I assume that if the user passes a Quantity refX and a refX_unit, the refX_unit should get overwritten by refX.unit.