### PR TITLE
ValueError: Map is all NaNs or infs.  

### DIFF
--- a/docs/example_n2hp.rst
+++ b/docs/example_n2hp.rst
@@ -5,33 +5,9 @@ Radio Fitting: N\ :sub:`2`\ H+ example
 ============================================
 Example hyperfine line fitting for the N\ :sub:`2`\ H+ 1-0 line.
 
+.. literalinclude:: ../examples/n2hp_example.py
+    :language: python
 
-:: 
-
-    import pyspeckit
-
-    # Load the spectrum
-    sp = pyspeckit.Spectrum('n2hp_opha_example.fits')
-
-    # Register the fitter
-    # The N2H+ fitter is 'built-in' but is not registered by default; this example
-    # shows how to register a fitting procedure
-    # 'multi' indicates that it is possible to fit multiple components and a
-    # background will not automatically be fit 
-    # 4 is the number of parameters in the model (excitation temperature,
-    # optical depth, line center, and line width)
-    sp.Registry.add_fitter('n2hp_vtau', pyspeckit.models.n2hp.n2hp_vtau_fitter,4)
-
-    # Run the fitter
-    sp.specfit(fittype='n2hp_vtau',guesses=[15,2,4,0.2])
-
-    # Plot the results
-    sp.plotter()
-    # Re-run the fitter (to get proper error bars) and show the individual fit components
-    sp.specfit(fittype='n2hp_vtau', guesses=[15,2,4,0.2], show_hyperfine_components=True)
-
-    # Save the figure (this step is just so that an image can be included on the web page)
-    sp.plotter.savefig('n2hp_ophA_fit.png')
 
 .. figure:: images/n2hp_ophA_fit.png
 	:alt: Fit to the 15 hyperfine components of N2H+ simultaneously.  The (0)'s indicate that this is the 0'th velocity component being fit

--- a/examples/n2hp_example.py
+++ b/examples/n2hp_example.py
@@ -17,7 +17,8 @@ sp.specfit(fittype='n2hp_vtau',multifit=None,guesses=[15,2,4,0.2])
 # Plot the results
 sp.plotter()
 # Re-run the fitter (to get proper error bars) and show the individual fit components
-sp.specfit(fittype='n2hp_vtau',multifit=None,guesses=[15,2,4,0.2],show_components=True)
+sp.specfit(fittype='n2hp_vtau', multifit=None, guesses=[15, 2, 4, 0.2],
+           show_hyperfine_components=True)
 
 # Save the figure (this step is just so that an image can be included on the web page)
 sp.plotter.savefig('n2hp_ophA_fit.png')

--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -313,7 +313,7 @@ class Cube(spectrum.Spectrum):
 
         return Cube(xarr=self.xarr.__getitem__(indx[0]), cube=self.cube[indx],
                     errorcube=self.errorcube[indx] if self.errorcube else None,
-                    maskmap=self.maskmap)
+                    maskmap=self.maskmap[indx[1:]] if self.maskmap is not None else None)
 
     def set_spectrum(self, x, y):
         self.data = self.cube[:,y,x]


### PR DESCRIPTION
This error raised when I try to fit N2H+ cube following
[this link](http://pyspeckit.bitbucket.org/html/sphinx/example_n2hp_cube.html)
Seems straightforward to fix (hopefully).

```python
     45                 signal_cut=6, # minimize the # of pixels fit for the example
     46                 start_from_point=(168,32), # start at a pixel with signal
---> 47                 errmap=errmap
     48                 )
     49     # There are a huge number of parameters for the fiteach procedure.  See:

/home/kwang/anaconda/lib/python2.7/site-packages/pyspeckit-0.1.18.dev1933-py2.7.egg/pyspeckit/cubes/SpectralCube.pyc in fiteach(self, errspec, errmap, guesses, verbose, verbose_level, quiet, signal_cut, usemomentcube, blank_value, integral, direct, absorption, use_nearest_as_guess, use_neighbor_as_guess, start_from_point, multicore, position_order, continuum_map, prevalidate_guesses, maskmap, **fitkwargs)
    627 
    628         if not hasattr(self.mapplot,'plane'):
--> 629             self.mapplot.makeplane()
    630 
    631         if maskmap is None:

/home/kwang/anaconda/lib/python2.7/site-packages/pyspeckit-0.1.18.dev1933-py2.7.egg/pyspeckit/cubes/mapplot.pyc in makeplane(self, estimator)
    238 
    239         if np.sum(np.isfinite(self.plane)) == 0:
--> 240             raise ValueError("Map is all NaNs or infs.  Check your estimator or your input cube.")
    241 
    242     def click(self,event):

ValueError: Map is all NaNs or infs.  Check your estimator or your input cube.
```