### PR TITLE
Fix some issues with Baselines

### DIFF
--- a/pyspeckit/spectrum/baseline.py
+++ b/pyspeckit/spectrum/baseline.py
@@ -5,6 +5,7 @@ from ..config import ConfigDescriptor as cfgdec
 import interactive
 import copy
 import history
+from . import models
 from .. import specwarnings
 from astropy import log
 
@@ -174,8 +175,10 @@ class Baseline(interactive.Interactive):
                                subtract=subtract,
                                LoudDebug=LoudDebug,
                                **kwargs)
-            if highlight_fitregion: self.highlight_fitregion()
-        if save: self.savefit()
+            if highlight_fitregion:
+                self.highlight_fitregion()
+        if save:
+            self.savefit()
 
     def set_spectofit(self, fit_original=True, fit_residuals=False):
         """
@@ -189,7 +192,8 @@ class Baseline(interactive.Interactive):
             self.spectofit = self.Spectrum.data.copy()
 
     def fit(self, powerlaw=None, order=None, includemask=None, spline=False,
-            spline_sampling=10, spline_downsampler=np.median, **kwargs):
+            spline_sampling=10, spline_downsampler=np.median,
+            xarr_fit_unit=None, **kwargs):
         """
         Run the fit and set `self.basespec`
         """
@@ -216,10 +220,11 @@ class Baseline(interactive.Interactive):
                                  err=self.Spectrum.error, order=self.order,
                                  masktoexclude=~self.includemask,
                                  powerlaw=self.powerlaw,
-                                 xarr_fit_units=xarr.unit, **kwargs)
+                                 xarr_fitunits=xarr_fit_unit,
+                                 **kwargs)
             self.basespec, self.baselinepars = (a,b)
 
-            self.set_basespec_frompars()
+            self.set_basespec_frompars(xarr_fit_unit=xarr_fit_unit)
 
     def button2action(self, event=None, debug=False, subtract=True,
                       powerlaw=None, fit_original=False,
@@ -231,7 +236,8 @@ class Baseline(interactive.Interactive):
         Do the baseline fitting and save and plot the results.
 
         """
-        if debug: print "Button 2/3 Baseline.  Subtract=",subtract
+        if debug:
+            print("Button 2/3 Baseline.  Subtract={0}".format(subtract))
         if self.subtracted:
             self.unsubtract()
 
@@ -251,7 +257,8 @@ class Baseline(interactive.Interactive):
         self.fit(powerlaw=powerlaw, includemask=self.includemask,
                  order=self.order, spline=spline,
                  spline_sampling=spline_sampling,
-                 spline_downsampler=spline_downsampler)
+                 spline_downsampler=spline_downsampler,
+                 **kwargs)
 
         if subtract:
             if self.subtracted and fit_original:
@@ -266,7 +273,7 @@ class Baseline(interactive.Interactive):
             self.subtracted = False
 
         if self.Spectrum.plotter.axis is not None:
-            if debug: print "Plotting baseline"
+            log.debug("Plotting baseline")
             if event is not None:
                 # preserve frame if fitting interactively
                 kwargs.update({'use_window_limits':True})
@@ -278,16 +285,33 @@ class Baseline(interactive.Interactive):
 
         if hasattr(self.Spectrum,'header'):
             history.write_history(self.Spectrum.header,
-                    "BASELINE order=%i pars=%s" % (self.order,
-                        ",".join([str(s) for s in self.baselinepars])) +
-                        "(powerlaw)" if self.powerlaw else "")
+                                  "BASELINE order=%i pars=%s"
+                                  % (self.order, ",".join([str(s) for s in
+                                                           self.baselinepars]))
+                                  + "(powerlaw)" if self.powerlaw else "")
 
-    def set_basespec_frompars(self, baselinepars=None):
+    def set_basespec_frompars(self, baselinepars=None, xarr_fit_unit=None):
         """
         Set the baseline spectrum based on the fitted parameters
-        """
 
