### PR TITLE
specfit.measure_approximate_fwhm() emission=False fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,11 +69,15 @@ before_install:
     # Use utf8 encoding. Should be default, but this is insurance against
     # future changes
     - export PYTHONIOENCODING=UTF8
-    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-    - chmod +x miniconda.sh
-    - ./miniconda.sh -b
-    - export PATH=/home/travis/miniconda/bin:$PATH
-    - conda update --yes conda
+
+    # http://conda.pydata.org/docs/travis.html#the-travis-yml-file
+    - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - export PATH="$HOME/miniconda/bin:$PATH"
+    - hash -r
+    - conda config --set always_yes yes --set changeps1 no
+    - conda update -q conda
+    - conda info -a
 
     # UPDATE APT-GET LISTINGS
     - sudo apt-get update

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -1911,10 +1911,16 @@ class Specfit(interactive.Interactive):
         if plot:
             # for plotting, use a negative if absorption
             sign = 1 if emission else -1
+
+            # shift with baseline if baseline is plotted
+            yoffset = self.Spectrum.plotter.offset
+            if not self.Spectrum.baseline.subtracted:
+                yoffset = yoffset + self.Spectrum.baseline.basespec
+
             self.Spectrum.plotter.axis.plot([xarr[hm_right].value,
                                              xarr[hm_left].value],
                                             sign*np.array([peak/2.,peak/2.]) +
-                                            self.Spectrum.plotter.offset,
+                                            yoffset,
                                             **kwargs)
             self.Spectrum.plotter.refresh()
 

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -1919,8 +1919,8 @@ class Specfit(interactive.Interactive):
 
             self.Spectrum.plotter.axis.plot([xarr[hm_right].value,
                                              xarr[hm_left].value],
-                                            sign*np.array([peak/2.,peak/2.]) +
-                                            yoffset,
+                                            sign*np.array([peak/2.+yoffset,
+                                                           peak/2.+yoffset]),
                                             **kwargs)
             self.Spectrum.plotter.refresh()
 

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -1913,14 +1913,16 @@ class Specfit(interactive.Interactive):
             sign = 1 if emission else -1
 
             # shift with baseline if baseline is plotted
-            yoffset = self.Spectrum.plotter.offset
             if not self.Spectrum.baseline.subtracted:
-                yoffset = yoffset + self.Spectrum.baseline.basespec
+                yoffleft = self.Spectrum.plotter.offset + self.Spectrum.baseline.basespec[hm_left]
+                yoffright = self.Spectrum.plotter.offset + self.Spectrum.baseline.basespec[hm_right]
+            else:
+                yoffleft = yoffright = self.Spectrum.plotter.offset
 
             self.Spectrum.plotter.axis.plot([xarr[hm_right].value,
                                              xarr[hm_left].value],
-                                            sign*np.array([peak/2.+yoffset,
-                                                           peak/2.+yoffset]),
+                                            sign*np.array([peak/2.+yoffleft,
+                                                           peak/2.+yoffright]),
                                             **kwargs)
             self.Spectrum.plotter.refresh()
 

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -1868,16 +1868,14 @@ class Specfit(interactive.Interactive):
         line_region = model > threshold
         if line_region.sum() == 0:
             raise ValueError("No valid data included in FWHM computation")
-        if line_region.sum() <= 2:
-            # if fewer than 2 points included, expand by 1 pixel in each
-            # direction.  This is a bit of a hack.
+        if line_region.sum() <= grow_threshold:
             line_region[line_region.argmax()-1:line_region.argmax()+1] = True
             reverse_argmax = len(line_region) - line_region.argmax() - 1
             line_region[reverse_argmax-1:reverse_argmax+1] = True
-            log.warn("Only two pixels were identified as part of the fit.  "
-                     "To enable statistical measurements, the range has been"
+            log.warn("Fewer than {0} pixels were identified as part of the fit."
+                     " To enable statistical measurements, the range has been"
                      " expanded by 2 pixels including some regions below the"
-                     " threshold.")
+                     " threshold.".format(grow_threshold))
 
         # determine peak (because data is neg if absorption, always use max)
         peak = data[line_region].max()
@@ -1911,8 +1909,8 @@ class Specfit(interactive.Interactive):
         deltax = xarr[hm_right]-xarr[hm_left]
 
         if plot:
