### PR TITLE
Bugfix: in_range needs to check units before comparing

### DIFF
--- a/pyspeckit/spectrum/tests/test_units.py
+++ b/pyspeckit/spectrum/tests/test_units.py
@@ -80,6 +80,14 @@ def test_convert_units2():
 
     assert np.all(velocity_arr.value==velocity_arr2.value)
 
+def test_in_range():
+    xarr = units.SpectroscopicAxis(np.linspace(1,10,10),unit='Hz')
+
+    assert not xarr.in_range(10*u.GHz)
+    assert xarr.in_range(5*u.Hz)
+
+    # TODO: make sure warning is raised
+    assert xarr.in_range(5)
 
 
 @pytest.mark.parametrize(('unit_from','unit_to','convention','ref_unit'),params)

--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -500,7 +500,8 @@ class SpectroscopicAxis(u.Quantity):
 
         if unit is not None:
             # could be reversed
-            return np.max([self.coord_to_x(self.max(), units),self.coord_to_x(self.min(),units)])
+            return np.max([self.coord_to_x(self.max(), units),
+                           self.coord_to_x(self.min(),units)])
         else: 
             return self.max()
 
@@ -512,7 +513,8 @@ class SpectroscopicAxis(u.Quantity):
 
         if unit is not None:
             # could be reversed
-            return np.min([self.coord_to_x(self.max(), units),self.coord_to_x(self.min(),units)])
+            return np.min([self.coord_to_x(self.max(), units),
+                           self.coord_to_x(self.min(),units)])
         else: 
             return self.min()
 
@@ -537,7 +539,14 @@ class SpectroscopicAxis(u.Quantity):
         """
         Given an X coordinate in SpectroscopicAxis' units, return whether the pixel is in range
         """
-        return bool((xval > self.min()) * (xval < self.max()))
+        if hasattr(xval, 'unit'):
+            return bool((xval > self.min()) * (xval < self.max()))
+        else:
+            warnings.warn("The xvalue being compared in "
+                          "SpectroscopicAxis.in_range has no unit.  "
+                          "Assuming the unit is the same as the current "
+                          "axis unit.")
+            return bool((xval > self.min().value) * (xval < self.max().value))
 
     def x_to_coord(self, xval, xunit, verbose=False):
         """


### PR DESCRIPTION
This affects only small corners of pyspeckit, but in particular the NH3 wrapper module