### PR TITLE
measuring EQWs for low-res optical spectra 

### DIFF
--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -1629,7 +1629,7 @@ class Specfit(interactive.Interactive):
                                                       parlimitdict=parlimitdict,
                                                       **kwargs)
         else:
-            print "Must have a fitter instantiated before creating sliders"
+            log.error("Must have a fitter instantiated before creating sliders")
 
     def optimal_chi2(self, reduced=True, threshold='error', **kwargs):
         """

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import matplotlib
 import numpy as np
 from ..config import mycfg
@@ -1202,10 +1203,10 @@ class Specfit(interactive.Interactive):
         """
 
         if self.Spectrum.baseline.baselinepars is not None and print_baseline:
-            print "Baseline: " + " + ".join(["%12g x^%i" % (x,i) for i,x in enumerate(self.Spectrum.baseline.baselinepars[::-1])])
+            print("Baseline: " + " + ".join(["%12g x^%i" % (x,i) for i,x in enumerate(self.Spectrum.baseline.baselinepars[::-1])]))
 
         for i,p in enumerate(self.parinfo):
-            print "%15s: %12g +/- %12g" % (p['parname'],p['value'],p['error'])
+            print("%15s: %12g +/- %12g" % (p['parname'],p['value'],p['error']))
 
     def clear(self, legend=True, components=True):
         """
@@ -1384,7 +1385,9 @@ class Specfit(interactive.Interactive):
                 dx = np.median(dx)
                 integ = self.fitter.integral(self.modelpars, dx=dx, **kwargs)
                 if return_error:
-                    if mycfg.WARN: print "WARNING: The computation of the error on the integral is not obviously correct or robust... it's just a guess."
+                    if mycfg.WARN: print("WARNING: The computation of the error "
+                                         "on the integral is not obviously "
+                                         "correct or robust... it's just a guess.")
                     OK = np.abs( fullmodel ) > threshold
                     error = np.sqrt((self.errspec[OK]**2).sum()) * dx
                     #raise NotImplementedError("We haven't written up correct error estimation for integrals of fits")
@@ -1518,13 +1521,15 @@ class Specfit(interactive.Interactive):
         self.Spectrum.plotter.figure.canvas.mpl_disconnect(self.keyclick)
         npars = 2+nwidths
         if self.npeaks > 0:
-            print len(self.guesses)/npars," Guesses: ",self.guesses," X channel range: ",self.xmin,self.xmax
+            log.info("{0} Guesses : {1}  X channel range: {2}-{3}"
+                     .format(len(self.guesses)/npars, self.guesses, self.xmin,
+                             self.xmax))
             if len(self.guesses) % npars == 0:
                 self.multifit(use_window_limits=True)
                 for p in self.button2plot + self.button1plot:
                     p.set_visible(False)
             else: 
-                print "error, wrong # of pars"
+                log.error("Wrong # of parameters")
 
         # disconnect interactive window (and more importantly, reconnect to
         # original interactive cmds)

--- a/pyspeckit/spectrum/interactive.py
+++ b/pyspeckit/spectrum/interactive.py
@@ -79,7 +79,11 @@ class Interactive(object):
                 return
 
             if debug or self._debug:
-                print "button: ",button," x,y: ",event.xdata,event.ydata," nclicks 1: %i  2: %i" % (self.nclicks_b1,self.nclicks_b2)
+                log.debug("button: {0} x,y: {1},{2} " 
+                          " nclicks 1: {3:d}  2: {4:d}".format
+                          (self.nclicks_b1, self.nclicks_b2,
+                          button, event.xdata, event.ydata,
+                          ))
 
             if button in ('p','P','1',1,'i','a'): # p for... parea?  a for area.  i for include
                 # button one is always region selection
@@ -92,19 +96,20 @@ class Interactive(object):
                 # exclude/delete/remove
                 self.selectregion_interactive(event, mark_include=False, debug=debug)
             elif button in ('m','M','2',2): # m for mark
-                if debug or self._debug: print "Button 2 action"
+                if debug or self._debug: log.debug("Button 2 action")
                 self.button2action(event,debug=debug,nwidths=nwidths)
             elif button in ('d','D','3',3): # d for done
-                if debug or self._debug: print "Button 3 action"
+                if debug or self._debug: log.debug("Button 3 action")
                 self.button3action(event,debug=debug,nwidths=nwidths)
             elif button in ('?'):
-                print self.interactive_help_message
+                # print statement: we really want this to go to the terminal
+                print(self.interactive_help_message)
             elif hasattr(self,'Registry') and button in self.Registry.fitkeys:
                 fittername = self.Registry.fitkeys[button]
                 if fittername in self.Registry.multifitters:
                     self.fitter = self.Registry.multifitters[fittername]
                     self.fittype = fittername
-                    print "Selected multi-fitter %s" % fittername
+                    print("Selected multi-fitter %s" % fittername)
                 else: 
                     print "ERROR: Did not find fitter %s" % fittername
             if self.Spectrum.plotter.autorefresh: self.Spectrum.plotter.refresh()
@@ -413,26 +418,25 @@ class Interactive(object):
             if debug or self._debug: print "Including self.xmin:self.xmax = %f:%f (and excluding the rest)" % (self.xmin,self.xmax)
             self.includemask[self.xmin:self.xmax] = True
         else:
-            if verbose: print "Left region selection unchanged.  xminpix, xmaxpix: %i,%i" % (self.xmin,self.xmax)
+            if verbose: log.info("Left region selection unchanged."
+                                 "  xminpix, xmaxpix: %i,%i" % (self.xmin,self.xmax))
         
         if self.xmin == self.xmax:
             # Reset if there is no fitting region
             self.xmin = 0
             # End-inclusive
             self.xmax = self.Spectrum.data.shape[0]
-            if debug or self._debug:
-                print "Reset to full range because the endpoints were equal"
+            log.debug("Reset to full range because the endpoints were equal")
         elif self.xmin>self.xmax: 
             # Swap endpoints if the axis has a negative delta-X
             self.xmin,self.xmax = self.xmax,self.xmin
-            if debug or self._debug:
-                print "Swapped endpoints because the left end was greater than the right"
+            log.debug("Swapped endpoints because the left end was greater than the right")
 
         self.includemask[:self.xmin] = False
         self.includemask[self.xmax:] = False
 
         # Exclude keyword-specified excludes.  Assumes exclusion in current X array units
-        if debug or self._debug: print "Exclude: ",exclude
+        if debug or self._debug: log.debug("Exclude: {0}".format(exclude))
         if exclude is not None and len(exclude) % 2 == 0:
             for x1,x2 in zip(exclude[::2],exclude[1::2]):
                 if xtype.lower() in ('wcs',) or xtype in pyspeckit.spectrum.units.xtype_dict:

--- a/pyspeckit/spectrum/interactive.py
+++ b/pyspeckit/spectrum/interactive.py
@@ -80,7 +80,7 @@ class Interactive(object):
 
             if debug or self._debug:
                 log.debug("button: {0} x,y: {1},{2} " 
-                          " nclicks 1: {3:d}  2: {4:d}".format
+                          " nclicks 1: {3:f}  2: {4:f}".format
                           (self.nclicks_b1, self.nclicks_b2,
                           button, event.xdata, event.ydata,
                           ))

--- a/pyspeckit/spectrum/interactive.py
+++ b/pyspeckit/spectrum/interactive.py
@@ -337,7 +337,8 @@ class Interactive(object):
         """
         for p in self.button1plot:
             p.set_visible(False)