-        self.basespec = self.get_model(xarr=self.Spectrum.xarr,
+        Parameters
+        ----------
+        baselinepars : list
+            Optional list of fit parameters, e.g. a list of polynomial
+            coefficients
+        xarr_fit_unit : None or 'pixels' or 'native' or unit
+            The units that were used in the baseline fit
+        """
+        if xarr_fit_unit == 'pixels':
+            xarrconv = np.arange(self.Spectrum.data.size)
+        elif xarr_fit_unit not in (None, 'native'):
+            xarrconv = self.Spectrum.xarr.as_unit(xarr_fit_unit)
+        else:
+            xarrconv = self.Spectrum.xarr
+
+        log.debug("xarr_fit_unit: {0}".format(xarr_fit_unit))
+
+        self.basespec = self.get_model(xarr=xarrconv,
                                        baselinepars=baselinepars)
 
     def get_model(self, xarr=None, baselinepars=None):
@@ -433,7 +457,7 @@ class Baseline(interactive.Interactive):
 
     def _baseline(self, spectrum, xarr=None, err=None,
                   order=1, quiet=True, masktoexclude=None, powerlaw=False,
-                  xarr_fit_units='pixels', LoudDebug=False, renormalize='auto',
+                  xarr_fit_unit='pixels', LoudDebug=False, renormalize='auto',
                   zeroerr_is_OK=True, spline=False, **kwargs):
         """
         Fit a baseline/continuum to a spectrum
@@ -457,8 +481,13 @@ class Baseline(interactive.Interactive):
         #elif xmax is None:
         #    xmax = spectrum.shape[-1]
 
-        if xarr is None:
-            xarr = np.indices(spectrum.shape).squeeze()
+        if xarr is None or xarr_fit_unit == 'pixels':
+            xarrconv = np.arange(spectrum.size)
+        elif xarr_fit_unit not in (None, 'native'):
+            xarrconv = xarr.as_unit(xarr_fit_unit)
+        else:
+            xarrconv = xarr
+        log.debug("xarrconv = {0}".format(xarrconv))
 
 
         # A good alternate implementation of masking is to only pass mpfit the data
@@ -481,19 +510,19 @@ class Baseline(interactive.Interactive):
             if masktoexclude.dtype.name != 'bool':
                 masktoexclude = masktoexclude.astype('bool')
             err[masktoexclude] = 1e10
-            if LoudDebug: print "In _baseline: %i points masked out" % masktoexclude.sum()
+            if LoudDebug:
+                print("In _baseline: %i points masked out" % masktoexclude.sum())
         if (spectrum!=spectrum).sum() > 0:
-            print "There is an error in baseline: some values are NaN"
+            print("There is an error in baseline: some values are NaN")
             import pdb; pdb.set_trace()
 
-        #xarrconv = xarr[xmin:xmax].as_unit(xarr_fit_units)
-        OK = True-masktoexclude
-        xarrconv = xarr.as_unit(xarr_fit_units)
+        OK = ~masktoexclude
         if powerlaw:
             # for powerlaw fitting, only consider positive data
             OK *= spectrum > 0
             pguess = [np.median(spectrum[OK]),2.0]
-            if LoudDebug: print "_baseline powerlaw Guesses: ",pguess
+            if LoudDebug:
+                print("_baseline powerlaw Guesses: ",pguess)
 
             def mpfitfun(data,err):
                 #def f(p,fjac=None): return [0,np.ravel(((p[0] * (xarrconv[OK]-p[2])**(-p[1]))-data)/err)]
@@ -506,10 +535,12 @@ class Baseline(interactive.Interactive):
                 return f
         else:
             pguess = [0]*(order+1)
-            if LoudDebug: print "_baseline Guesses: ",pguess
+            if LoudDebug:
+                print("_baseline Guesses: ",pguess)
 
             def mpfitfun(data,err):
-                def f(p,fjac=None): return [0,np.ravel((np.poly1d(p)(xarrconv[OK])-data)/err)]
+                def f(p,fjac=None):
+                    return [0,np.ravel((np.poly1d(p)(xarrconv[OK])-data)/err)]
                 return f
         #scalefactor = 1.0
         #if renormalize in ('auto',True):
@@ -520,13 +551,25 @@ class Baseline(interactive.Interactive):
         #        spectrum /= scalefactor
         #        err /= scalefactor
 
+        # error checking:
+        shapeOK = (xarrconv.shape == spectrum.shape and xarrconv.shape ==
+                   err.shape and OK.shape == xarrconv.shape)
+        if not shapeOK:
+            raise ValueError("The shape of the fitted spectra are not"
+                             " identical.  This is a major error, please "
+                             "report it as an Issue: "
+                             "https://github.com/pyspeckit/pyspeckit/issues")
+
+
         import pyspeckit.mpfit as mpfit
-        mp = mpfit.mpfit(mpfitfun(spectrum[OK],err[OK]),xall=pguess,quiet=quiet) # mpfit doesn't need to take kwargs, I think ,**kwargs)
+        mp = mpfit.mpfit(mpfitfun(spectrum[OK], err[OK]), xall=pguess,
+                         quiet=quiet)
         if np.isnan(mp.fnorm):
             raise ValueError("chi^2 is NAN in baseline fitting")
+        self.mpfit_status = models.mpfit_messages[mp.status]
+        log.debug("mpfit message: {0}".format(self.mpfit_status))
         fitp = mp.params
         if powerlaw:
-            #bestfit = (fitp[0]*(xarrconv)**(-fitp[1])).squeeze()
             bestfit = (fitp[0]*(xarrconv)**(-fitp[1])).squeeze()
         else:
             bestfit = np.poly1d(fitp)(xarrconv).squeeze()

--- a/pyspeckit/spectrum/baseline.py
+++ b/pyspeckit/spectrum/baseline.py
@@ -193,7 +193,7 @@ class Baseline(interactive.Interactive):
 
     def fit(self, powerlaw=None, order=None, includemask=None, spline=False,
             spline_sampling=10, spline_downsampler=np.median,
-            xarr_fit_unit=None, **kwargs):
+            xarr_fit_unit='pixels', **kwargs):
         """
         Run the fit and set `self.basespec`
         """

