### PR TITLE
use_nearest_as_guess breaks fiteach()

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -699,7 +699,8 @@ class Cube(spectrum.Spectrum):
             d_from_start = ((xx-start_from_point[1])**2 + (yy-start_from_point[0])**2)**0.5
             sort_distance = np.argsort(d_from_start.flat)
 
-
+        if use_neighbor_as_guess:
+            distance = ((xx)**2 + (yy)**2)**0.5
 
         valid_pixels = list(zip(xx.flat[sort_distance][OK.flat[sort_distance]],
                                 yy.flat[sort_distance][OK.flat[sort_distance]]))
@@ -793,9 +794,9 @@ class Cube(spectrum.Spectrum):
             if use_nearest_as_guess and self.has_fit.sum() > 0:
                 if verbose_level > 1 and ii == 0 or verbose_level > 4:
                     log.info("Using nearest fit as guess")
-                d = np.roll(np.roll(distance, x, 0), y, 1)
+                rolled_distance = np.roll(np.roll(distance, x, 0), y, 1)
                 # If there's no fit, set its distance to be unreasonably large
-                nearest_ind = np.argmin(d+1e10*(~self.has_fit))
+                nearest_ind = np.argmin(rolled_distance+1e10*(~self.has_fit))
                 nearest_x, nearest_y = xx.flat[nearest_ind],yy.flat[nearest_ind]
                 gg = self.parcube[:,nearest_y,nearest_x]
             elif use_neighbor_as_guess and np.any(local_fits):


### PR DESCRIPTION
The title is self-explanatory: setting `use_nearest_as_guess=True` causes a `NameError` when making a call to `fiteach()`. From looking at the source file this looks like a bug - the `distance` variable - on which `use_nearest_as_guess` depends - isn't defined anywhere since de9c0c1b6252e3c2571b45b9b7a22013b2a50baf was pushed. Not sure what should be done with it, so raising it as an issue.