### PR TITLE
Poor optically thin N2H+(1-0) fit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ CHANGES
 Version 0.1.19 (unreleased)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    * None yet
+    * MAJOR bugfix #125: Discovered a major issue introduced in #122 in which a
+      typo in the radiative transfer equation results in an incorrect model
 
 Version 0.1.18 (2015-12-09)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pyspeckit/spectrum/models/hyperfine.py
+++ b/pyspeckit/spectrum/models/hyperfine.py
@@ -222,8 +222,8 @@ class hyperfinemodel(object):
                 + Tbackground)
 
     def hyperfine_background(self, xarr, Tbackground=2.73, Tex=5.0, tau=0.1,
-                                xoff_v=0.0, width=1.0, return_tau=False,
-                                **kwargs):
+                             xoff_v=0.0, width=1.0, return_tau=False,
+                             **kwargs):
         """
         Identical to hyperfine, but with Tbackground free.  Assumes already
         background-subtracted

--- a/pyspeckit/spectrum/models/hyperfine.py
+++ b/pyspeckit/spectrum/models/hyperfine.py
@@ -345,7 +345,7 @@ class hyperfinemodel(object):
 
             # this is the exact version of 15.29
             T0 = hoverk * xarr
-            spec = (1.0-np.exp(-np.array(tau_nu_cumul)))*T0*(1/(np.exp(T0/Tex-1)) - 1/(np.exp(T0/Tbackground)-1))
+            spec = (1.0-np.exp(-np.array(tau_nu_cumul)))*T0*(1/(np.exp(T0/Tex)-1) - 1/(np.exp(T0/Tbackground)-1))
             
             # This is the equation of radiative transfer using the RJ definitions
             # (eqn 1.37 in Rohlfs)

--- a/pyspeckit/spectrum/models/tests/test_astropy_models.py
+++ b/pyspeckit/spectrum/models/tests/test_astropy_models.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from .. import astropy_models
 import numpy as np
 try:
@@ -13,8 +14,8 @@ def test_powerlaw(scale=5., alpha=2.):
     plm = powerlaws.PowerLaw1D(1,1,1)
     fitter = fitting.LevMarLSQFitter()
     result = fitter(plm, x, y)
-    print "Result: ",result
-    print "plm.params: ",plm
+    print("Result: ",result)
+    print("plm.params: ",plm)
     return plm
 
 if __name__ == "__main__":

--- a/pyspeckit/spectrum/models/tests/test_hyperfine.py
+++ b/pyspeckit/spectrum/models/tests/test_hyperfine.py
@@ -1,0 +1,30 @@
+from .. import hyperfine
+import numpy as np
+from astropy import units as u
+from astropy import constants
+
+def test_hyperfine():
+    # Regression test for issue 125
+
+    vtau_model = hyperfine.hyperfinemodel(['one'], {'one':0.0},
+                                          {'one':100e9},
+                                          {'one':1.0},
+                                          {'one':1.0})
+
+
+    xarr = [100]*u.GHz
+    Tex = 10.0
+    Tbackground = 2.73
+    tau = 0.1
+    result = vtau_model.hyperfine(xarr, Tex=Tex,
+                                  tau=tau, xoff_v=0.0, width=1.0,
+                                  Tbackground=Tbackground)
+
+    hoverk = (constants.h.cgs/constants.k_B.cgs).value
+    T0 = hoverk * xarr.to(u.Hz).value
+    oneminusetotheminustau = (1.0-np.exp(-np.array(tau)))
+    term1 = (np.exp(T0/Tex) - 1)**-1
+    term2 = (np.exp(T0/Tbackground) - 1)**-1
+    correctresult = oneminusetotheminustau*T0*(term1 - term2)
+
+    assert result == correctresult


### PR DESCRIPTION
Optically thin fit does not reproduce N2H+(1-0) hyperfine structure and returns too high T_ex (e+11) and sigma, two times bigger than a real value (calculated with CLASS or optically thick approach).  
The criterion we use to decide which fit results to use, optically thin or thick, is tau/delta_tau>=3. Most of N2H+(1-0) spectra will pass this criterion, however there are points on the edges of the cores where N2H+ line is not strong enough so we need optically thin approach. 
I've checked some of such points and optically thin fit does not give good result, please see the thin and thick fits of the same spectrum in the attached figures. The spectrum used to produce the figures is here https://github.com/Punanova/thick_vs_thin/blob/master/73-core2_N2Hp.fits

![n2hp_pyspeckit_poor_thin_fit](https://cloud.githubusercontent.com/assets/15927281/11690937/2b0a0538-9e99-11e5-9271-9471a9bd2e4b.png)
![n2hp_pyspeckit_poor_thick_fit](https://cloud.githubusercontent.com/assets/15927281/11690938/2b1fcb0c-9e99-11e5-99c7-dfc417589ecd.png)

. 