### PR TITLE
index out of bounds with fiteach

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -1228,11 +1228,12 @@ def get_neighbors(x, y, shape):
     """
     Find the 9 nearest neighbors, excluding self and any out of bounds points
     """
+    ysh, xsh = shape
     xpyp = [(ii,jj) 
             for ii,jj in itertools.product((-1,0,1),
                                            (-1,0,1))
-            if (jj+x < shape[1]) and (jj+x >= 0)
-            and  (ii+y < shape[0]) and (ii+y >= 0)
+            if (ii+x < xsh) and (ii+x >= 0)
+            and  (jj+y < ysh) and (jj+y >= 0)
             and not (ii==0 and jj==0)]
     xpatch, ypatch = zip(*xpyp)
 
@@ -1240,13 +1241,21 @@ def get_neighbors(x, y, shape):
 
 def test_get_neighbors():
     xp,yp = get_neighbors(0,0,[10,10])
-    assert np.all(xp == [0,1,1])
-    assert np.all(yp == [1,0,1])
+    assert set(xp) == {0,1}
+    assert set(yp) == {0,1}
 
     xp,yp = get_neighbors(0,1,[10,10])
-    assert np.all(xp == [-1,-1,0,1,1])
-    assert np.all(yp == [ 0, 1,1,0,1])
+    assert set(xp) == {0,1}
+    assert set(yp) == {-1,0,1}
+
+    xp,yp = get_neighbors(5,6,[10,10])
+    assert set(xp) == {-1,0,1}
+    assert set(yp) == {-1,0,1}
 
     xp,yp = get_neighbors(9,9,[10,10])
-    assert np.all(xp == [-1,-1, 0,])
-    assert np.all(yp == [-1, 0,-1,])
+    assert set(xp) == {0,-1}
+    assert set(yp) == {0,-1}
+
+    xp,yp = get_neighbors(9,8,[10,10])
+    assert set(xp) == {-1,0}
+    assert set(yp) == {-1,0,1}


### PR DESCRIPTION
I'm running fiteach on a 16x14 pixel cube and I keep getting this error:

```python
IndexError: index 16 is out of bounds for axis 0 with size 16
```
Sometimes it's for index 14 and axis 1, depending on how many cores I'm running on.

This is the traceback if I'm running on 2 cores:

```python
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
/Volumes/Storage/Observing/APO/Orion_cubes/fitscript_h2_orion.py in <module>()
     44                 (True,True)], 
     45                 parlimits=[(0.9,1.4), (0,16), (21210,21225), (0.5,5)],
---> 46                 signal_cut=2,start_from_point=(8,7))
     47 
     48 # plot the fits as images (you can click on these to see the spectra + fits)

/Users/allison/anaconda/lib/python2.7/site-packages/pyspeckit/cubes/SpectralCube.pyc in fiteach(self, errspec, errmap, guesses, verbose, verbose_level, quiet, signal_cut, usemomentcube, blank_value, integral, direct, absorption, use_nearest_as_guess, use_neighbor_as_guess, start_from_point, multicore, position_order, continuum_map, **fitkwargs)
    805         if multicore > 1:
    806             sequence = [(ii,x,y) for ii,(x,y) in tuple(enumerate(valid_pixels))]
--> 807             result = parallel_map(fit_a_pixel, sequence, numcores=multicore)
    808             self._result = result # backup - don't want to lose data in the case of a failure
    809             # a lot of ugly hacking to deal with the way parallel_map returns

/Users/allison/anaconda/lib/python2.7/site-packages/pyspeckit/parallel_map/parallel_map.pyc in parallel_map(function, sequence, numcores)
    157          for ii, chunk in enumerate(sequence)]
    158 
--> 159   return run_tasks(procs, err_q, out_q, numcores)
    160 
    161 

/Users/allison/anaconda/lib/python2.7/site-packages/pyspeckit/parallel_map/parallel_map.pyc in run_tasks(procs, err_q, out_q, num)
     84     # kill all on any exception from any one slave
     85     die(procs)
---> 86     raise err_q.get()
     87 
     88   # Processes finish in arbitrary order. Process IDs double

IndexError: index 16 is out of bounds for axis 0 with size 16

```

This is the traceback if I'm running on 1 core:
```python
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
/Volumes/Storage/Observing/APO/Orion_cubes/fitscript_h2_orion.py in <module>()
     44                 (True,True)], 
     45                 parlimits=[(0.9,1.4), (0,16), (21210,21225), (0.5,5)],
---> 46                 signal_cut=2,start_from_point=(8,7))
     47 
     48 # plot the fits as images (you can click on these to see the spectra + fits)

/Users/allison/anaconda/lib/python2.7/site-packages/pyspeckit/cubes/SpectralCube.pyc in fiteach(self, errspec, errmap, guesses, verbose, verbose_level, quiet, signal_cut, usemomentcube, blank_value, integral, direct, absorption, use_nearest_as_guess, use_neighbor_as_guess, start_from_point, multicore, position_order, continuum_map, **fitkwargs)
    861         else:
    862             for ii,(x,y) in enumerate(valid_pixels):
--> 863                 fit_a_pixel((ii,x,y))
    864 
    865 

/Users/allison/anaconda/lib/python2.7/site-packages/pyspeckit/cubes/SpectralCube.pyc in fit_a_pixel(iixy)
    690             xpatch = np.array([1,1,1,0,0,0,-1,-1,-1],dtype=np.int)
    691             ypatch = np.array([1,0,-1,1,0,-1,1,0,-1],dtype=np.int)
--> 692             local_fits = self.has_fit[ypatch+y,xpatch+x]
    693 
    694 

IndexError: index 14 is out of bounds for axis 1 with size 14
```

Maybe this doesn't matter, but I made this subcube with spectral-cube from a ds9 region file.