### PR TITLE
Memory leak in specfit?

### DIFF
--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -1024,17 +1024,17 @@ class Specfit(interactive.Interactive):
             self._full_model()
             model = self.fullmodel
 
-        self.modelplot += self.Spectrum.plotter.axis.plot(
-                xarr,
-                model + plot_offset,
-                color=composite_fit_color, linewidth=lw,
-                **plotkwargs)
+        self.modelplot += self.Spectrum.plotter.axis.plot(xarr,
+                                                          model + plot_offset,
+                                                          color=composite_fit_color,
+                                                          linewidth=lw,
+                                                          **plotkwargs)
         
         # Plot components
         if show_components or show_hyperfine_components:
             self.plot_components(xarr=xarr,
-                    show_hyperfine_components=show_hyperfine_components,
-                    pars=pars, plotkwargs=plotkwargs)
+                                 show_hyperfine_components=show_hyperfine_components,
+                                 pars=pars, plotkwargs=plotkwargs)
 
         uwl = use_window_limits if use_window_limits is not None else self.use_window_limits
         # plotter kwargs are kwargs for the Spectrum.plotter,
@@ -1283,9 +1283,15 @@ class Specfit(interactive.Interactive):
         if self.Spectrum.plotter.axis is not None:
             for p in self.modelplot:
                 p.set_visible(False)
-            if legend: self._clearlegend()
-            if components: self._clearcomponents()
-            if self.Spectrum.plotter.autorefresh: self.Spectrum.plotter.refresh()
+            if legend:
+                self._clearlegend()
+            if components:
+                self._clearcomponents()
+            if self.Spectrum.plotter.autorefresh:
+                self.Spectrum.plotter.refresh()
+
+        # Empty the modelplot array to free memory
+        self.modelplot = []
     
         # remove residuals from self if they're there.
         if hasattr(self,'residualplot'):
@@ -1298,7 +1304,11 @@ class Specfit(interactive.Interactive):
             pc.set_visible(False)
             if pc in self.Spectrum.plotter.axis.lines:
                 self.Spectrum.plotter.axis.lines.remove(pc)
-        if self.Spectrum.plotter.autorefresh: self.Spectrum.plotter.refresh()
+        if self.Spectrum.plotter.autorefresh:
+            self.Spectrum.plotter.refresh()
+
+        # Empty the plotted components array to free memory
+        self._plotted_components = []
 
     def _clearlegend(self):
         """

--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -205,6 +205,9 @@ class Plotter(object):
 
         if clear and self.axis is not None:
             self.axis.clear()
+            # Need to empty the stored model plots
+            if hasattr(self.Spectrum, 'fitter'):
+                self.Spectrum.fitter.clear()
 
         if autorefresh is not None:
             self.autorefresh = autorefresh


### PR DESCRIPTION
(I apologize for the long post in advance...)
I have a module which measures absorption lines in optical spectra using pyspeckit, and I'm seeing a pretty substantial memory leak. I think it's not in my code, but I was hoping that the "hive mind" could help...

Here's the (pseudo-) code I use. The example spectra was a 1.5MB .fits file:

```python
#Loading the spectrum:
if (certain instruments):
    apertureList = [pyspeckit.Spectrum(spectrumFilename)]
else: # (other instruments)
    apertureList = pyspeckit.wrappers.load_IRAF_multispec(spectraFilename)

# Smooth all the apertures
for roughSpec in specList:
    roughSpec.smooth(smooth=2,downsample=False)

# Set up pyplot
pylab.ion()    # Put matplotlib into interactive mode
plotFigure = pyplot.figure(num='Line Analysis')

# Loop through, and measure all my atomic lines
for (line info) in (long (~1300) list of atomic lines):
    smoothSpec = apertureList[(aperture containing this line)]
    smoothSpec.plotter((aperture W.L. and Flux limits), figure=plotFigure) # Plot for debugging
    spline = FitSplineBaseline((aperture W.L. limits), smoothSpec)
    # Note: The ability to pass a pre-fitted continuum (baseline) to pyspeckit
    #           is something I have in my local sources, but doesn't affect memory 
    #           usage...I think...

    lineGuesses = MakeLineGuesses((aperture W.L. limits), smoothSpec)
    # My line guesses are based on local minima/maxima, and my knowledge
    # of stellar conditions (rotational velocity, etc.)
    # Example memory usage at this point:
    #                        for loop pass #1: 147668k
    #                        for loop pass #2: 230668k
    #                        for loop pass #3: 316272k
    smoothSpec.baseline(subtract=False, order=0, prefit_continuum = spline)
    # Memory usage at this point:
    #                        for loop pass #1: 157152k
    #                        for loop pass #2: 245346k
    #                        for loop pass #3: 326052k
    smoothSpec.specfit(fittype='gaussian', guesses=lineGuesses, quiet=True, save=False, show_components=True, use_window_limits=True, vheight=True, clear=True, reset_selection = True, exclude=[(aperture sub-range WL limits)])
    lineResults = smoothSpec.specfit.modelpars[:]
    # Memory usage at this point:
    #                        for loop pass #1: 228072k
    #                        for loop pass #2: 313656k
    #                        for loop pass #3: 372388k
```

Since I am doing multiple fits, I'm guessing that the leak is due to my multiple calls to fit both baselines and (line) fits. Is there a way I can force pyspeckit to clean up the unused (old) fits?

Any other thoughts?

(edit: had to change comment and editorial delineators)
edit 2:Finally got the pseudo-code to format well -- Sorry!