### PR TITLE
Hill5 model is broken

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -592,7 +592,7 @@ class Cube(spectrum.Spectrum):
                 verbose_level=1, quiet=True, signal_cut=3, usemomentcube=False,
                 blank_value=0, integral=True, direct=False, absorption=False,
                 use_nearest_as_guess=False, use_neighbor_as_guess=False,
-                start_from_point=(0,0), multicore=1, position_order = None,
+                start_from_point=(0,0), multicore=1, position_order=None,
                 continuum_map=None, prevalidate_guesses=False, maskmap=None,
                 **fitkwargs):
         """
@@ -691,15 +691,12 @@ class Cube(spectrum.Spectrum):
             OK &= (~bad)
 
 
-        distance = ((xx)**2 + (yy)**2)**0.5
         if start_from_point == 'center':
             start_from_point = (xx.max()/2., yy.max/2.)
         if hasattr(position_order,'shape') and position_order.shape == self.cube.shape[1:]:
             sort_distance = np.argsort(position_order.flat)
         else:
-            d_from_start = np.roll(np.roll(distance,
-                                           start_from_point[0], 0),
-                                   start_from_point[1], 1)
+            d_from_start = ((xx-start_from_point[1])**2 + (yy-start_from_point[0])**2)**0.5
             sort_distance = np.argsort(d_from_start.flat)
 
 
@@ -993,7 +990,7 @@ class Cube(spectrum.Spectrum):
 
         if verbose:
             log.info("Finished final fit %i.  "
-                     "Elapsed time was %0.1f seconds" % (ii+1, time.time()-t0))
+                     "Elapsed time was %0.1f seconds" % (len(valid_pixels), time.time()-t0))
 
 
     def momenteach(self, verbose=True, verbose_level=1, multicore=1, **kwargs):

--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -824,18 +824,22 @@ class Cube(spectrum.Spectrum):
                 try:
                     sp.specfit(guesses=gg, quiet=verbose_level<=3,
                                verbose=verbose_level>3, **fitkwargs)
+                    self.parcube[:,y,x] = sp.specfit.modelpars
+                    self.errcube[:,y,x] = sp.specfit.modelerrs
+                    success = True
                 except Exception as ex:
                     log.exception("Fit number %i at %i,%i failed on error %s" % (ii,x,y, str(ex)))
                     log.exception("Guesses were: {0}".format(str(gg)))
                     log.exception("Fitkwargs were: {0}".format(str(fitkwargs)))
+                    success = False
                     if isinstance(ex,KeyboardInterrupt):
                         raise ex
-                self.parcube[:,y,x] = sp.specfit.modelpars
-                self.errcube[:,y,x] = sp.specfit.modelerrs
-                if integral:
+
+                # keep this out of the 'try' statement
+                if integral and success:
                     self.integralmap[:,y,x] = sp.specfit.integral(direct=direct,
                                                                   return_error=True)
-                self.has_fit[y,x] = True
+                self.has_fit[y,x] = success
             else:
                 self.has_fit[y,x] = False
                 self.parcube[:,y,x] = blank_value

--- a/pyspeckit/spectrum/models/model.py
+++ b/pyspeckit/spectrum/models/model.py
@@ -663,6 +663,10 @@ class SpectralModel(fitter.SimpleFitter):
         IGNORES modelpars;
         just sums self.model
         """
+        if not hasattr(self,'model'):
+            raise ValueError("Must fit (or compute) a model before computing"
+                             " its integral.")
+
         if dx is not None:
             return (self.model*dx).sum()
         else:
