### PR TITLE
ymin.value is called on a non-quantity

### DIFF
--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -1082,8 +1082,8 @@ class Specfit(interactive.Interactive):
                                            self.Spectrum.plotter.xmax.value)
             if ((self.Spectrum.plotter.ymin is not None) and
                 (self.Spectrum.plotter.ymax is not None)):
-                self.residualaxis.set_ylim(self.Spectrum.plotter.ymin.value,
-                                           self.Spectrum.plotter.ymax.value)
+                self.residualaxis.set_ylim(self.Spectrum.plotter.ymin,
+                                           self.Spectrum.plotter.ymax)
         if label:
             self.residualaxis.set_xlabel(self.Spectrum.plotter.xlabel)
             self.residualaxis.set_ylabel(self.Spectrum.plotter.ylabel)

--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -346,7 +346,8 @@ class Plotter(object):
                 return
             
             if self.ymin and self.ymax:
-                if (self.Spectrum.xarr.max() < self.ymin or self.Spectrum.xarr.min() > self.ymax
+                # this is utter nonsense....
+                if (self.Spectrum.data.max() < self.ymin or self.Spectrum.data.min() > self.ymax
                         or reset_ylimits):
                     if not self.silent and not reset_ylimits: warn( "Resetting Y-axis min/max because the plot is out of bounds." )
                     self.ymin = None
@@ -364,22 +365,24 @@ class Plotter(object):
                 else:
                     self.ymin = float(yminval)/float(ypeakscale)
 
-            if ymax is not None: self.ymax = ymax
+            if ymax is not None:
+                self.ymax = ymax
             elif self.ymax is None:
                 if hasattr(self.Spectrum.data, 'mask'):
-                    ymaxval = ((self.Spectrum.data[xpixmin:xpixmax]).max()-self.ymin.value)
+                    ymaxval = ((self.Spectrum.data[xpixmin:xpixmax]).max()-self.ymin)
                 else:
-                    ymaxval = (np.nanmax(self.Spectrum.data[xpixmin:xpixmax])-self.ymin.value)
+                    ymaxval = (np.nanmax(self.Spectrum.data[xpixmin:xpixmax])-self.ymin)
                 if ymaxval > 0:
-                    self.ymax = float(ymaxval) * float(ypeakscale) + self.ymin.value
+                    self.ymax = float(ymaxval) * float(ypeakscale) + self.ymin
                 else:
-                    self.ymax = float(ymaxval) / float(ypeakscale) + self.ymin.value
+                    self.ymax = float(ymaxval) / float(ypeakscale) + self.ymin
 
-            self.ymin += u.Quantity(self.offset, self.ymin.unit)
-            self.ymax += u.Quantity(self.offset, self.ymax.unit)
+            self.ymin += self.offset
+            self.ymax += self.offset
 
-        self.axis.set_xlim(self.xmin.value,self.xmax.value)
-        self.axis.set_ylim(self.ymin.value,self.ymax.value)
+        self.axis.set_xlim(self.xmin.value if hasattr(self.xmin, 'value') else self.xmin,
+                           self.xmax.value if hasattr(self.xmax, 'value') else self.xmax)
+        self.axis.set_ylim(self.ymin, self.ymax)
         
 
     def label(self, title=None, xlabel=None, ylabel=None, verbose_label=False,

--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -398,12 +398,14 @@ class Plotter(object):
         if xlabel is not None:
             self.xlabel = xlabel
         elif self._xunit:
+            # WAS: self.xlabel = self.Spectrum.xarr.xtype.title()
             try:
-                self.xlabel += \
-                    " ("+"{0} ({1})".format(xlabel_table[self._xunit.physical_type.title()], self._xunit.to_string())+")"
+                self.xlabel = xlabel_table[self._xunit.physical_type.lower()]
             except KeyError:
-                self.xlabel += \
-                    " ("+"{0} ({1})".format(self._xunit.physical_type.title(), self._xunit.to_string())+")"
+                self.xlabel = self._xunit.physical_type.title()
+            # WAS: self.xlabel += " ("+u.Unit(self._xunit).to_string()+")"
+            self.xlabel += " ({0})".format(self._xunit.to_string())
+
             if verbose_label:
                 self.xlabel = "%s %s" % ( self.Spectrum.xarr.velocity_convention.title(),
                                           self.xlabel )

--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -414,26 +414,26 @@ class Plotter(object):
         if ylabel is not None:
             self.ylabel=ylabel
             self.axis.set_ylabel(self.ylabel)
-        elif self.Spectrum.units in ['Ta*','Tastar','K']:
+        elif self.Spectrum.unit in ['Ta*','Tastar','K']:
             self.axis.set_ylabel("$T_A^*$ (K)")
-        elif self.Spectrum.units == 'mJy':
+        elif self.Spectrum.unit == 'mJy':
             self.axis.set_ylabel("$S_\\nu$ (mJy)")
-        elif self.Spectrum.units == 'Jy':
+        elif self.Spectrum.unit == 'Jy':
             self.axis.set_ylabel("$S_\\nu$ (Jy)")            
         else:
-            if "$" in self.Spectrum.units:
+            if "$" in self.Spectrum.unit:
                 # assume LaTeX already
-                self.axis.set_ylabel(self.Spectrum.units)
-            elif len(self.Spectrum.units.split()) > 1: 
-                if self.Spectrum.units.split()[1] in ['erg/cm^2/s/Ang',
+                self.axis.set_ylabel(self.Spectrum.unit)
+            elif len(self.Spectrum.unit.split()) > 1: 
+                if self.Spectrum.unit.split()[1] in ['erg/cm^2/s/Ang',
                         'erg/cm2/s/A', 'erg/cm2/s/Ang', 'erg/cm/s/Ang']:
-                    norm = parse_norm(self.Spectrum.units.split()[0])
+                    norm = parse_norm(self.Spectrum.unit.split()[0])
                     self.axis.set_ylabel("$%s \\mathrm{erg/s/cm^2/\\AA}$" % norm)
-                elif self.Spectrum.units.split()[1] in ['W/m^2/Hz','w/m^2/hz','W/m/hz','W/m/Hz']:
-                    norm = parse_norm(self.Spectrum.units.split()[0])
+                elif self.Spectrum.unit.split()[1] in ['W/m^2/Hz','w/m^2/hz','W/m/hz','W/m/Hz']:
+                    norm = parse_norm(self.Spectrum.unit.split()[0])
                     self.axis.set_ylabel("$%s \\mathrm{W/m^2/Hz}$" % norm)
             else:
-                label_units = parse_units(self.Spectrum.units)
+                label_units = parse_units(self.Spectrum.unit)
                 self.axis.set_ylabel(label_units)
 
     def refresh(self):
@@ -520,7 +520,7 @@ class Plotter(object):
         return newplotter
 
     def line_ids(self, line_names, line_xvals, xval_units=None, auto_yloc=True,
-            auto_yloc_fraction=0.9,  **kwargs):
+                 auto_yloc_fraction=0.9,  **kwargs):
         """
         Add line ID labels to a plot using lineid_plot
         http://oneau.wordpress.com/2011/10/01/line-id-plot/

--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -37,8 +37,8 @@ class Plotter(object):
     """
 
 
-    def __init__(self, Spectrum, autorefresh=True, title="", ylabel="",
-            xlabel="", silent=True, plotscale=1.0, **kwargs):
+    def __init__(self, Spectrum, autorefresh=True, title="",
+                 xlabel="", silent=True, plotscale=1.0, **kwargs):
         self.figure = None
         self.axis = None
         self.Spectrum = Spectrum
@@ -47,7 +47,6 @@ class Plotter(object):
         self.offset = 0.0 # vertical offset
         self.autorefresh = autorefresh
         self.xlabel = xlabel
-        self.ylabel = ylabel
         self.title  = title
         self.errorplot = None
         self.plotkwargs = kwargs

--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -414,8 +414,7 @@ class Plotter(object):
             self.axis.set_xlabel(self.xlabel)
 
         if ylabel is not None:
-            self.ylabel=ylabel
-            self.axis.set_ylabel(self.ylabel)
+            self.axis.set_ylabel(ylabel)
         elif self.Spectrum.unit in ['Ta*','Tastar','K']:
             self.axis.set_ylabel("$T_A^*$ (K)")
         elif self.Spectrum.unit == 'mJy':
@@ -437,6 +436,10 @@ class Plotter(object):
             else:
                 label_units = parse_units(self.Spectrum.unit)
                 self.axis.set_ylabel(label_units)
+
+    @property
+    def ylabel(self):
+        return self.axis.get_ylabel()
 
     def refresh(self):
         if self.axis is not None:

--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -85,18 +85,8 @@ class Plotter(object):
                     return self._xlim[1]
             elif xy == 'y':
                 if minmax == 'min':
-                    if self._ylim[0] and self._xunit:
-                        try:
-                            self._ylim[0]._unit = self._xunit 
-                        except AttributeError:
-                            self._ylim[0] = u.Quantity(self._ylim[0], self._xunit)    
                     return self._ylim[0]
                 elif minmax == 'max':
-                    if self._ylim[1] and self._xunit:
-                        try:
-                            self._ylim[1]._unit = self._xunit 
-                        except AttributeError:
-                            self._ylim[1] = u.Quantity(self._ylim[1], self._xunit)    
                     return self._ylim[1]
         return getprop
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "<ipython-input-34-e23bed8a5063>", line 1, in <module>
    spectrum.plotter()
  File "/Users/adam/repos/pyspeckit/pyspeckit/spectrum/plotters.py", line 202, in __call__
    self.plot(**kwargs)
  File "/Users/adam/repos/pyspeckit/pyspeckit/spectrum/plotters.py", line 293, in plot
    self.reset_limits(use_window_limits=use_window_limits, **reset_kwargs)
  File "/Users/adam/repos/pyspeckit/pyspeckit/spectrum/plotters.py", line 370, in reset_limits
    ymaxval = ((self.Spectrum.data[xpixmin:xpixmax]).max()-self.ymin.value)
AttributeError: 'float' object has no attribute 'value'
```

@dinossimpson this is related to your work