-            self.Spectrum.plotter.axis.plot([xarr[hm_right],
-                                             xarr[hm_left]],
+            self.Spectrum.plotter.axis.plot([xarr[hm_right].value,
+                                             xarr[hm_left].value],
                                             np.array([peak/2.,peak/2.]) +
                                             self.Spectrum.plotter.offset,
                                             **kwargs)

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -1909,9 +1909,11 @@ class Specfit(interactive.Interactive):
         deltax = xarr[hm_right]-xarr[hm_left]
 
         if plot:
+            # for plotting, use a negative if absorption
+            sign = 1 if emission else -1
             self.Spectrum.plotter.axis.plot([xarr[hm_right].value,
                                              xarr[hm_left].value],
-                                            np.array([peak/2.,peak/2.]) +
+                                            sign*np.array([peak/2.,peak/2.]) +
                                             self.Spectrum.plotter.offset,
                                             **kwargs)
             self.Spectrum.plotter.refresh()

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -1920,10 +1920,13 @@ class Specfit(interactive.Interactive):
             else:
                 yoffleft = yoffright = self.Spectrum.plotter.offset
 
+            log.debug("peak={2} yoffleft={0} yoffright={1}".format(yoffleft, yoffright, peak))
+            log.debug("hm_left={0} hm_right={1} xarr[hm_left]={2} xarr[hm_right]={3}".format(hm_left, hm_right, xarr[hm_left], xarr[hm_right]))
+
             self.Spectrum.plotter.axis.plot([xarr[hm_right].value,
                                              xarr[hm_left].value],
-                                            sign*np.array([peak/2.+yoffleft,
-                                                           peak/2.+yoffright]),
+                                            np.array([sign*peak/2.+yoffleft,
+                                                      sign*peak/2.+yoffright]),
                                             **kwargs)
             self.Spectrum.plotter.refresh()
 

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -1915,8 +1915,8 @@ class Specfit(interactive.Interactive):
             # shift with baseline if baseline is plotted
             if not self.Spectrum.baseline.subtracted:
                 basespec = self.Spectrum.baseline.get_model(xarr)
-                yoffleft = self.Spectrum.plotter.offset + basespec
-                yoffright = self.Spectrum.plotter.offset + basespec
+                yoffleft = self.Spectrum.plotter.offset + basespec[hm_left]
+                yoffright = self.Spectrum.plotter.offset + basespec[hm_right]
             else:
                 yoffleft = yoffright = self.Spectrum.plotter.offset
 

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -1914,8 +1914,9 @@ class Specfit(interactive.Interactive):
 
             # shift with baseline if baseline is plotted
             if not self.Spectrum.baseline.subtracted:
-                yoffleft = self.Spectrum.plotter.offset + self.Spectrum.baseline.basespec[hm_left]
-                yoffright = self.Spectrum.plotter.offset + self.Spectrum.baseline.basespec[hm_right]
+                basespec = self.Spectrum.baseline.get_model(xarr)
+                yoffleft = self.Spectrum.plotter.offset + basespec
+                yoffright = self.Spectrum.plotter.offset + basespec
             else:
                 yoffleft = yoffright = self.Spectrum.plotter.offset
 


### PR DESCRIPTION
I'm trying to use `measure_approximate_fwhm()` to measure FWHM for a set of absorption lines. The following code runs, but yields an extremely small measurement (`fwhm = 0.00899764977619`). 
   
    sp = pyspeckit.Spectrum(filename)
    sp.xarr.units = 'micron'
    sp.xarr.xtype = 'wavelength'
    sp.plotter(xmin=1.250, xmax=1.255, ymin=0, errstyle = 'fill', color='black')      
    sp.specfit(plot=True, fittype='voigt', color='blue')
    fwhm = sp.specfit.measure_approximate_fwhm(threshold='error', emission=True, interpolate_factor=1024, plot=True, grow_threshold=1)
    sp.plotter.refresh()
    print fwhm
    xarr_fit_units = 'microns'
    plt.ylabel('Normalized Flux')
    plt.xlabel('Wavelength ($\mu m$)')

It seems like the code is incorrectly calculating the FWHM, since the line that should be drawn at the FWHM is well below the feature (see figure below). Also, `emission=False` gives `ValueError: No valid data included in FWHM computation`.

![fwhm](https://cloud.githubusercontent.com/assets/3017712/11005304/fba368ca-848a-11e5-906d-2e333e22dd1a.png)
