### PR TITLE
Added error description in TypeError in units.py: generate_xarr 

### DIFF
--- a/examples/n2hp_cube_example.py
+++ b/examples/n2hp_cube_example.py
@@ -33,11 +33,13 @@ if os.path.exists('n2hp_fitted_parameters.fits'):
 else:
     # Run the fitter
     # Estimated time to completion ~ 2 minutes
+    spc.xarr.refX = 23*u.Hz
+    spc.xarr.velocity_convention = 'radio'
     spc.fiteach(fittype='n2hp_vtau', multifit=True,
                 guesses=[5,0.5,3,1], # Tex=5K, tau=0.5, v_center=12, width=1 km/s
                 signal_cut=6, # minimize the # of pixels fit for the example
                 start_from_point=(16,13), # start at a pixel with signal
-                errmap=errmap, velocity_convention="radio"
+                errmap=errmap,
                 )
     # There are a huge number of parameters for the fiteach procedure.  See:
     # http://pyspeckit.readthedocs.org/en/latest/example_nh3_cube.html

--- a/examples/n2hp_cube_example.py
+++ b/examples/n2hp_cube_example.py
@@ -1,5 +1,6 @@
 import pyspeckit
 import os
+import astropy.units as u
 
 if not os.path.exists('n2hp_cube.fit'):
     import astropy.utils.data as aud
@@ -36,7 +37,7 @@ else:
                 guesses=[5,0.5,3,1], # Tex=5K, tau=0.5, v_center=12, width=1 km/s
                 signal_cut=6, # minimize the # of pixels fit for the example
                 start_from_point=(16,13), # start at a pixel with signal
-                errmap=errmap,
+                errmap=errmap, velocity_convention="radio"
                 )
     # There are a huge number of parameters for the fiteach procedure.  See:
     # http://pyspeckit.readthedocs.org/en/latest/example_nh3_cube.html

--- a/examples/n2hp_cube_example.py
+++ b/examples/n2hp_cube_example.py
@@ -33,7 +33,7 @@ if os.path.exists('n2hp_fitted_parameters.fits'):
 else:
     # Run the fitter
     # Estimated time to completion ~ 2 minutes
-    spc.xarr.refX = 23*u.Hz
+    spc.xarr.refX = 93176265000.0*u.Hz
     spc.xarr.velocity_convention = 'radio'
     spc.fiteach(fittype='n2hp_vtau', multifit=True,
                 guesses=[5,0.5,3,1], # Tex=5K, tau=0.5, v_center=12, width=1 km/s

--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -191,7 +191,7 @@ class Cube(spectrum.Spectrum):
 
     def __repr__(self):
         return r'<Cube object over spectral range %6.5g : %6.5g %s and flux range = [%2.1f, %2.1f] %s with shape %r at %s>' % \
-                (self.xarr.min(), self.xarr.max(), self.xarr.unit,
+                (self.xarr.min().value, self.xarr.max().value, self.xarr.unit,
                         self.data.min(), self.data.max(), self.unit,
                         self.cube.shape, str(hex(self.__hash__())))
 

--- a/pyspeckit/spectrum/classes.py
+++ b/pyspeckit/spectrum/classes.py
@@ -193,6 +193,8 @@ class Spectrum(object):
 
         if unit is not None:
             self._unit = unit
+        else:
+            self._unit = u.dimensionless_unscaled
 
         if doplot: self.plotter(**plotkwargs)
 

--- a/pyspeckit/spectrum/classes.py
+++ b/pyspeckit/spectrum/classes.py
@@ -193,8 +193,8 @@ class Spectrum(object):
 
         if unit is not None:
             self._unit = unit
-        else:
-            self._unit = u.dimensionless_unscaled
+        # else:
+        #     self._unit = u.dimensionless_unscaled
 
         if doplot: self.plotter(**plotkwargs)
 

--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -262,7 +262,8 @@ def generate_xarr(input_array, unit=None):
     elif isinstance(input_array, np.ndarray):
         return SpectroscopicAxis(input_array, unit=unit)
     else:
-        raise TypeError("Unrecognized input type")
+        raise TypeError("Unrecognized input type. Input array of type: {0}"+\
+            "is not a Quantity, SpectroscopicAxis or numpy.ndarray".format(type(input_array)))
 
 class SpectroscopicAxis(u.Quantity):
     """

--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -375,7 +375,10 @@ class SpectroscopicAxis(u.Quantity):
         selfstr =  "SpectroscopicAxis with units %s and range %g:%g." % (
                 self.unit,self.umin().value,self.umax().value)
         if self.refX is not None:
-            selfstr += "Reference is %g %s" % (self.refX, self.refX_unit)
+            if not hasattr(self.refX, 'unit'):
+                selfstr += "Reference is %g %s" % (self.refX, self.refX_unit)
+            else:
+                selfstr += "Reference is %s" % (self.refX)
         return selfstr
 
     @property
@@ -618,6 +621,7 @@ class SpectroscopicAxis(u.Quantity):
         
         if isinstance(self.unit, str):
             self._unit = u.Unit(self.unit)
+
         return self.to(unit, equivalencies=self.equivalencies)
 
     def make_dxarr(self, coordinate_location='center'):


### PR DESCRIPTION
This PR addresses https://github.com/pyspeckit/pyspeckit/issues/59#
When input_array is not a Quantity, numpy.ndarray or already a SpecAxis generate_xarr will raise a TypeError describing the error. I noticed that in the example mentioned in the issue, there is a call to load_fits from spectal-cube which produces the input_array.
Also, I added a commented out initialization for self._unit in Spectrum.`__init`__ in case unit=None which I think is the case that produces the error in https://github.com/pyspeckit/pyspeckit/issues/48. 
