### PR TITLE
Opposite CRPIX adjustment in subimage_integ?

### DIFF
--- a/pyspeckit/cubes/cubes.py
+++ b/pyspeckit/cubes/cubes.py
@@ -439,8 +439,8 @@ def subimage_integ(cube, xcen, xwidth, ycen, ywidth, vrange, header=None,
         #    flathead['CRVAL2'] = crv2.item() # np 0-d arrays are not scalar
 
         # xlo, ylo have been forced to integers already above
-        flathead['CRPIX1'] = flathead['CRPIX1'] + xlo
-        flathead['CRPIX2'] = flathead['CRPIX2'] + ylo
+        flathead['CRPIX1'] = flathead['CRPIX1'] - xlo
+        flathead['CRPIX2'] = flathead['CRPIX2'] - ylo
 
         if return_HDU:
             return fits.PrimaryHDU(data=subim,header=flathead)

--- a/pyspeckit/cubes/cubes.py
+++ b/pyspeckit/cubes/cubes.py
@@ -20,6 +20,7 @@ import os
 import astropy.io.fits as fits
 import astropy.wcs as pywcs
 import tempfile
+import warnings
 from astropy import coordinates
 from astropy import log
 try:
@@ -278,6 +279,8 @@ def extract_aperture(cube, ap, r_mask=False, wcs=None,
     r_mask : bool
     return mask in addition to spectrum (for error checking?)
     """
+    warnings.warn("SpectralCube can do what subimage_integ does much more easily!",
+                  DeprecationWarning)
 
     if wcs is not None and coordsys is not None:
         if debug:

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -1,0 +1,31 @@
+from .. import cubes
+
+from astropy.io import fits
+
+import os
+
+def test_subimage_integ_header():
+    # getting a dummy .fits file
+    if not os.path.exists('foo.fits'):
+        from astropy.utils.data import download_file
+        tmp_path = download_file('https://db.tt/oleS9xD6')
+        try:
+            os.rename(tmp_path, 'foo.fits')
+        except OSError:
+            # os.rename doesn't like cross-device links
+            import shutil
+            shutil.move(tmp_path, 'foo.fits')
+
+    cube = fits.getdata('foo.fits')
+    header = fits.getheader('foo.fits')
+
+    xcen, ycen = 4.5, 4.5
+    xwidth, ywidth = 2.5, 2.5
+
+    # saving results from subimage_integ:
+    cutData, cutHead = cubes.subimage_integ(cube, xcen, xwidth, ycen, ywidth,
+                                            vrange=(0,9), zunits='pixels',
+                                            units='pixels', header=header)
+
+    assert cutHead['CRPIX1'] == 3.0
+    assert cutHead['CRPIX2'] == -6.0


### PR DESCRIPTION
It seems that subimage_integ doesn't update the header properly when cropping the sky coordinates. This code should reproduce the issue:
```python
import matplotlib.pyplot as plt
import pyspeckit
import aplpy
from astropy.io import fits
import os

# getting a dummy .fits file
if not os.path.exists('foo.fits'):
    from astropy.utils.data import download_file
    tmp_path = download_file('https://db.tt/oleS9xD6')
    try:
        os.rename(tmp_path, 'foo.fits')
    except OSError:
        # os.rename doesn't like cross-device links
        import shutil
        shutil.move(tmp_path, 'foo.fits')

spc = pyspeckit.Cube('foo.fits')

xcen, ycen = 4.5, 4.5
xwidth, ywidth = 2.5, 2.5

# saving results from subimage_integ:
cutData, cutHead = pyspeckit.cubes.subimage_integ(spc.cube, xcen, xwidth, 
                             ycen, ywidth, vrange=(0,9), zunits='pixels', 
                             units='pixels', header=spc.header)
fits.writeto('cut.fits', cutData, cutHead, clobber=True)

# restoring the world coordinates: 
xlo = int(max([xcen-xwidth,0]))
ylo = int(max([ycen-ywidth,0]))
cutHead['CRPIX1'] = cutHead['CRPIX1'] - xlo * 2
cutHead['CRPIX2'] = cutHead['CRPIX2'] - ylo * 2
fits.writeto('fix.fits', cutData, cutHead, clobber=True)

# plotting the two cuts with contours from    #
# the original cube to illustrate the offset: #
plt.rc('text', usetex=True)
spc.mapplot(cmap='Blues')
canv = plt.figure(figsize=(16,7))
for i,fname in enumerate(['cut.fits', 'fix.fits']):
    fig = aplpy.FITSFigure(fname, figure=canv, 
                     subplot=[0.1+i*0.5,0.1,0.35,0.8])
    fig.show_colorscale(cmap='Blues')
    fig.show_contour('foo.fits', levels=[1,1.5,2], 
                     dimensions=[0,1], slices=[5], 
                     colors='k', alpha=0.6)
    fig.add_colorbar()
```

Current subimage (left) vs subimage after the proposed change below (right), with contours from the original cube to illustrate the mismatch:
![subimage-integ-cuts](https://cloud.githubusercontent.com/assets/11835115/11194621/5b3341f0-8cad-11e5-9e4f-2061b66ca746.png)


Looks like changing the following <a href="https://github.com/pyspeckit/pyspeckit/blob/master/pyspeckit/cubes/cubes.py#L442-L443">two lines</a> might solve the issue:
```python
        # xlo, ylo have been forced to integers already above
        flathead['CRPIX1'] = flathead['CRPIX1'] - xlo
        flathead['CRPIX2'] = flathead['CRPIX2'] - ylo
```