### PR TITLE
cube.get_spectrum(...) does not preserve cube unit

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -446,7 +446,9 @@ class Cube(spectrum.Spectrum):
         sp = pyspeckit.Spectrum(xarr=self.xarr.copy(), data=self.cube[:,y,x],
                                 header=header,
                                 error=(self.errorcube[:,y,x] if self.errorcube
-                                       is not None else None))
+                                       is not None else None),
+                                unit=self.unit,
+                               )
 
         sp.specfit = copy.copy(self.specfit)
         # explicitly re-do this (test)


### PR DESCRIPTION
```
In [97]: blah = cube11.get_spectrum(512,512)
c
In [98]: cube11.un
cube11.unit   cube11.units  

In [98]: cube11.unit
Out[98]: 'K'

In [99]: blah.unit
Out[99]: 'JY/BEAM'
```