### PR TITLE
problem loading fit from file

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -1146,6 +1146,7 @@ class Cube(spectrum.Spectrum):
             self.specfit.fitter = sp.specfit.fitter
         except Exception as ex:
             log.error("Fitting the pixel at location {0} failed with error: {1}".format(_temp_fit_loc, ex))
+            log.error("Try setting _temp_fit_loc to a valid pixel")
 
         self.specfit.fittype = sp.specfit.fittype
         self.specfit.parinfo = sp.specfit.parinfo

--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -1145,8 +1145,8 @@ class Cube(spectrum.Spectrum):
             sp.specfit(fittype=fittype, guesses=guesses.values)
             self.specfit.fitter = sp.specfit.fitter
         except Exception as ex:
-            log.error("Fitting the pixel at location {0} failed with error: {1}".format(_temp_fit_loc, ex))
-            log.error("Try setting _temp_fit_loc to a valid pixel")
+            log.error("Fitting the pixel at location {0} failed with error: {1}.  "
+                      "Try setting _temp_fit_loc to a valid pixel".format(_temp_fit_loc, ex)))
 
         self.specfit.fittype = sp.specfit.fittype
         self.specfit.parinfo = sp.specfit.parinfo

--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -1146,7 +1146,7 @@ class Cube(spectrum.Spectrum):
             self.specfit.fitter = sp.specfit.fitter
         except Exception as ex:
             log.error("Fitting the pixel at location {0} failed with error: {1}.  "
-                      "Try setting _temp_fit_loc to a valid pixel".format(_temp_fit_loc, ex)))
+                      "Try setting _temp_fit_loc to a valid pixel".format(_temp_fit_loc, ex))
 
         self.specfit.fittype = sp.specfit.fittype
         self.specfit.parinfo = sp.specfit.parinfo

--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -465,7 +465,6 @@ class Cube(spectrum.Spectrum):
 
         if hasattr(self,'parcube'):
             sp.specfit.modelpars = self.parcube[:,y,x]
-            sp.specfit.fitter.mpp = sp.specfit.modelpars # also for annotations (differs depending on which function... sigh... need to unify)
             if hasattr(self.specfit,'parinfo') and self.specfit.parinfo is not None:
                 # set the parinfo values correctly for annotations
                 for pi,p,e in zip(sp.specfit.parinfo, sp.specfit.modelpars, self.errcube[:,y,x]):
@@ -476,6 +475,7 @@ class Cube(spectrum.Spectrum):
                         pass
 
             if hasattr(self.specfit,'fitter') and self.specfit.fitter is not None:
+                sp.specfit.fitter.mpp = sp.specfit.modelpars # also for annotations (differs depending on which function... sigh... need to unify)
                 sp.specfit.npeaks = self.specfit.fitter.npeaks
                 sp.specfit.fitter.npeaks = len(sp.specfit.modelpars) / sp.specfit.fitter.npars
                 sp.specfit.fitter.parinfo = sp.specfit.parinfo
@@ -1141,9 +1141,12 @@ class Cube(spectrum.Spectrum):
             whereOK = np.where(OKmask)
             guesses.values = self.parcube[:,whereOK[0][0],whereOK[1][0]]
 
-        sp.specfit(fittype=fittype, guesses=guesses.values)
+        try:
+            sp.specfit(fittype=fittype, guesses=guesses.values)
+            self.specfit.fitter = sp.specfit.fitter
+        except Exception as ex:
+            log.error("Fitting the pixel at location {0} failed with error: {1}".format(_temp_fit_loc, ex))
 
-        self.specfit.fitter = sp.specfit.fitter
         self.specfit.fittype = sp.specfit.fittype
         self.specfit.parinfo = sp.specfit.parinfo
 

--- a/pyspeckit/spectrum/models/hyperfine.py
+++ b/pyspeckit/spectrum/models/hyperfine.py
@@ -350,6 +350,3 @@ class hyperfinemodel(object):
                 return spec
             else:
                 return spec/spec.max() * amp
-
-
-

--- a/pyspeckit/spectrum/models/n2dp.py
+++ b/pyspeckit/spectrum/models/n2dp.py
@@ -15,7 +15,7 @@ DOI: 10.1051/0004-6361:200810570
 
 
 """
-import hyperfine
+from . import hyperfine
 import astropy.units as u
 
 # line_names = ['J1-0', 'J2-1', 'J3-2',]

--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -174,6 +174,11 @@ class Plotter(object):
         elif self.axis is None:
             self.axis = self.figure.gca()
 
+        # A check to deal with issue #117: if you close the figure, the axis
+        # still exists, but it cannot be reattached to a figure
+        if not (self.axis.get_figure() is matplotlib.pyplot.figure(self.axis.get_figure().number)):
+            self.axis = self.figure.gca()
+
         if self.axis is not None and self.axis not in self.figure.axes:
             # if you've cleared the axis, but the figure is still open, you
             # need a new axis

--- a/pyspeckit/wrappers/fitnh3.py
+++ b/pyspeckit/wrappers/fitnh3.py
@@ -119,7 +119,7 @@ def fitnh3tkin(input_dict, dobaseline=True, baselinekwargs={}, crop=False,
     return spdict,spectra
 
 def plot_nh3(spdict,spectra,fignum=1, show_components=False, residfignum=None,
-             show_hyperfine_components=True,
+             show_hyperfine_components=True, annotate=True,
              **plotkwargs):
     """
     Plot the results from a multi-nh3 fit