@@ -755,6 +759,9 @@ class SpectralModel(fitter.SimpleFitter):
             The X coordinates of the model over which the centroid should be
             computed.  If unspecified, the centroid will be in pixel units
         """
+        if not hasattr(self, 'model'):
+            raise ValueError("Must fit (or compute) a model before measuring "
+                             "its centroid")
         if xarr is None:
             xarr = np.arange(self.model.size)
 

--- a/pyspeckit/spectrum/models/tests/test_hill5.py
+++ b/pyspeckit/spectrum/models/tests/test_hill5.py
@@ -1,0 +1,22 @@
+from .. import hill5infall
+from ...classes import Spectrum
+from ... import units
+import numpy as np
+from astropy import units as u
+
+def test_hill5():
+    x = np.linspace(-5,5,20)*u.km/u.s
+    xarr = units.SpectroscopicAxis(x, refX=5*u.GHz, velocity_convention='radio')
+    y = hill5infall.hill5_model(xarr, 0.5, 1.0, 2.0, 1.0, 1.0)
+
+    sp = Spectrum(xarr=xarr, data=y)
+
+    sp.Registry.add_fitter('hill5_fitter', hill5infall.hill5_fitter, 5)
+
+    sp.specfit(fittype='hill5_fitter', guesses=[0.4, 0.9, 2.2, 0.9, 1.1])
+
+    np.testing.assert_almost_equal(sp.specfit.parinfo[0].value, 0.5)
+    np.testing.assert_almost_equal(sp.specfit.parinfo[1].value, 1.0)
+    np.testing.assert_almost_equal(sp.specfit.parinfo[2].value, 2.0)
+    np.testing.assert_almost_equal(sp.specfit.parinfo[3].value, 1.0)
+    np.testing.assert_almost_equal(sp.specfit.parinfo[4].value, 1.0)


### PR DESCRIPTION
It looks like the Hill5 model is broken, because it might be missing some parameters: `npeaks` 
I'm using `pyspeckit` version `0.1.19.dev2152`


```python
import pyspeckit
import numpy as np
import astropy.units as u

from pyspeckit.spectrum.models import hill5infall

snr_min = 5

cube = pyspeckit.Cube(file_in)
cube.xarr.refX = freq_line
cube.xarr.velocity_convention = 'radio'
cube.xarr.convert_to_unit('km/s')

rms_map = cube.slice(6.0, 6.6, unit='km/s').cube.std(axis=0)
peaksnr =  cube.slice(vmin, vmax, unit='km/s').cube.max(axis=0)/rms_map

cube.Registry.add_fitter('hill5_model', pyspeckit.models.hill5infall.hill5_model, 5)
sz=np.shape(Vlsr)
my_guess=np.empty( (5,sz[1],sz[0]) )
my_guess[0,:,:]=1.0
my_guess[1,:,:]=7.0
my_guess[2,:,:]=0.1
my_guess[3,:,:]=0.2
my_guess[4,:,:]=1.0

print('start Hill5 model fit')
cube.fiteach(fittype='hill5_model',  guesses=my_guess, 
                 verbose_level=2, signal_cut=snr_min,
                 limitedmax=[T,T,T,T,T],
                 limitedmin=[T,T,T,F,T],
                 minpars=[  0,   0, 0.004,  0.05,  0.0],
                 maxpars=[200.0, 0, 10.,    0.00, 10.0],
                 fixed=[F,T,F,F,F],
                 position_order = 1/peaksnr,
                 errmap=rms_map)
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
/Users/jpineda/science/ALMA_L1544/v2/fit_DCOp_tap.py in <module>()
     87                  position_order = 1/peaksnr,
---> 88                  errmap=rms_map, npeaks=1)

/Users/jpineda/code/python_code/pyspeckit/pyspeckit/cubes/SpectralCube.pyc in fiteach(self, errspec, errmap, guesses, verbose, verbose_level, quiet, signal_cut, usemomentcube, blank_value, integral, direct, absorption, use_nearest_as_guess, use_neighbor_as_guess, start_from_point, multicore, position_order, continuum_map, prevalidate_guesses, maskmap, **fitkwargs)
    876         # session that's just going to crash at the end.
    877         # try a first fit for exception-catching
--> 878         try0 = fit_a_pixel((0,valid_pixels[0][0],valid_pixels[0][1]))
    879         try:
    880             assert len(try0[1]) == len(guesses) == len(self.parcube) == len(self.errcube)

/Users/jpineda/code/python_code/pyspeckit/pyspeckit/cubes/SpectralCube.pyc in fit_a_pixel(iixy)
    746         def fit_a_pixel(iixy):
    747             ii,x,y = iixy
--> 748             sp = self.get_spectrum(x,y)
    749 
    750             # very annoying - cannot use min/max without checking type

/Users/jpineda/code/python_code/pyspeckit/pyspeckit/cubes/SpectralCube.pyc in get_spectrum(self, x, y)
    477             if hasattr(self.specfit,'fitter') and self.specfit.fitter is not None:
    478                 sp.specfit.fitter.mpp = sp.specfit.modelpars # also for annotations (differs depending on which function... sigh... need to unify)
--> 479                 sp.specfit.npeaks = self.specfit.fitter.npeaks
    480                 sp.specfit.fitter.npeaks = len(sp.specfit.modelpars) / sp.specfit.fitter.npars
    481                 sp.specfit.fitter.parinfo = sp.specfit.parinfo

AttributeError: 'function' object has no attribute 'npeaks'
```