### PR TITLE
SpectroscopicAxis: best way for unit to pixel mapping?

### DIFF
--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -585,21 +585,24 @@ class SpectroscopicAxis(u.Quantity):
         else: 
             return self.min()
 
-    def x_to_pix(self, xval, xval_units=None):
+    def x_to_pix(self, xval, xval_units=None, equivalencies=None):
         """
         Given an X coordinate in SpectroscopicAxis' units, return the corresponding pixel number
         """
         if xval_units in pixel_dict:
             return xval
         else:
-            try:
-                if not xval_units:
-                    xval_units = xval.unit
-            except AttributeError:
-                xval_units = u.dimensionless_unscaled
-            xval = xval * u.Unit(xval_units)            
-            nearest_pix = np.argmin(np.abs(self.value-xval.value))
-            # nearest_pix = np.argmin(np.abs(self.value-xval))
+            if xval_units:
+                xval = xval * u.Unit(xval_units)
+            elif type(xval) is not u.Quantity:
+                xval_units = self.unit
+                xval = xval * u.Unit(xval_units)
+
+            if equivalencies is None:
+                equivalencies = self.equivalencies
+
+            nearest_pix = np.argmin(np.abs(self-xval.to(self.unit, equivalencies)))
+
             return nearest_pix
 
     def in_range(self, xval):

--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -592,11 +592,8 @@ class SpectroscopicAxis(u.Quantity):
         if xval_units in pixel_dict:
             return xval
         else:
-            if xval_units:
-                xval = xval * u.Unit(xval_units)
-            elif type(xval) is not u.Quantity:
-                xval_units = self.unit
-                xval = xval * u.Unit(xval_units)
+            if not hasattr(xval, 'unit'):
+                xval = u.Quantity(xval, xval_units or self.unit)
 
             if equivalencies is None:
                 equivalencies = self.equivalencies

--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -331,10 +331,11 @@ class SpectroscopicAxis(u.Quantity):
             log.debug("Created subarr from a non-ndarray {0}".format(type(xarr)))
         else:
             if not xarr.flags['OWNDATA']:
-                log.warning("The X array does not 'own' its data."
-                            "  It will therefore be copied.")
-                warnings.warn("The X array does not 'own' its data."
-                              "  It will therefore be copied.")
+                # nothing owns its data.  We nearly always have to copy this. =(
+                #log.warning("The X array does not 'own' its data."
+                #            "  It will therefore be copied.")
+                #warnings.warn("The X array does not 'own' its data."
+                #              "  It will therefore be copied.")
                 subarr = xarr.copy()
             else:
                 log.debug("xarr owns its own data.  Continuing as normal.")


### PR DESCRIPTION
Is there a way, given a quantity valid as a `SpectroscopicAxis` coordinate, to convert it into a nearest pixel value? Can't seem to find a way to do this without converting the whole axis to that unit.

So, given this example set-up,
```python
import pyspeckit
import astropy.units as u
from pyspeckit.cubes.tests import test_cubetools
test_cubetools.make_test_cube()
spc = pyspeckit.Cube('test.fits')

spc.xarr.velocity_convention = 'radio'
spc.xarr.refX = 100 * u.GHz
```
what I'm looking for is this:
```python
spc.xarr.x_to_pix(2) # for 2 km/s
```
but for units other than `spc.xarr.unit`

Currently this works:
```python
spc.xarr.convert_to_unit('GHz')
spc.xarr.x_to_pix(99.9986)
```
but I feel that it's an overkill.