### PR TITLE
Allow `data` to be passed as a Quantity

### DIFF
--- a/pyspeckit/spectrum/classes.py
+++ b/pyspeckit/spectrum/classes.py
@@ -170,6 +170,11 @@ class Spectrum(object):
                 self.header = pyfits.Header()
             self.parse_header(self.header)
 
+        if hasattr(self.data,'unit'):
+            # TODO: use the quantity more appropriately
+            self.unit = str(self.data.unit)
+            self.data = self.data.value
+
         if maskdata:
             if hasattr(self.data,'mask'):
                 self.data.mask += np.isnan(self.data) + np.isinf(self.data)


### PR DESCRIPTION
If you try to give a `Spectrum` a quantity for the data at the moment, it will die kind of like this:

```
NotImplementedError                       Traceback (most recent call last)
<ipython-input-24-7a72129aa2ad> in <module>()
----> 1 spec = ps.Spectrum(data=c[:,50,50], xarr=c.spectral_axis)

/Users/anon/anaconda/lib/python2.7/site-packages/pyspeckit/spectrum/classes.pyc in __init__(self, filename, filetype, xarr, data, error, header, doplot, maskdata, unit, plotkwargs, xarrkwargs, **kwargs)
    178             else:
    179                 self.data = np.ma.masked_where(np.isnan(self.data) + np.isinf(self.data), self.data)
--> 180                 self.error = np.ma.masked_where(np.isnan(self.data) + np.isinf(self.data), self.error)
    181 
    182         # it is very important that this be done BEFORE the spectofit is set!

/Users/anon/anaconda/lib/python2.7/site-packages/numpy/ma/core.pyc in masked_where(condition, a, copy)
   1803     """
   1804     # Make sure that condition is a valid standard-type mask.
-> 1805     cond = make_mask(condition)
   1806     a = np.array(a, copy=copy, subok=True)
   1807 

/Users/anon/anaconda/lib/python2.7/site-packages/numpy/ma/core.pyc in make_mask(m, copy, shrink, dtype)
   1517         result = np.array(filled(m, True), dtype=MaskType)
   1518     # Bas les masques !
-> 1519     if shrink and (not result.dtype.names) and (not result.any()):
   1520         return nomask
   1521     else:

/Users/anon/anaconda/lib/python2.7/site-packages/astropy/units/quantity.pyc in any(self, axis, out)
1319 
1320     def any(self, axis=None, out=None):
-> 1321         raise NotImplementedError("cannot evaluate truth value of quantities. "
1322                                   "Evaluate array with q.value.any(...)")
1323 

NotImplementedError: cannot evaluate truth value of quantities. Evaluate array with q.value.any(...)
```

The workaround for now is just to pass `Spectrum(data=data.value, xarr=xarr)`,
but this PR will allow `Quantity`s to be passed directly