### PR TITLE
Missing formatting for a fiteach error

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -862,7 +862,7 @@ class Cube(spectrum.Spectrum):
                              (ii+1, npix, x, y, snmsg, time.time()-t0, pct))
 
             if sp.specfit.modelerrs is None:
-                log.exception("Fit number %i at %i,%i failed with no specific error.")
+                log.exception("Fit number %i at %i,%i failed with no specific error.") % (ii,x,y)
                 log.exception("Guesses were: {0}".format(str(gg)))
                 log.exception("Fitkwargs were: {0}".format(str(fitkwargs)))
                 raise TypeError("The fit never completed; something has gone wrong.")

--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -862,7 +862,7 @@ class Cube(spectrum.Spectrum):
                              (ii+1, npix, x, y, snmsg, time.time()-t0, pct))
 
             if sp.specfit.modelerrs is None:
-                log.exception("Fit number %i at %i,%i failed with no specific error.") % (ii,x,y)
+                log.exception("Fit number %i at %i,%i failed with no specific error." % (ii,x,y))
                 log.exception("Guesses were: {0}".format(str(gg)))
                 log.exception("Fitkwargs were: {0}".format(str(fitkwargs)))
                 raise TypeError("The fit never completed; something has gone wrong.")


### PR DESCRIPTION
Cube indices and fit number are missing in the string formatting for "no specific error" failure in fiteach function.