### PR TITLE
get_modelcube fix for CubeStack class

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -1353,6 +1353,7 @@ class CubeStack(Cube):
         # Special.  This needs to be modified to be more flexible; for now I need it to work for nh3
         self.plot_special = None
         self.plot_special_kwargs = {}
+        self._modelcube = None
 
         self.mapplot = mapplot.MapPlotter(self)
 


### PR DESCRIPTION
CubeStack class doesn't have CubeStack._modelcube attribute defined, but it does have get_modelcube() method. This causes CubeStack.get_modelcube() to crash. Initializing _modelcube as None in CubeStack solves the problem.