--- a/pyspeckit/spectrum/classes.py
+++ b/pyspeckit/spectrum/classes.py
@@ -394,14 +394,22 @@ class Spectrum(object):
         Fixes CRPIX1 and baseline and model spectra to match cropped data spectrum
 
         """
-        if self.xarr.unit and not unit:
-            unit = self.xarr.unit
-        elif not self.xarr.unit and not unit:
-            unit = u.dimensionless_unscaled
 
         # do slice (this code is redundant... need to figure out how to fix that)
-        x1pix = np.argmin(np.abs(x1-self.xarr.as_unit(unit).value))
-        x2pix = np.argmin(np.abs(x2-self.xarr.as_unit(unit).value))
+        if not hasattr(x1, 'unit') and unit is not None:
+            x1pix = np.argmin(np.abs(x1-self.xarr.as_unit(unit).value))
+            x2pix = np.argmin(np.abs(x2-self.xarr.as_unit(unit).value))
+        elif hasattr(x1, 'unit') and unit is not None:
+            raise ValueError("If you give x1,x2 as quantities, don't specify "
+                             "the X-axis unit (it must be equivalent, though).")
+        else:
+            # Hack: something about the inheritance of xarr prevents equivalent
+            # unit arithmetic
+            x1pix = np.argmin(np.abs(x1-u.Quantity(self.xarr)))
+            x2pix = np.argmin(np.abs(x2-u.Quantity(self.xarr)))
+            x1 = x1.value
+            x2 = x2.value
+
         if x1pix > x2pix:
             x1pix,x2pix = x2pix,x1pix
         elif x1pix == x2pix:
@@ -418,11 +426,15 @@ class Spectrum(object):
             self.specfit._full_model()
 
         if hasattr(self,'header'):
-            history.write_history(self.header,"CROP: Cropped from %g to %g (pixel %i to %i)" % (x1,x2,x1pix,x2pix))
+            history.write_history(self.header,
+                                  "CROP: Cropped from %g to %g (pixel %i to %i)"
+                                  % (x1,x2,x1pix,x2pix))
 
             if self.header.get('CRPIX1'):
                 self.header['CRPIX1'] = self.header.get('CRPIX1') - x1pix
-                history.write_history(self.header,"CROP: Changed CRPIX1 from %f to %f" % (self.header.get('CRPIX1')+x1pix,self.header.get('CRPIX1')))
+                history.write_history(self.header,
+                                      "CROP: Changed CRPIX1 from %f to %f"
+                                      % (self.header.get('CRPIX1')+x1pix,self.header.get('CRPIX1')))
 
     def slice(self, start=None, stop=None, unit='pixel', copy=True, xcopy=True,
               preserve_fits=False):

--- a/pyspeckit/spectrum/classes.py
+++ b/pyspeckit/spectrum/classes.py
@@ -402,6 +402,9 @@ class Spectrum(object):
         elif hasattr(x1, 'unit') and unit is not None:
             raise ValueError("If you give x1,x2 as quantities, don't specify "
                              "the X-axis unit (it must be equivalent, though).")
+        elif not hasattr(x1, 'unit') and unit is None:
+            x1pix = x1
+            x2pix = x2
         else:
             # Hack: something about the inheritance of xarr prevents equivalent
             # unit arithmetic


### PR DESCRIPTION
Continuum fitting will fail pretty badly if the X-axis units are huge numbers,
e.g. Hz.  The default is therefore best set to 'pixels' for the fit unit...