### PR TITLE
UI bugfix: re-trying to fit interactively in an over-plotted window fails sometimes

### DIFF
--- a/pyspeckit/spectrum/interactive.py
+++ b/pyspeckit/spectrum/interactive.py
@@ -116,8 +116,13 @@ class Interactive(object):
                 else: 
                     print("ERROR: Did not find fitter %s" % fittername)
             if self.Spectrum.plotter.autorefresh: self.Spectrum.plotter.refresh()
-        elif debug or self._debug:
+        else:
+        #elif debug or self._debug:
             print("Button press not acknowledged",event)
+            if hasattr(event,'button'):
+                print("event.button={0}".format(event.button))
+            if hasattr(event,'key'):
+                print("event.key={0}".format(event.key))
 
 
     def selectregion_interactive(self, event, mark_include=True, debug=False, **kwargs):

--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -14,6 +14,11 @@ import astropy.units as u
 import copy
 import inspect
 
+try:
+    from matplotlib.cbook import BoundMethodProxy
+except ImportError:
+    from matplotlib.cbook import _BoundMethodProxy as BoundMethodProxy
+
 from . import widgets
 from ..specwarnings import warn
 
@@ -116,10 +121,6 @@ class Plotter(object):
         """
         Disconnected the matplotlib key-press callbacks
         """
-        try:
-            from matplotlib.cbook import BoundMethodProxy
-        except ImportError:
-            from matplotlib.cbook import _BoundMethodProxy as BoundMethodProxy
         if self.figure is not None:
             cbs = self.figure.canvas.callbacks.callbacks
             # this may cause problems since the dict of key press events is a
@@ -137,12 +138,11 @@ class Plotter(object):
         """
         Reconnect the previously disconnected matplotlib keys
         """
-        from matplotlib import cbook
         if self.figure is not None and hasattr(self,'_mpl_key_callbacks'):
             self.figure.canvas.callbacks.callbacks['key_press_event'].update(self._mpl_key_callbacks)
         elif self.figure is not None:
             mpl_keypress_handler = self.figure.canvas.manager.key_press_handler_id
-            bmp = cbook.BoundMethodProxy(self.figure.canvas.manager.key_press)
+            bmp = BoundMethodProxy(self.figure.canvas.manager.key_press)
             self.figure.canvas.callbacks.callbacks['key_press_event'].update({mpl_keypress_handler:
                                                                               bmp})
 

--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -116,7 +116,10 @@ class Plotter(object):
         """
         Disconnected the matplotlib key-press callbacks
         """
-        from matplotlib import cbook
+        try:
+            from matplotlib.cbook import BoundMethodProxy
+        except ImportError:
+            from matplotlib.cbook import _BoundMethodProxy as BoundMethodProxy
         if self.figure is not None:
             cbs = self.figure.canvas.callbacks.callbacks
             # this may cause problems since the dict of key press events is a
@@ -126,7 +129,7 @@ class Plotter(object):
                 self._mpl_key_callbacks = {mpl_keypress_handler:
                                            cbs['key_press_event'].pop(mpl_keypress_handler)}
             except KeyError:
-                bmp = cbook.BoundMethodProxy(self.figure.canvas.manager.key_press)
+                bmp = BoundMethodProxy(self.figure.canvas.manager.key_press)
                 self._mpl_key_callbacks = {mpl_keypress_handler:
                                            bmp}
 

--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -120,9 +120,13 @@ class Plotter(object):
             cbs = self.figure.canvas.callbacks.callbacks
             # this may cause problems since the dict of key press events is a
             # dict, i.e. not ordered, and we want to pop the first one...
-            self._mpl_key_callbacks = dict([(k, cbs['key_press_event'].pop(k))
-                                            for k in
-                                            list(cbs['key_press_event'].keys())[0:1]])
+            mpl_keypress_hander = self.figure.canvas.manager.key_press_handler_id
+            try:
+                self._mpl_key_callbacks = {mpl_keypress_hander:
+                                           cbs['key_press_event'].pop(mpl_keypress_hander)}
+            except KeyError:
+                self._mpl_key_callbacks = {mpl_keypress_hander:
+                                           self.figure.canvas.manager.key_press}
 
     def _reconnect_matplotlib_keys(self):
         """
@@ -130,6 +134,9 @@ class Plotter(object):
         """
         if self.figure is not None and hasattr(self,'_mpl_key_callbacks'):
             self.figure.canvas.callbacks.callbacks['key_press_event'].update(self._mpl_key_callbacks)
+        elif self.figure is not None:
+            self.figure.canvas.callbacks.callbacks['key_press_event'].update({mpl_keypress_hander:
+                                                                              self.figure.canvas.manager.key_press})
 
     def __call__(self, figure=None, axis=None, clear=True, autorefresh=None,
                  plotscale=1.0, override_plotkwargs=False, **kwargs):

--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -116,27 +116,32 @@ class Plotter(object):
         """
         Disconnected the matplotlib key-press callbacks
         """
+        from matplotlib import cbook
         if self.figure is not None:
             cbs = self.figure.canvas.callbacks.callbacks
             # this may cause problems since the dict of key press events is a
             # dict, i.e. not ordered, and we want to pop the first one...
-            mpl_keypress_hander = self.figure.canvas.manager.key_press_handler_id
+            mpl_keypress_handler = self.figure.canvas.manager.key_press_handler_id
             try:
-                self._mpl_key_callbacks = {mpl_keypress_hander:
-                                           cbs['key_press_event'].pop(mpl_keypress_hander)}
+                self._mpl_key_callbacks = {mpl_keypress_handler:
+                                           cbs['key_press_event'].pop(mpl_keypress_handler)}
             except KeyError:
-                self._mpl_key_callbacks = {mpl_keypress_hander:
-                                           self.figure.canvas.manager.key_press}
+                bmp = cbook.BoundMethodProxy(self.figure.canvas.manager.key_press)
+                self._mpl_key_callbacks = {mpl_keypress_handler:
+                                           bmp}
 
     def _reconnect_matplotlib_keys(self):
         """
         Reconnect the previously disconnected matplotlib keys
         """
+        from matplotlib import cbook
         if self.figure is not None and hasattr(self,'_mpl_key_callbacks'):
             self.figure.canvas.callbacks.callbacks['key_press_event'].update(self._mpl_key_callbacks)
         elif self.figure is not None:
-            self.figure.canvas.callbacks.callbacks['key_press_event'].update({mpl_keypress_hander:
-                                                                              self.figure.canvas.manager.key_press})
+            mpl_keypress_handler = self.figure.canvas.manager.key_press_handler_id
+            bmp = cbook.BoundMethodProxy(self.figure.canvas.manager.key_press)
+            self.figure.canvas.callbacks.callbacks['key_press_event'].update({mpl_keypress_handler:
+                                                                              bmp})
 
     def __call__(self, figure=None, axis=None, clear=True, autorefresh=None,
                  plotscale=1.0, override_plotkwargs=False, **kwargs):


### PR DESCRIPTION
This is a weird bug that probably only affects python3 and had something to do with ordering of dictionary keys.  I've fixed it by using the appropriate components of the mpl API, I hope