### PR TITLE
fiteach can result in parameters out of range by 1 ULP

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -719,7 +719,8 @@ class Cube(spectrum.Spectrum):
             elif use_neighbor_as_guess and np.any(local_fits):
                 # Array is N_guess X Nvalid_nbrs so averaging over 
                 # Axis=1 is the axis of all valid neighbors
-                gg = np.mean(self.parcube[:,(ypatch+y)[local_fits],(xpatch+x)[local_fits]],axis=1)
+                gg = np.mean(self.parcube[:, (ypatch+y)[local_fits],
+                                          (xpatch+x)[local_fits]], axis=1)
             elif usemomentcube:
                 if verbose_level > 1 and ii == 0: log.info("Using moment cube")
                 gg = self.momentcube[:,y,x]

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -593,7 +593,7 @@ class Specfit(interactive.Interactive):
         spectofit = self.spectofit[self.xmin:self.xmax][~self.mask_sliced]
         err = self.errspec[self.xmin:self.xmax][~self.mask_sliced]
 
-        self._validate_parinfo(parinfo)
+        self._validate_parinfo(parinfo, mode='fix')
 
         mpp,model,mpperr,chi2 = self.fitter(xtofit, spectofit, err=err,
                                             npeaks=self.npeaks,
@@ -601,6 +601,12 @@ class Specfit(interactive.Interactive):
                                             params=guesses,
                                             use_lmfit=use_lmfit,
                                             **self.fitkwargs)
+
+        check = self._validate_parinfo(self.fitter.parinfo, mode='check')
+
+        if not check:
+            warn("The fitter returned values that are outside the "
+                 "parameter limits.  DEBUG INFO: {0}".format(check))
 
         self.spectofit *= scalefactor
         self.errspec   *= scalefactor
@@ -1838,19 +1844,48 @@ class Specfit(interactive.Interactive):
 
         return deltax
 
-    def _validate_parinfo(self, parinfo):
+    def _validate_parinfo(self, parinfo, mode='fix'):
+
+        assert mode in ('fix','raise','check')
+
+        check = []
 
         for param in self.parinfo:
-            if (param.limited[0] and (param.value < param.limits[0]) and
-                np.allclose(param.value, param.limits[0])):
-                # nextafter -> next representable float
-                warn("{0} is less than the lower limit {1}, but very close."
-                     " Converting to {1}+ULP".format(param.value,
-                                                     param.limits[0]))
-                param.value = np.nextafter(param.limits[0], param.limits[0]+1)
-            if (param.limited[1] and (param.value > param.limits[1]) and
-                np.allclose(param.value, param.limits[1])):
-                param.value = np.nextafter(param.limits[1], param.limits[1]-1)
-                warn("{0} is less than the lower limit {1}, but very close."
-                     " Converting to {1}-ULP".format(param.value,
-                                                     param.limits[1]))
+            if (param.limited[0] and (param.value < param.limits[0])):
+                if (np.allclose(param.value, param.limits[0])):
+                    # nextafter -> next representable float
+                    if mode == 'fix':
+                        warn("{0} is less than the lower limit {1}, but very close."
+                             " Converting to {1}+ULP".format(param.value,
+                                                             param.limits[0]))
+                        param.value = np.nextafter(param.limits[0], param.limits[0]+1)
+                    elif mode == 'raise':
+                        raise ValueError("{0} is less than the lower limit {1}, but very close."
+                                         .format(param.value, param.limits[1]))
+                    elif mode == 'check':
+                        check.append("lt:close",)
+                if mode == 'raise':
+                    raise ValueError("{0} is less than the lower limit {1}"
+                                     .format(param.value, param.limits[0]))
+                elif mode == 'check':
+                    check.append(False)
+
+            if (param.limited[1] and (param.value > param.limits[1])):
+                if (np.allclose(param.value, param.limits[1])):
+                    if mode =='fix':
+                        param.value = np.nextafter(param.limits[1], param.limits[1]-1)
+                        warn("{0} is greater than the upper limit {1}, but very close."
+                             " Converting to {1}-ULP".format(param.value,
+                                                             param.limits[1]))
+                    elif mode == 'raise':
+                        raise ValueError("{0} is greater than the upper limit {1}, but very close."
+                                         .format(param.value, param.limits[1]))
+                    elif mode == 'check':
+                        check.append("gt:close")
+                if mode == 'raise':
+                    raise ValueError("{0} is greater than the upper limit {1}"
+                                     .format(param.value, param.limits[0]))
+                elif mode == 'check':
+                    check.append(False)
+
+        return check


### PR DESCRIPTION
See https://github.com/GBTAmmoniaSurvey/GAS/issues/45

It is not obvious how this happens, but it results from the fitter *returning* values 1 ULP out of range.

Workaround: extra validation.  Unfortunately, this adds some (hopefully tiny) overhead to each fit.