@@ -171,7 +171,7 @@ def plot_nh3(spdict,spectra,fignum=1, show_components=False, residfignum=None,
         if sp.specfit.modelpars is not None:
             sp.specfit.plot_fit(annotate=False, show_components=show_components,
                                 show_hyperfine_components=show_hyperfine_components)
-    if spdict['oneone'].specfit.modelpars is not None:
+    if spdict['oneone'].specfit.modelpars is not None and annotate:
         spdict['oneone'].specfit.annotate(labelspacing=0.05,
                                           prop={'size':'small',
                                                 'stretch':'extra-condensed'},


### PR DESCRIPTION
@keflavich  @Punanova  This is a continuation to issue #117 , because it is using the same data, but we have a different issue.

We run the following script and the fit is performed, but it can not be loaded. The problem is important because we want to load the fit results afterwards, and the system breaks, but the results from the fit are OK when inspected before calling  `write_fit()`
```
import matplotlib.pyplot as plt
plt.ion()

import pyspeckit

file_in='Core2_N2Dp_21_fine5.fits'
file_gauss= 'Gaussian_fitted_parameters3.fits'
cube = pyspeckit.Cube(file_in)
F=False
T=True

cube.fiteach(fittype='gaussian',  guesses=[1.3, 6.7e3, 0.3e3], 
             verbose_level=1, signal_cut=5, limitedmax=[F,T,F], maxpars=[0,8.0e3,1.0e3],
             limitedmin=[T,T,F], minpars=[0,5.0e3,0.05e3], use_neighbor_as_guess=True, 
             start_from_point=(10,10), multicore=4)
cube.write_fit(file_gauss, clobber=True)
cube.load_model_fit(file_gauss, npars=3, npeaks=1)


```
I get the following error message
```
WARNING: The computation of the error on the integral is not obviously correct or robust... it's just a guess.
INFO: Finished fit    275 of    395 at (  13,   7) s/n=  5.8. Elapsed time is 1.9 seconds.  %70 [pyspeckit.cubes.SpectralCube]
WARNING: The computation of the error on the integral is not obviously correct or robust... it's just a guess.
INFO: Finished fit    292 of    395 at (  10,   8) s/n=  5.9. Elapsed time is 2.1 seconds.  %74 [pyspeckit.cubes.SpectralCube]
WARNING: The computation of the error on the integral is not obviously correct or robust... it's just a guess.
INFO: Finished fit    297 of    395 at (  12,   8) s/n=  5.8. Elapsed time is 2.3 seconds.  %75 [pyspeckit.cubes.SpectralCube]
INFO: Finished final fit 395.  Elapsed time was 2.5 seconds [pyspeckit.cubes.SpectralCube]
INFO: Left region selection unchanged.  xminpix, xmaxpix: 0,616 [pyspeckit.spectrum.interactive]
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-1-689c3c1fa6d0> in <module>()
----> 1 execfile('test_pyspeckit_fit.py')

/Users/jpineda/science/Anna_Taurus/test_pyspeckit_fit.py in <module>()
     23 
     24 
---> 25 cube.load_model_fit(file_gauss, npars=3, npeaks=1)

/Users/jpineda/code/pyspeckit/pyspeckit/cubes/SpectralCube.pyc in load_model_fit(self, fitsfilename, npars, npeaks, fittype, _temp_fit_loc)
   1142             guesses.values = self.parcube[:,whereOK[0][0],whereOK[1][0]]
   1143 
-> 1144         sp.specfit(fittype=fittype, guesses=guesses.values)
   1145 
   1146         self.specfit.fitter = sp.specfit.fitter

/Users/jpineda/code/pyspeckit/pyspeckit/config.pyc in decorator(self, *args, **kwargs)
    135             new_kwargs[arg] = kwargs[arg]
    136 
--> 137         f(self, *args, **new_kwargs)
    138 
    139     # documentation should be passed on, else sphinx doesn't work and the user can't access the docs

/Users/jpineda/code/pyspeckit/pyspeckit/spectrum/fitters.pyc in __call__(self, interactive, usemoments, clear_all_connections, debug, guesses, parinfo, save, annotate, show_components, use_lmfit, verbose, clear, reset_selection, fit_plotted_area, use_window_limits, vheight, exclude, **kwargs)
    308                 self.multifit(show_components=show_components, verbose=verbose,
    309                               debug=debug, use_lmfit=use_lmfit,
--> 310                               guesses=guesses, annotate=annotate, **kwargs)
    311             else:
    312                 raise ValueError("Guess and parinfo were somehow invalid.")

/Users/jpineda/code/pyspeckit/pyspeckit/spectrum/fitters.pyc in multifit(self, fittype, renormalize, annotate, show_components, verbose, color, guesses, parinfo, reset_fitspec, use_window_limits, use_lmfit, plot, **kwargs)
    581             self.setfitspec()
    582         if not self._valid:
--> 583             raise ValueError("Data are invalid; cannot be fit.")
    584         #if self.fitkwargs.has_key('negamp'): self.fitkwargs.pop('negamp') # We now do this in gaussfitter.py
    585         if fittype is not None:

ValueError: Data are invalid; cannot be fit.
```
