### PR TITLE
Framework for cube tests

### DIFF
--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -47,12 +47,12 @@ def make_test_cube(shape=(30,9,9), outfile='test.fits', sigma=None, seed=0):
     keylist['SEED'  ] = seed
 
     try:
-	test_header = fits.Header(keylist)
-	assert test_header[keylist.keys()[0]] == keylist[keylist.keys()[0]]
+        test_header = fits.Header(keylist)
+        assert test_header[keylist.keys()[0]] == keylist[keylist.keys()[0]]
     except AssertionError:
-	# seems to fail on some systems
+    # seems to fail on some systems
         for key in keylist:
-	    test_header[key] = keylist[key]
+            test_header[key] = keylist[key]
     test_hdu = fits.PrimaryHDU(data=test_cube, header=test_header)
     test_hdu.writeto(outfile, clobber=True, checksum=True)
 
@@ -77,8 +77,8 @@ def test_subimage_integ_header(cubefile='test.fits'):
     """
     # getting a dummy .fits file
     if not os.path.exists(cubefile):
-	    #download_test_cube(cubefile)
-	    make_test_cube((100,9,9),cubefile)
+        #download_test_cube(cubefile)
+        make_test_cube((100,9,9),cubefile)
 
     cube = fits.getdata(cubefile)
     header = fits.getheader(cubefile)
@@ -110,7 +110,7 @@ def do_fiteach(save_cube=None, save_pars=None, show_plot=False):
         save_cube = 'test.fits'
     test_sigma = 10 # in pixel values, each pixel is CDELT3 thick
     make_test_cube((100,10,10), save_cube, 
-                   sigma=(test_sigma, 5) )
+                      sigma=(test_sigma, 5) )
     # from .. import Cube
     spc = Cube(save_cube)
     guesses = [0.5,0.2,0.8]
@@ -123,13 +123,13 @@ def do_fiteach(save_cube=None, save_pars=None, show_plot=False):
         ncores = 1
         pass
     spc.fiteach(fittype = 'gaussian',
-		guesses = guesses,
-		start_from_pixel = (5,5),
-		multicore = ncores,
-		blank_value = np.nan,
-		verbose_level = 3,
-		errmap = map_rms,
-		signal_cut = 5)
+                guesses = guesses,
+                start_from_pixel = (5,5),
+                multicore = ncores,
+                blank_value = np.nan,
+                verbose_level = 3,
+                errmap = map_rms,
+                signal_cut = 5)
     if show_plot:
         spc.mapplot()
     if save_pars:
@@ -181,7 +181,7 @@ def test_get_modelcube(cubefile=None, parfile=None, sigma_threshold=5):
         spc.load_model_fit(parfile, npars=3)
         spc.get_modelcube()
         resid_cube = spc.cube - spc._modelcube
-	above3sig = (resid_cube.std(axis=0) > map_rms*3).flatten()
+    above3sig = (resid_cube.std(axis=0) > map_rms*3).flatten()
 
-	assert map_seed == 0
-	assert above3sig[above3sig].size == 77
+    assert map_seed == 0
+    assert above3sig[above3sig].size == 77

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -71,6 +71,10 @@ def download_test_cube(outfile='test.fits'):
         shutil.move(tmp_path, outfile)
 
 def test_subimage_integ_header(cubefile='test.fits'):
+    """
+    Checks if the coordinates of the spectral
+    cube are drifting away after cropping it.
+    """
     # getting a dummy .fits file
     if not os.path.exists(cubefile):
 	    #download_test_cube(cubefile)
@@ -101,14 +105,7 @@ def test_subimage_integ_header(cubefile='test.fits'):
     np.testing.assert_almost_equal(y1,y2)
 
 def do_fiteach(save_cube=None, save_pars=None, show_plot=False):
-    """
-    A draft version for running a simple test
-    on fiteach(). For now only the line widths
-    of gaussian fits are being checked.
-
-    Generates a fits file and checks that the
-    fitted line width is within expected values.
-    """
+    """Fits a cube with a gaussian for later use"""
     if save_cube is None:
         save_cube = 'test.fits'
     test_sigma = 10 # in pixel values, each pixel is CDELT3 thick
@@ -141,12 +138,10 @@ def do_fiteach(save_cube=None, save_pars=None, show_plot=False):
 
 def test_fiteach(save_cube=None, save_pars=None, show_plot=False):
     """
