### PR TITLE
Specfit with masked arrays

### DIFF
--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -490,16 +490,18 @@ class Specfit(interactive.Interactive):
 
     @property
     def mask(self):
+        """ Mask: True means "exclude" """
         if (hasattr(self.spectofit, 'mask') and
             self.spectofit.shape==self.spectofit.mask.shape):
             mask = self.spectofit.mask
         else:
-            mask = np.zeros(self.spectofit, dtype='bool')
+            mask = np.zeros_like(self.spectofit, dtype='bool')
 
         return mask
 
     @property
     def mask_sliced(self):
+        """ Sliced (subset) Mask: True means "exclude" """
         return self.mask[self.xmin:self.xmax]
 
     def multifit(self, fittype=None, renormalize='auto', annotate=None,
@@ -582,9 +584,9 @@ class Specfit(interactive.Interactive):
                     if par.scaleable:
                         guesses[jj] /= scalefactor
 
-        xtofit = self.Spectrum.xarr[self.xmin:self.xmax][self.mask_sliced]
-        spectofit = self.spectofit[self.xmin:self.xmax][self.mask_sliced]
-        err = self.errspec[self.xmin:self.xmax][self.mask_sliced]
+        xtofit = self.Spectrum.xarr[self.xmin:self.xmax][~self.mask_sliced]
+        spectofit = self.spectofit[self.xmin:self.xmax][~self.mask_sliced]
+        err = self.errspec[self.xmin:self.xmax][~self.mask_sliced]
 
         mpp,model,mpperr,chi2 = self.fitter(xtofit, spectofit, err=err,
                                             npeaks=self.npeaks,

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -488,6 +488,20 @@ class Specfit(interactive.Interactive):
         if self.includemask is not None and (self.includemask.shape == self.errspec.shape):
             self.errspec[~self.includemask] = 1e10*self.errspec.max()
 
+    @property
+    def mask(self):
+        if (hasattr(self.spectofit, 'mask') and
+            self.spectofit.shape==self.spectofit.mask.shape):
+            mask = self.spectofit.mask
+        else:
+            mask = np.zeros(self.spectofit, dtype='bool')
+
+        return mask
+
+    @property
+    def mask_sliced(self):
+        return self.mask[self.xmin:self.xmax]
+
     def multifit(self, fittype=None, renormalize='auto', annotate=None,
                  show_components=None, verbose=True, color=None,
                  guesses=None, parinfo=None, reset_fitspec=True,
@@ -568,12 +582,16 @@ class Specfit(interactive.Interactive):
                     if par.scaleable:
                         guesses[jj] /= scalefactor
 
-        mpp,model,mpperr,chi2 = self.fitter(
-            self.Spectrum.xarr[self.xmin:self.xmax],
-            self.spectofit[self.xmin:self.xmax],
-            err=self.errspec[self.xmin:self.xmax], npeaks=self.npeaks,
-            parinfo=parinfo, # the user MUST be allowed to override parinfo.
-            params=guesses, use_lmfit=use_lmfit, **self.fitkwargs)
+        xtofit = self.Spectrum.xarr[self.xmin:self.xmax][self.mask_sliced]
+        spectofit = self.spectofit[self.xmin:self.xmax][self.mask_sliced]
+        err = self.errspec[self.xmin:self.xmax][self.mask_sliced]
+
+        mpp,model,mpperr,chi2 = self.fitter(xtofit, spectofit, err=err,
+                                            npeaks=self.npeaks,
+                                            parinfo=parinfo, # the user MUST be allowed to override parinfo.
+                                            params=guesses,
+                                            use_lmfit=use_lmfit,
+                                            **self.fitkwargs)
 
         self.spectofit *= scalefactor
         self.errspec   *= scalefactor
@@ -1113,7 +1131,11 @@ class Specfit(interactive.Interactive):
         #xtypename = units.unit_type_dict[self.Spectrum.xarr.xtype]
         xcharconv = units.SmartCaseNoSpaceDict({u.Hz.physical_type:'\\nu',
                                                 u.m.physical_type:'\\lambda',
-                                                (u.km/u.s).physical_type:'v', 'pixels':'x'})
+                                                (u.km/u.s).physical_type:'v',
+                                                'pixels':'x',
+                                                u.dimensionless_unscaled:'x',
+                                                'dimensionless':'x',
+                                               })
         try:
             xchar = xcharconv[self.Spectrum.xarr.unit.physical_type]
         except AttributeError:

--- a/pyspeckit/spectrum/models/ammonia.py
+++ b/pyspeckit/spectrum/models/ammonia.py
@@ -660,7 +660,7 @@ class ammonia_model_vtau(ammonia_model):
         """
 
         # TKIN, TEX, ntot, width, center, ortho fraction
-        return [20,10, 1, 1.0, 0.0, 1.0]
+        return [20, 10, 1, 1.0, 0.0, 1.0]
 
     def __call__(self,*args,**kwargs):
         return self.multinh3fit(*args,**kwargs)

--- a/pyspeckit/spectrum/models/ammonia_hf.py
+++ b/pyspeckit/spectrum/models/ammonia_hf.py
@@ -22,7 +22,9 @@ from ammonia_constants import (line_names, freq_dict, aval_dict, ortho_dict,
                                voff_lines_dict, tau_wts_dict)
 
 
-nh3_vtau = hyperfine.hyperfinemodel(line_names, voff_lines_dict, freq_dict, line_strength_dict, relative_strength_total_degeneracy)
+nh3_vtau = hyperfine.hyperfinemodel(line_names, voff_lines_dict, freq_dict,
+                                    line_strength_dict,
+                                    relative_strength_total_degeneracy)
 nh3_vtau_fitter = nh3_vtau.fitter
 nh3_vtau_vheight_fitter = nh3_vtau.vheight_fitter
 

--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -346,7 +346,8 @@ class Plotter(object):
                 return
             
             if self.ymin and self.ymax:
-                if (self.Spectrum.xarr.max() < self.ymin or self.Spectrum.xarr.min() > self.ymax
+                # this is utter nonsense....
+                if (self.Spectrum.data.max() < self.ymin or self.Spectrum.data.min() > self.ymax
                         or reset_ylimits):
                     if not self.silent and not reset_ylimits: warn( "Resetting Y-axis min/max because the plot is out of bounds." )
                     self.ymin = None
@@ -364,22 +365,24 @@ class Plotter(object):
                 else:
                     self.ymin = float(yminval)/float(ypeakscale)
 
-            if ymax is not None: self.ymax = ymax
+            if ymax is not None:
+                self.ymax = ymax
             elif self.ymax is None:
                 if hasattr(self.Spectrum.data, 'mask'):
-                    ymaxval = ((self.Spectrum.data[xpixmin:xpixmax]).max()-self.ymin.value)
+                    ymaxval = ((self.Spectrum.data[xpixmin:xpixmax]).max()-self.ymin)
                 else:
-                    ymaxval = (np.nanmax(self.Spectrum.data[xpixmin:xpixmax])-self.ymin.value)
+                    ymaxval = (np.nanmax(self.Spectrum.data[xpixmin:xpixmax])-self.ymin)
                 if ymaxval > 0:
-                    self.ymax = float(ymaxval) * float(ypeakscale) + self.ymin.value
+                    self.ymax = float(ymaxval) * float(ypeakscale) + self.ymin
                 else:
-                    self.ymax = float(ymaxval) / float(ypeakscale) + self.ymin.value
+                    self.ymax = float(ymaxval) / float(ypeakscale) + self.ymin
 
-            self.ymin += u.Quantity(self.offset, self.ymin.unit)
-            self.ymax += u.Quantity(self.offset, self.ymax.unit)
+            self.ymin += self.offset
+            self.ymax += self.offset
 
-        self.axis.set_xlim(self.xmin.value,self.xmax.value)
-        self.axis.set_ylim(self.ymin.value,self.ymax.value)
+        self.axis.set_xlim(self.xmin.value if hasattr(self.xmin, 'value') else self.xmin,
+                           self.xmax.value if hasattr(self.xmax, 'value') else self.xmax)
+        self.axis.set_ylim(self.ymin, self.ymax)
         
 
     def label(self, title=None, xlabel=None, ylabel=None, verbose_label=False,

--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -38,7 +38,7 @@ class Plotter(object):
 
 
     def __init__(self, Spectrum, autorefresh=True, title="", ylabel="",
-            xlabel="", silent=True, plotscale=1.0, **kwargs):
+                 xlabel="", silent=True, plotscale=1.0, **kwargs):
         self.figure = None
         self.axis = None
         self.Spectrum = Spectrum


### PR DESCRIPTION
I think the chi-square calculation for fits on masked arrays (numpy.ndarray) is incorrect.  I can't replicate the chi-square value, and the degrees of freedom value isn't reduced by the length of the mask.

In the example below, wave, flux, and error are (unmasked) numpy.ndarray's.
spec = pyspeckit.spectrum.classes.Spectrum(xarr=wave,data=flux,error=error)

spec.data.mask = np.isnan(spec.data)

spec.data.mask[32:35] = True

spec.specfit(fittype='myfunc',guesses=[blah,blah2,blah3],quiet=False,multifit=False)