### PR TITLE
errors in N2H+ line are *much* larger than CLASS

### DIFF
--- a/pyspeckit/spectrum/classes.py
+++ b/pyspeckit/spectrum/classes.py
@@ -122,6 +122,18 @@ class Spectrum(object):
         >>> sp = pyspeckit.Spectrum('test.fits')
         """
         if filename:
+            if error is not None:
+                raise ValueError("When reading from a file, you cannot specify"
+                                 "the error as an array.  Instead, set it "
+                                 "separately after reading the file, e.g.: \n"
+                                 "sp = Spectrum(filename)\n"
+                                 "sp.error[:] = rms")
+            if xarr is not None:
+                raise ValueError("Cannot specify xarr when reading from a "
+                                 "file.  If the xarr in the file is incorrect,"
+                                 "change it after reading the file in, i.e., "
+                                 "set sp.xarr on another line.")
+
             if filetype is None:
                 suffix = filename.rsplit('.',1)[1]
                 if suffix in readers.suffix_types:
@@ -171,6 +183,9 @@ class Spectrum(object):
                 warn( "WARNING: No header given.  Creating an empty one." )
                 self.header = pyfits.Header()
             self.parse_header(self.header)
+        else:
+            raise ValueError("Must either give a filename or xarr and data "
+                             "keywords to instantiate a pyspeckit.Spectrum")
 
         if hasattr(self.data,'unit'):
             # TODO: use the quantity more appropriately

--- a/pyspeckit/spectrum/models/hyperfine.py
+++ b/pyspeckit/spectrum/models/hyperfine.py
@@ -6,6 +6,7 @@ Generalized hyperfine component fitter
 """
 import numpy as np
 from astropy import units as u
+from astropy import constants
 import copy
 
 from . import model
@@ -13,6 +14,7 @@ from . import fitter
 
 # should be imported in the future
 ckms = 2.99792458e5
+hoverk = (constants.h.cgs/constants.k_B.cgs).value
 
 class hyperfinemodel(object):
     """
@@ -339,7 +341,11 @@ class hyperfinemodel(object):
             # With "background" function B_nu = CMB, S_nu = absorber, and I_nu = received:
             # I_nu = B_nu * exp(-tau) + (1-exp(-tau)) * S_nu
             # This is a very good approximation for Rohlfs & Wilson eqn 15.29:
-            spec = (1.0-np.exp(-np.array(tau_nu_cumul)))*(Tex-Tbackground)
+            #spec = (1.0-np.exp(-np.array(tau_nu_cumul)))*(Tex-Tbackground)
+
+            # this is the exact version of 15.29
+            T0 = hoverk * xarr
+            spec = (1.0-np.exp(-np.array(tau_nu_cumul)))*T0*(1/(np.exp(T0/Tex-1)) - 1/(np.exp(T0/Tbackground)-1))
             
             # This is the equation of radiative transfer using the RJ definitions
             # (eqn 1.37 in Rohlfs)


### PR DESCRIPTION
We have developed a test that compares the HFS fit from `pyspeckit` and `GILDAS/CLASS`. The FITS and CLASS files and the python and CLASS scripts to perform the fits are also available here: 
https://github.com/Punanova/fit_N2Hp

For the same spectrum we get a similar fit, but a much larger uncertainty. These are the best fit spectrum using both methods
![n2hp_pyspeckit_fit](https://cloud.githubusercontent.com/assets/6529114/11478456/66df4810-978d-11e5-94a8-45dc2dbe8973.png)
![n2hp_class_fit](https://cloud.githubusercontent.com/assets/6529114/11478576/25df8fae-978e-11e5-8940-be11522856af.png)

The centroid velocities are similar (after taking into account the 7km/s offset due to some annoying non-standard FITS keyword).
```
parameter | CLASS | pyspeckit
---------- | --------------------------- | --------------------
Vlsr | 7.003 $+-$ 0.001   | 7.003 $+-$ 0.022
FWHM |   0.240 $+-$ 0.001  | 0.240 $+-$ 0.056  (FWHM=2.3548*sigma)
tau      |   7.169 $+-$ 0.077    | 7.2 $+-$ 9
```

@keflavich any ideas of why is `pyspeckit` getting such a large uncertainty? We'll keep exploring, but this seems like a well constrained issue.

@Punanova