-    A draft version for runing a simple test
-    on fiteach(). For now only the line widths
-    of gaussian fits are being checked.
-
-    Generates a fits file and checks that the
-    fitted line width is within expected values.
+    A simple test on Cube.fiteach() checking
+    that for a noise with set seed the fraction
+    of line width values within errorbars is
+    remaning constant.
     """
     spc = do_fiteach(save_cube, save_pars, show_plot)
 
@@ -164,7 +159,11 @@ def test_get_modelcube(cubefile=None, parfile=None, sigma_threshold=5):
     """
     Tests get_modelcube() method for Cube and CubeStack classes.
     If either cubefile or parfile isn't set, fill generate and
-    fit a sample cube through do_fiteach()
+    fit a sample cube through do_fiteach().
+
+    Computes the residual cube and collapses it into standard
+    deviation of the residual map. Checks that the number of the
+    residual pixels three sigma doesn't change for a fixed noise.
     """
     if cubefile is None or parfile is None:
         cubefile = 'test.fits'
@@ -182,5 +181,5 @@ def test_get_modelcube(cubefile=None, parfile=None, sigma_threshold=5):
         resid_cube = spc.cube - spc._modelcube
         # TODO: need to come up with something smarter
         # for verifying that residuals are acceptable
-        #assert np.allclose(spc.cube.std(axis=0), spc._modelcube.std(axis=0),
-        #        equal_nan=True, atol=spc.header['RMSLVL']*sigma_theshold)
+        assert np.allclose(spc.cube.std(axis=0), spc._modelcube.std(axis=0),
+                equal_nan=True, atol=spc.header['RMSLVL']*sigma_theshold)

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -1,31 +1,181 @@
-from .. import cubes
+from .. import cubes, Cube, CubeStack
 
 from astropy.io import fits
 
 import os
 
-def test_subimage_integ_header():
-    # getting a dummy .fits file
-    if not os.path.exists('foo.fits'):
-        from astropy.utils.data import download_file
-        tmp_path = download_file('https://db.tt/oleS9xD6')
-        try:
-            os.rename(tmp_path, 'foo.fits')
-        except OSError:
-            # os.rename doesn't like cross-device links
-            import shutil
-            shutil.move(tmp_path, 'foo.fits')
+def make_test_cube(shape=(30,9,9), outfile='test.fits', sigma=None):
+    """
+    Generates a simple gaussian cube with noise of
+    given shape and writes it as a fits file.
+    """
+    from astropy.convolution import Gaussian1DKernel, Gaussian2DKernel
+    if sigma is None:
+        sigma1d, sigma2d = shape[0]/10., np.mean(shape[1:])/5.
+    else:
+        sigma1d, sigma2d = sigma
 
-    cube = fits.getdata('foo.fits')
-    header = fits.getheader('foo.fits')
+    gauss1d = Gaussian1DKernel(stddev=sigma1d, x_size=shape[0])
+    gauss2d = Gaussian2DKernel(stddev=sigma2d, x_size=shape[1], 
+                                               y_size=shape[2])
+    test_cube = gauss1d.array[:,None,None] * gauss2d.array
+    test_cube=test_cube/test_cube.max()
+    # adding noise:
+    noise_cube = (np.random.random(test_cube.shape)-.5)* \
+                        np.median(test_cube.std(axis=0))
+    test_cube += noise_cube
+    true_rms = noise_cube.std()
+    
+    # making a simple header for the test cube:
+    test_hdu = fits.PrimaryHDU(test_cube)
+    # the strange cdelt values are a workaround 
+    # for what seems to be a bug in wcslib:
+    # https://github.com/astropy/astropy/issues/4555
+    cdelt1, cdelt2, cdelt3 = -(4e-3+1e-8), 4e-3+1e-8, -0.1
+    keylist = {'CTYPE1': 'RA---GLS', 'CTYPE2': 'DEC--GLS', 'CTYPE3': 'VRAD',
+               'CDELT1': cdelt1, 'CDELT2': cdelt2, 'CDELT3': cdelt3,
+               'CRVAL1': 0, 'CRVAL2': 0, 'CRVAL3': 5, 
+               'CRPIX1': 9, 'CRPIX2': 0, 'CRPIX3': 5,
+               'CUNIT1': 'deg', 'CUNIT2': 'deg', 'CUNIT3': 'km s-1',
+               'BUNIT' : 'K', 'EQUINOX': 2000.0}
+    for key in keylist:
+        test_hdu.header[key] = keylist[key]
+
+    # write out some values used to generate the cube:
+    test_hdu.header['SIGMA'] = abs(sigma1d*cdelt3), 'in units of CUNIT3'
+    test_hdu.header['RMSLVL'] = true_rms
+
+    test_hdu.writeto(outfile, clobber=True, checksum=True)
+
+def download_test_cube(outfile='test.fits'):
+    """
+    Downloads a sample fits file from Dropbox (325kB).
+    """
+    from astropy.utils.data import download_file
+    test_cube_url = 'https://db.tt/i0jWA7DU'
+    tmp_path = download_file(test_cube_url)
+    try:
+        os.rename(tmp_path, outfile)
+    except OSError:
+        # os.rename doesn't like cross-device links
+        import shutil
+        shutil.move(tmp_path, outfile)
+
+def test_subimage_integ_header(cubefile='test.fits'):
+    # getting a dummy .fits file
+    if not os.path.exists(cubefile):
+	    #download_test_cube(cubefile)
+	    make_test_cube((100,9,9),cubefile)
+
+    cube = fits.getdata(cubefile)
+    header = fits.getheader(cubefile)
 
     xcen, ycen = 4.5, 4.5
     xwidth, ywidth = 2.5, 2.5
 
     # saving results from subimage_integ:
     cutData, cutHead = cubes.subimage_integ(cube, xcen, xwidth, ycen, ywidth,
-                                            vrange=(0,9), zunits='pixels',
-                                            units='pixels', header=header)
+                                            vrange=(0,header['NAXIS3'-1]), 
+                                            zunits='pixels', units='pixels', 
+                                            header=header)
 
-    assert cutHead['CRPIX1'] == 3.0
-    assert cutHead['CRPIX2'] == -6.0
+    assert cutHead['CRPIX1'] == 7.0
+    assert cutHead['CRPIX2'] == -2.0
+
+def do_fiteach(save_cube=None, save_pars=None, show_plot=False):
+    """
+    A draft version for runing a simple test
+    on fiteach(). For now only the line widths
+    of gaussian fits are being checked.
+
+    Generates a fits file and checks that the
+    fitted line width is within expected values.
+    """
+    if save_cube is None:
+        save_cube = 'test.fits'
+    test_sigma = 10 # in pixel values, each pixel is CDELT3 thick
+    make_test_cube((100,10,10), save_cube, 
+                   sigma=(test_sigma, 5) )
+    # from .. import Cube
+    spc = Cube(save_cube)
+    guesses = [0.5,0.2,0.8]
+    map_rms = np.zeros_like(spc.cube[0])+spc.header['RMSLVL']
+    map_snr = spc.cube.std(axis=0)/map_rms
+    try:
+        import multiprocessing
+        ncores = multiprocessing.cpu_count()
+    except ImportError:
+        ncores = 1
+        pass
+    spc.fiteach(fittype = 'gaussian',
+	        guesses = guesses,
+	        start_from_pixel = (5,5),
+	    	multicore = ncores,
+                blank_value = np.nan,
+	    	verbose_level = 3,
+                errmap = map_rms,
+                signal_cut = 5)
+    if show_plot:
+        spc.mapplot()
+    if save_pars:
+        spc.write_fit(save_pars, clobber=True)
+    return spc
+
+def test_fiteach(save_cube=None, save_pars=None, show_plot=False):
+    """
+    A draft version for runing a simple test
+    on fiteach(). For now only the line widths
+    of gaussian fits are being checked.
+
+    Generates a fits file and checks that the
+    fitted line width is within expected values.
+    """
+    spc = do_fiteach(save_cube, save_pars, show_plot)
+
+    # checking the fit
+    map_sigma_post = spc.parcube[2]
+    map_sigma_true = np.zeros_like(map_sigma_post) + spc.header['SIGMA']
+    map_in_bounds = np.abs(map_sigma_true-map_sigma_post) < spc.errcube[2]
+    err_frac = map_in_bounds[~map_in_bounds].size / float(map_sigma_post.size)
+    # TODO: this is not an ideal aproach - should probably do proper statistics
+    #       on the expected value of median sigma value and check that it lies
+    #       within something like 99.7% of the expected sigma's PDF
+    # make sure the fraction of the fits that don't 
+    # include the true value is within tolerance
+    # TODO: rewrite - the condition is too strict!
+    # if 1-.68 is a peak of the expected value for
+    # the error fraction then this will fail half
+    # of the time. Letting it pass for now.
+    try:
+        assert err_frac < 1-.68, "the fraction of true values outside "+\
+                                 "the confidence intervals is too high "+\
+                                 "({}%)".format(err_frac*100)
+    except AssertionError:
+        pass
+
+def test_get_modelcube(cubefile=None, parfile=None, sigma_threshold=5):
+    """
+    Tests get_modelcube() method for Cube and CubeStack classes.
+    If either cubefile or parfile isn't set, fill generate and
+    fit a sample cube through do_fiteach()
+    """
+    if cubefile is None or parfile is None:
+        cubefile = 'test.fits'
+        parfile  = 'test_pars.fits'
+        sp_cube = do_fiteach(save_cube=cubefile, save_pars=parfile)
+    else:
+        sp_cube  = Cube(cubefile)
+    sp_cube.xarr.velocity_convention = 'radio'
+    sp_stack = CubeStack([sp_cube])
+    sp_stack._modelcube = None
+    # assuming one gaussian component
+    for spc in [sp_cube, sp_stack]:
+        spc.load_model_fit(parfile, npars=3)
+        spc.get_modelcube()
+        resid_cube = spc.cube - spc._modelcube
+        # TODO: need to come up with something smarter
+        # for verifying that residuals are acceptable
+        #assert np.allclose(spc.cube.std(axis=0), spc._modelcube.std(axis=0),
+        #        equal_nan=True, atol=spc.header['RMSLVL']*sigma_theshold)
+
+    assert np.allclose(sp_cube._modelcube,sp_stack._modelcube,equal_nan=True)

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -171,6 +171,8 @@ def test_get_modelcube(cubefile=None, parfile=None, sigma_threshold=5):
         sp_cube = do_fiteach(save_cube=cubefile, save_pars=parfile)
     else:
         sp_cube  = Cube(cubefile)
+    map_seed = sp_cube.header['SEED']
+    map_rms = sp_cube.header['RMSLVL']
     sp_cube.xarr.velocity_convention = 'radio'
     sp_stack = CubeStack([sp_cube])
     sp_stack._modelcube = None
@@ -179,7 +181,7 @@ def test_get_modelcube(cubefile=None, parfile=None, sigma_threshold=5):
         spc.load_model_fit(parfile, npars=3)
         spc.get_modelcube()
         resid_cube = spc.cube - spc._modelcube
-        # TODO: need to come up with something smarter
-        # for verifying that residuals are acceptable
-        assert np.allclose(spc.cube.std(axis=0), spc._modelcube.std(axis=0),
-                equal_nan=True, atol=spc.header['RMSLVL']*sigma_theshold)
+	above3sig = (resid_cube.std(axis=0) > map_rms*3).flatten()
+
+	assert map_seed == 0
+	assert above3sig[above3sig].size == 77

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -46,7 +46,14 @@ def make_test_cube(shape=(30,9,9), outfile='test.fits', sigma=None, seed=0):
     keylist['RMSLVL'] = true_rms
     keylist['SEED'  ] = seed
 
-    test_hdu = fits.PrimaryHDU(data=test_cube, header=fits.Header(keylist))
+    try:
+	test_header = fits.Header(keylist)
+	assert test_header[keylist.keys()[0]] == keylist[keylist.keys()[0]]
+    except AssertionError:
+	# seems to fail on some systems
+        for key in keylist:
+	    test_header[key] = keylist[key]
+    test_hdu = fits.PrimaryHDU(data=test_cube, header=test_header)
     test_hdu.writeto(outfile, clobber=True, checksum=True)
 
 def download_test_cube(outfile='test.fits'):
@@ -119,13 +126,13 @@ def do_fiteach(save_cube=None, save_pars=None, show_plot=False):
         ncores = 1
         pass
     spc.fiteach(fittype = 'gaussian',
-	        guesses = guesses,
-	        start_from_pixel = (5,5),
-	    	multicore = ncores,
-                blank_value = np.nan,
-	    	verbose_level = 3,
-                errmap = map_rms,
-                signal_cut = 5)
+		guesses = guesses,
+		start_from_pixel = (5,5),
+		multicore = ncores,
+		blank_value = np.nan,
+		verbose_level = 3,
+		errmap = map_rms,
+		signal_cut = 5)
     if show_plot:
         spc.mapplot()
     if save_pars:

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -41,14 +41,12 @@ def make_test_cube(shape=(30,9,9), outfile='test.fits', sigma=None, seed=0):
                'CRPIX1': 9, 'CRPIX2': 0, 'CRPIX3': 5,
                'CUNIT1': 'deg', 'CUNIT2': 'deg', 'CUNIT3': 'km s-1',
                'BUNIT' : 'K', 'EQUINOX': 2000.0}
-    for key in keylist:
-        test_hdu.header[key] = keylist[key]
-
     # write out some values used to generate the cube:
-    test_hdu.header['SIGMA'] = abs(sigma1d*cdelt3), 'in units of CUNIT3'
-    test_hdu.header['RMSLVL'] = true_rms
-    test_hdu.header['SEED'] = seed
+    keylist['SIGMA' ] = abs(sigma1d*cdelt3), 'in units of CUNIT3'
+    keylist['RMSLVL'] = true_rms
+    keylist['SEED'  ] = seed
 
+    test_hdu = fits.PrimaryHDU(data=test_cube, header=fits.Header(keylist))
     test_hdu.writeto(outfile, clobber=True, checksum=True)
 
 def download_test_cube(outfile='test.fits'):

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -151,25 +151,14 @@ def test_fiteach(save_cube=None, save_pars=None, show_plot=False):
     spc = do_fiteach(save_cube, save_pars, show_plot)
 
     # checking the fit
+    map_seed = spc.header['SEED']
     map_sigma_post = spc.parcube[2]
     map_sigma_true = np.zeros_like(map_sigma_post) + spc.header['SIGMA']
     map_in_bounds = np.abs(map_sigma_true-map_sigma_post) < spc.errcube[2]
     err_frac = map_in_bounds[~map_in_bounds].size / float(map_sigma_post.size)
-    # TODO: this is not an ideal aproach - should probably do proper statistics
-    #       on the expected value of median sigma value and check that it lies
-    #       within something like 99.7% of the expected sigma's PDF
-    # make sure the fraction of the fits that don't 
-    # include the true value is within tolerance
-    # TODO: rewrite - the condition is too strict!
-    # if 1-.68 is a peak of the expected value for
-    # the error fraction then this will fail half
-    # of the time. Letting it pass for now.
-    try:
-        assert err_frac < 1-.68, "the fraction of true values outside "+\
-                                 "the confidence intervals is too high "+\
-                                 "({}%)".format(err_frac*100)
-    except AssertionError:
-        pass
+
+    assert map_seed == 0
+    assert err_frac == 0.39
 
 def test_get_modelcube(cubefile=None, parfile=None, sigma_threshold=5):
     """

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -48,9 +48,9 @@ def make_test_cube(shape=(30,9,9), outfile='test.fits', sigma=None, seed=0):
 
     try:
         test_header = fits.Header(keylist)
-        assert test_header[keylist.keys()[0]] == keylist[keylist.keys()[0]]
+        assert test_header[list(keylist)[0]] == keylist[list(keylist)[0]]
     except AssertionError:
-    # seems to fail on some systems
+        # generates an empty header on some systems (TODO: why?)
         for key in keylist:
             test_header[key] = keylist[key]
     test_hdu = fits.PrimaryHDU(data=test_cube, header=test_header)


### PR DESCRIPTION
1. Added a function for generating test cubes. The cubes generated are basically Gaussian ellipsoids in ppv-space with some noise on top.
2. Added two preliminary tests, one that fits a gaussian to a cube and compares its parcube to original line widths; and another that makes sure that there isn't anything wrong with get_modelcube function (c.f. https://github.com/pyspeckit/pyspeckit/pull/131). Both still need some improvements in terms of passing criteria.

