### PR TITLE
Remove hard-coded K->T_A* label

### DIFF
--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -423,7 +423,7 @@ class Plotter(object):
         elif self.Spectrum.unit in ['Ta*','Tastar']:
             self.axis.set_ylabel("$T_A^*$ (K)")
         elif self.Spectrum.unit in ['K']:
-            self.axis.set_ylabel("$T_{beam}$ (K)")
+            self.axis.set_ylabel("Brightness Temperature $T$ (K)")
         elif self.Spectrum.unit == 'mJy':
             self.axis.set_ylabel("$S_\\nu$ (mJy)")
         elif self.Spectrum.unit == 'Jy':

--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -420,8 +420,10 @@ class Plotter(object):
 
         if ylabel is not None:
             self.axis.set_ylabel(ylabel)
-        elif self.Spectrum.unit in ['Ta*','Tastar','K']:
+        elif self.Spectrum.unit in ['Ta*','Tastar']:
             self.axis.set_ylabel("$T_A^*$ (K)")
+        elif self.Spectrum.unit in ['K']:
+            self.axis.set_ylabel("$T_{beam}$ (K)")
         elif self.Spectrum.unit == 'mJy':
             self.axis.set_ylabel("$S_\\nu$ (mJy)")
         elif self.Spectrum.unit == 'Jy':


### PR DESCRIPTION
Often, `T_{MB}` or other scales are intended when the units are Kelvin