### PR TITLE
refX_unit as a property

### DIFF
--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -405,6 +405,7 @@ class SpectroscopicAxis(u.Quantity):
         if name == 'refX_unit':
             return self.refX.unit
         else:
+            # can't use getattr because it triggers infinite recursion
             object.__getattribute__(self, name)
 
     def __array_finalize__(self,obj):

--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -400,6 +400,12 @@ class SpectroscopicAxis(u.Quantity):
     def refX_units(self, value):
         log.warn("'refX_units' is deprecated; please use 'refX_unit'", DeprecationWarning)
         self.refX_unit = value
+    
+    def __getattr__(self, name):
+        if name == 'refX_unit':
+            return self.refX.unit
+        else:
+            object.__getattribute__(self, name)
 
     def __array_finalize__(self,obj):
         """


### PR DESCRIPTION
refX_unit modified into a property and returns refX.unit (same for refX_units)
I added a log.warning when a user tries to set refX_unit directly but it spams alot!  