-            if p in self.Spectrum.plotter.axis.lines: self.Spectrum.plotter.axis.lines.remove(p)
+            if self.Spectrum.plotter.axis and p in self.Spectrum.plotter.axis.lines:
+                self.Spectrum.plotter.axis.lines.remove(p)
         self.button1plot=[] # I should be able to just remove from the list... but it breaks the loop...
         self.Spectrum.plotter.refresh()
 
@@ -436,7 +437,7 @@ class Interactive(object):
         self.includemask[self.xmax:] = False
 
         # Exclude keyword-specified excludes.  Assumes exclusion in current X array units
-        if debug or self._debug: log.debug("Exclude: {0}".format(exclude))
+        log.debug("Exclude: {0}".format(exclude))
         if exclude is not None and len(exclude) % 2 == 0:
             for x1,x2 in zip(exclude[::2],exclude[1::2]):
                 if xtype.lower() in ('wcs',) or xtype in pyspeckit.spectrum.units.xtype_dict:
@@ -444,6 +445,9 @@ class Interactive(object):
                     # WCS units should be end-inclusive
                     x2 = self.Spectrum.xarr.x_to_pix(x2)+1
                 self.includemask[x1:x2] = False
+        elif exclude is not None:
+            log.error("An 'exclude' keyword was specified with an odd number "
+                      "of parameters, which is not permitted.")
 
         if highlight:
             self.highlight_fitregion()

