### PR TITLE
Problem displaying the fits

### DIFF
--- a/pyspeckit/spectrum/models/hyperfine.py
+++ b/pyspeckit/spectrum/models/hyperfine.py
@@ -350,6 +350,3 @@ class hyperfinemodel(object):
                 return spec
             else:
                 return spec/spec.max() * amp
-
-
-

--- a/pyspeckit/spectrum/models/n2dp.py
+++ b/pyspeckit/spectrum/models/n2dp.py
@@ -15,7 +15,7 @@ DOI: 10.1051/0004-6361:200810570
 
 
 """
-import hyperfine
+from . import hyperfine
 import astropy.units as u
 
 # line_names = ['J1-0', 'J2-1', 'J3-2',]

--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -174,6 +174,11 @@ class Plotter(object):
         elif self.axis is None:
             self.axis = self.figure.gca()
 
+        # A check to deal with issue #117: if you close the figure, the axis
+        # still exists, but it cannot be reattached to a figure
+        if not (self.axis.get_figure() is matplotlib.pyplot.figure(self.axis.get_figure().number)):
+            self.axis = self.figure.gca()
+
         if self.axis is not None and self.axis not in self.figure.axes:
             # if you've cleared the axis, but the figure is still open, you
             # need a new axis

--- a/pyspeckit/wrappers/fitnh3.py
+++ b/pyspeckit/wrappers/fitnh3.py
@@ -119,7 +119,7 @@ def fitnh3tkin(input_dict, dobaseline=True, baselinekwargs={}, crop=False,
     return spdict,spectra
 
 def plot_nh3(spdict,spectra,fignum=1, show_components=False, residfignum=None,
-             show_hyperfine_components=True,
+             show_hyperfine_components=True, annotate=True,
              **plotkwargs):
     """
     Plot the results from a multi-nh3 fit
@@ -171,7 +171,7 @@ def plot_nh3(spdict,spectra,fignum=1, show_components=False, residfignum=None,
         if sp.specfit.modelpars is not None:
             sp.specfit.plot_fit(annotate=False, show_components=show_components,
                                 show_hyperfine_components=show_hyperfine_components)
-    if spdict['oneone'].specfit.modelpars is not None:
+    if spdict['oneone'].specfit.modelpars is not None and annotate:
         spdict['oneone'].specfit.annotate(labelspacing=0.05,
                                           prop={'size':'small',
                                                 'stretch':'extra-condensed'},


### PR DESCRIPTION
@jpinedaf 
Trying to show the result of N2D+ hyperfine structure fit I've got an error with loading the spectral cube. The data origin is GILDAS software, the fits header is shown below. Here is the sample:

```
import pyspeckit
cube = pyspeckit.Cube(file_in)
import matplotlib.pyplot as plt
cube.plot_spectrum(10,10)
```
until here the code works
```
from pyspeckit.spectrum.models import n2dp
cube.Registry.add_fitter('n2dp_vtau', pyspeckit.models.n2dp.n2dp_vtau_fitter, 4)
cube.plot_spectrum(10,10)
```
The error message:
```
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
<ipython-input-16-63e866b5228d> in <module>()
----> 1 cube.plot_spectrum(xmax,ymax)

/home/punanova/pyspeckit/pyspeckit/cubes/SpectralCube.pyc in plot_spectrum(self, x, y, plot_fit, **kwargs)
    337
    338         if self.plot_special is None:
--> 339             self.plotter(**kwargs)
    340             if plot_fit:
    341                 self.plot_fit(x,y)

/home/punanova/pyspeckit/pyspeckit/spectrum/plotters.pyc in __call__(self, figure, axis, clear, autorefresh, plotscale, override_plotkwargs, **kwargs)
    178             # if you've cleared the axis, but the figure is still open, you
    179             # need a new axis
--> 180             self.figure.add_axes(self.axis)
    181
    182

/home/punanova/.local/lib/python2.7/site-packages/matplotlib-1.4.3-py2.7-linux-x86_64.egg/matplotlib/figure.pyc in add_axes(self, *args, **kwargs)
    864         if isinstance(args[0], Axes):
    865             a = args[0]
--> 866             assert(a.get_figure() is self)
    867         else:
    868             rect = args[0]

AssertionError:

In [17]: pyspeckit.__version__
Out[17]: '0.1.18.dev2063'
```
The fits header: 
```
SIMPLE  =                    T / conforms to FITS standard                      
BITPIX  =                  -64 / array data type                                
NAXIS   =                    3 / number of array dimensions                     
NAXIS1  =                   21                                                  
NAXIS2  =                   23                                                  
NAXIS3  =                  616                                                  
BLANK   =           2147483647         / Blanking value                         
DATAMIN = -0.1670656323433E+01         /                                        
DATAMAX =  0.1339145541191E+01         /                                        
BUNIT   = 'K       '           / T_MB                                           
CTYPE1  = 'RA---SFL'           /                                                
CRVAL1  =  0.6446869999997E+02         /                                        
CDELT1  = -0.1666666625964E-02         /                                        
CRPIX1  =  0.6415799698695E+01         /                                        
CROTA1  =  0.0000000000000E+00         /                                        
CTYPE2  = 'DEC--SFL'           /                                                
CRVAL2  =  0.2794330000000E+02         /                                        
CDELT2  =  0.1666666625964E-02         /                                        
CRPIX2  =  0.1741666664582E+02         /                                        
CROTA2  =  0.0000000000000E+00         /                                        
CTYPE3  = 'VRAD        '               /                                        
CRVAL3  =  0.7000000000000E+04         /                                        
CDELT3  = -0.3796806558967E+02         /                                        
CRPIX3  =  0.3080065917969E+03         /                                        
CROTA3  =  0.0000000000000E+00         /                                        
OBJECT  = 'CORE2       '               /                                        
RA      =  0.6446869999997E+02         / Right Ascension                        
DEC     =  0.2794330000000E+02         / Declination                            
EQUINOX =  0.2000000000000E+04         /                                        
LINE    = 'NND+(2-1)   '               /                                        
ALTRPIX =  0.3080065917969E+03         /                                        
ALTRVAL =  0.1542134101120E+12         /                                        
RESTFREQ=  0.1542170110000E+12         /                                        
VELO-LSR=  0.7000000000000E+04         /                                        
VELREF  =                  257         /                                        
SPECSYS = 'LSRK    '           /                                                
BMAJ    =  0.4670668931643E-02         /                                        
BMIN    =  0.4670668931643E-02         /                                        
BPA     =  0.0000000000000E+00         /                                        
ORIGIN  = 'GILDAS Consortium  '        /                                        
DATE    = '2015-11-09T00:00:00.00'     / Date written 
```

