### PR TITLE
Bugfix: Cube.get_spectrum can provide invalid parameters

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -479,7 +479,12 @@ class Cube(spectrum.Spectrum):
                 sp.specfit.npeaks = self.specfit.fitter.npeaks
                 sp.specfit.fitter.npeaks = len(sp.specfit.modelpars) / sp.specfit.fitter.npars
                 sp.specfit.fitter.parinfo = sp.specfit.parinfo
-                sp.specfit.model = sp.specfit.fitter.n_modelfunc(sp.specfit.modelpars,**sp.specfit.fitter.modelfunc_kwargs)(sp.xarr)
+                try:
+                    sp.specfit.model = sp.specfit.fitter.n_modelfunc(sp.specfit.modelpars,
+                                                                     **sp.specfit.fitter.modelfunc_kwargs)(sp.xarr)
+                except ValueError:
+                    # possibly invalid model parameters, just skip
+                    sp.specfit.model = np.zeros_like(sp.data)
 
         return sp
 


### PR DESCRIPTION
related to https://github.com/GBTAmmoniaSurvey/GAS/issues/68