--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -267,10 +267,10 @@ class Plotter(object):
                     steppify((self.Spectrum.data*self.plotscale+self.offset+self.Spectrum.error*self.plotscale)[inds]),
                     facecolor=errcolor, edgecolor=errcolor, alpha=erralpha, **kwargs)]
             elif errstyle == 'bars':
-                self.errorplot = self.axis.errorbar(self.Spectrum.xarr[inds]+xoffset,
+                self.errorplot = self.axis.errorbar(self.Spectrum.xarr[inds].value+xoffset,
                                                     self.Spectrum.data[inds]*self.plotscale+self.offset,
                                                     yerr=self.Spectrum.error[inds]*self.plotscale,
-                                                    ecolor=errcolor, fmt=None,
+                                                    ecolor=errcolor, fmt='none',
                                                     **kwargs)
 
         self._spectrumplot = self.axis.plot(self.Spectrum.xarr.value[inds]+xoffset,

--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -269,7 +269,7 @@ class Plotter(object):
             elif errstyle == 'bars':
                 self.errorplot = self.axis.errorbar(self.Spectrum.xarr[inds]+xoffset,
                                                     self.Spectrum.data[inds]*self.plotscale+self.offset,
-                                                    yerr=self.Spectrum.error*self.plotscale,
+                                                    yerr=self.Spectrum.error[inds]*self.plotscale,
                                                     ecolor=errcolor, fmt=None,
                                                     **kwargs)
 

--- a/pyspeckit/spectrum/tests/test_eqw.py
+++ b/pyspeckit/spectrum/tests/test_eqw.py
@@ -10,5 +10,27 @@ def test_eqw():
     sp = Spectrum(xarr=x, data=y)
     sp.baseline(exclude=[-5,5], order=0, subtract=False)
     sp.specfit(fittype='gaussian', guesses=(-1, 0, 0.5))
+    eqw_nofit = sp.specfit.EQW(fitted=False)
     np.testing.assert_almost_equal(sp.specfit.EQW(), (1-y).sum() * dx, decimal=5)
     np.testing.assert_almost_equal(sp.specfit.EQW(continuum=1), (1-y).sum() * dx, decimal=5)
+    np.testing.assert_almost_equal(eqw_nofit, (1-y).sum() * dx, decimal=4)
+    return sp
+
+def test_eqw_plot():
+    dx = 0.1
+    x = np.arange(-6,6,dx)
+    y = 1-np.exp(-x**2 / 2.)
+    sp = Spectrum(xarr=x, data=y)
+    sp.plotter()
+    sp.baseline(exclude=[-5,5], order=0, subtract=False)
+    sp.specfit(fittype='gaussian', guesses=(-1, 0, 0.5))
+    eqw = sp.specfit.EQW()
+    eqw_nofit = sp.specfit.EQW(fitted=False)
+    eqw_cont = sp.specfit.EQW(plotcolor='g', fitted=True, continuum=1,
+                              plot=True,
+                              components=False, annotate=True,
+                              loc='lower left', xmin=None, xmax=None)
+    np.testing.assert_almost_equal(eqw, (1-y).sum() * dx, decimal=5)
+    np.testing.assert_almost_equal(eqw_cont, (1-y).sum() * dx, decimal=5)
+    np.testing.assert_almost_equal(eqw_nofit, (1-y).sum() * dx, decimal=4)
+    return sp


### PR DESCRIPTION
I am trying to measure equivalent widths for low-resolution optical spectra, but am encountering an error in the actual measurement. I'm getting an extremely small EW, an uncertainty on the order of 10e-11, and the Voigt profile fit does not appear on the final plot. It seems that the eq width procedure is trying to integrate to a point. 

![h-alpha_salt](https://cloud.githubusercontent.com/assets/3017712/8571469/18f47e0e-2555-11e5-8e12-7e7d255f76b0.png) 

Below is my code and the output plot. 

![screen shot 2015-07-08 at 9 37 34 am](https://cloud.githubusercontent.com/assets/3017712/8571463/0766af36-2555-11e5-9544-87bcf1bb7578.png)

![screen shot 2015-07-08 at 9 33 09 am](https://cloud.githubusercontent.com/assets/3017712/8571492/31fee254-2555-11e5-973c-67c121148aeb.png)

I ran this same code a few months ago and didn't have this issue (see below). 

![h_alpha](https://cloud.githubusercontent.com/assets/3017712/8571557/8f6da7fe-2555-11e5-9aff-2ddee8673ef1.png)