### PR TITLE
Offset between NH3(1,1) frequencies

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -34,6 +34,18 @@ from astropy import log
 from astropy import wcs
 from astropy import units
 from astropy.utils.console import ProgressBar
+from functools import wraps
+import warnings
+
+def not_for_cubes(func):
+
+    @wraps(func)
+    def wrapper(*args):
+        warnings.warn("This operation ({0}) operates on the spectrum selected "
+                      "from the cube, e.g. with `set_spectrum` or `set_apspec`"
+                      ", it does not operate on the whole cube.")
+        return func(*args)
+    return wrapper
 
 class Cube(spectrum.Spectrum):
 

--- a/pyspeckit/spectrum/classes.py
+++ b/pyspeckit/spectrum/classes.py
@@ -170,6 +170,11 @@ class Spectrum(object):
                 self.header = pyfits.Header()
             self.parse_header(self.header)
 
+        if hasattr(self.data,'unit'):
+            # TODO: use the quantity more appropriately
+            self.unit = str(self.data.unit)
+            self.data = self.data.value
+
         if maskdata:
             if hasattr(self.data,'mask'):
                 self.data.mask += np.isnan(self.data) + np.isinf(self.data)

--- a/pyspeckit/spectrum/models/ammonia_constants.py
+++ b/pyspeckit/spectrum/models/ammonia_constants.py
@@ -23,7 +23,7 @@ line_labels = {'oneone': '1-1',
               }
 
 freq_dict = { 
-    'oneone':     23.694506e9,
+    'oneone':     23.6944955e9, # Issue 91: Erik's custom frequency
     'twotwo':     23.722633335e9,
     'threethree': 23.8701296e9,
     'fourfour':   24.1394169e9,


### PR DESCRIPTION
Important bug: @keflavich @low-sky @rfriesen

I compared the frequencies for the HFS components of NH3(1,1) from Lovas (http://pml.nist.gov/cgi-bin/micro/table5/search.pl) with those used in `pyspeckit`, and there is an offset due to the wrong rest rfequency used.
```
In [1]: import astropy.units as u

In [2]: freq=23692.9265*u.MHz

In [3]: rest11_pyspeckit=23.694506*u.GHz

In [4]: freq.to(u.km/u.s, equivalencies=u.doppler_radio(rest11_pyspeckit))
Out[4]: <Quantity 19.984471818482156 km / s>

In [5]: new_rest11=23.6944955*u.GHz

In [6]: freq.to(u.km/u.s, equivalencies=u.doppler_radio(new_rest11))
Out[6]: <Quantity 19.851630375538335 km / s>

```
while the offset for the first component in `pyspeckit` is `19.8513`