### PR TITLE
Fix dimensional reduction issue in SpectroscopicAxis

### DIFF
--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -923,7 +923,9 @@ class Specfit(interactive.Interactive):
                 or add_baseline is False):
             return self.fitter.n_modelfunc(pars,**self.fitter.modelfunc_kwargs)(xarr)
         else:
-            return self.fitter.n_modelfunc(pars,**self.fitter.modelfunc_kwargs)(xarr) + self.Spectrum.baseline.get_model(xarr)
+            return (self.fitter.n_modelfunc(pars,
+                                            **self.fitter.modelfunc_kwargs)(xarr)
+                    + self.Spectrum.baseline.get_model(np.arange(xarr.size)))
 
     def plot_model(self, pars, offset=0.0, annotate=False, clear=False, **kwargs):
         """

--- a/pyspeckit/spectrum/models/model.py
+++ b/pyspeckit/spectrum/models/model.py
@@ -961,7 +961,10 @@ class SpectralModel(fitter.SimpleFitter):
         funcdet=pymc.Deterministic(name='f',eval=modelfunc,parents=funcdict,doc="The model function")
         d['f'] = funcdet
 
-        datamodel = pymc.distributions.Normal('data',mu=funcdet,tau=1/np.asarray(error)**2,observed=True,value=np.asarray(data))
+        datamodel = pymc.distributions.Normal('data', mu=funcdet,
+                                              tau=1/np.asarray(error)**2,
+                                              observed=True,
+                                              value=np.asarray(data))
         d['data']=datamodel
 
         if return_dict:

--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -716,6 +716,7 @@ class SpectroscopicAxis(u.Quantity):
 
         if refX is not None:
             center_frequency = u.Quantity(refX, unit=refX_unit)
+            self.refX = center_frequency
         else:
             center_frequency = None
 

--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -875,7 +875,7 @@ class SpectroscopicAxis(u.Quantity):
         elif unit is None:
             subclass = self.__class__
         else:
-            unit = Unit(unit)
+            unit = u.Unit(unit)
             subclass, subok = self.__quantity_subclass__(unit)
             if subok:
                 subclass = self.__class__


### PR DESCRIPTION
`sp.xarr.min()`, for example, would previously result in another
`SpectroscopicAxis` instance, which did not evaluate usefully in boolean
comparisons (e.g., `bool(SpectroscopicAxis([False]))` might have evaluated to
`True`).  This fixes the issue by overriding `_new_array` (or something...) in
the same way as `astropy.units.Quantity`