### PR TITLE
Allow quantities when .slice'ing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
         - NUMPY_VERSION=1.10
         - ASTROPY_VERSION=stable
         - CONDA_DEPENDENCIES='matplotlib=1.4 scipy'
-        - PIP_DEPENDENCIES='spectral-cube lmfit lineid-plot'
+        - PIP_DEPENDENCIES='spectral-cube lmfit lineid-plot specutils'
 
     matrix:
         # Make sure that egg_info works without dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,4 +87,4 @@ script:
    # some extras for future use
    # right now, run_tests is required
    # but py.test works, kinda
-   - py.test -x pyspeckit/spectrum/tests/test_units.py
+   - if [ $SETUP_CMD == 'test' ]; then py.test -x pyspeckit/spectrum/tests/test_units.py; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,4 +84,7 @@ install:
 
 script:
    - python setup.py $SETUP_CMD
-
+   # some extras for future use
+   # right now, run_tests is required
+   # but py.test works, kinda
+   - py.test -x pyspeckit/spectrum/tests/test_units.py

--- a/pyspeckit/spectrum/classes.py
+++ b/pyspeckit/spectrum/classes.py
@@ -749,7 +749,7 @@ class BaseSpectrum(object):
             elif hasattr(self,'xarr') and hasattr(other,'xarr'): # purely for readability
 
                 if self._arithmetic_threshold == 'exact':
-                    xarrcheck = np.all((self.xarr == other.xarr).value)
+                    xarrcheck = np.all((self.xarr == other.xarr))
                 else:
                     if self._arithmetic_threshold_units is None:
                         # not sure this should ever be allowed
@@ -939,7 +939,7 @@ class Spectra(BaseSpectrum):
 
         if other.xarr.unit != self.xarr.unit:
             # convert all inputs to same unit
-            other.xarr.convert_to_units(self.xarr.unit,**kwargs)
+            other.xarr.convert_to_units(self.xarr.unit)
         self.xarr = units.SpectroscopicAxes([self.xarr,other.xarr])
         self.data = np.concatenate([self.data,other.data])
         self.error = np.concatenate([self.error,other.error])

--- a/pyspeckit/spectrum/classes.py
+++ b/pyspeckit/spectrum/classes.py
@@ -456,9 +456,9 @@ class BaseSpectrum(object):
 
         Parameters
         ----------
-        start : numpy.float or int
+        start : numpy.float or int or astropy quantity
             start of slice
-        stop :  numpy.float or int
+        stop :  numpy.float or int or astropy quantity
             stop of slice
         unit : str
             allowed values are any supported physical unit, 'pixel'
@@ -468,15 +468,23 @@ class BaseSpectrum(object):
             Save the fitted parameters from self.fitter?
         """
 
-        if unit in ('pixel','pixels'):
+        if hasattr(start, 'unit'):
+            start_ind = self.xarr.x_to_pix(start)
+        elif unit in ('pixel','pixels'):
             start_ind = start
-            stop_ind  = stop
         else:
-            x_in_units = self.xarr.as_unit(unit)
-            start_ind = x_in_units.x_to_pix(start)
-            stop_ind  = x_in_units.x_to_pix(stop)
+            start_ind = self.xarr.x_to_pix(start, xval_units=unit)
+
+        if hasattr(stop, 'unit'):
+            stop_ind = self.xarr.x_to_pix(stop)
+        elif unit in ('pixel','pixels'):
+            stop_ind = stop
+        else:
+            stop_ind = self.xarr.x_to_pix(stop, xval_units=unit)
+
         if start_ind > stop_ind:
             start_ind,stop_ind = stop_ind,start_ind
+
         spectrum_slice = slice(start_ind,stop_ind)
 
         log.debug("Slicing from {start} to {stop} with unit {unit} and copy="

--- a/pyspeckit/spectrum/classes.py
+++ b/pyspeckit/spectrum/classes.py
@@ -826,7 +826,7 @@ class SingleSpectrum(BaseSpectrum):
         error = spec1d.uncertainty
 
         return cls(data=data, error=error, xarr=xarr,
-                   unit=spec1d._unit)
+                   unit=spec1d._unit, header=pyfits.Header())
 
 
     @classmethod

--- a/pyspeckit/spectrum/readers/tests/test_specutils_reading.py
+++ b/pyspeckit/spectrum/readers/tests/test_specutils_reading.py
@@ -36,6 +36,15 @@ def test_specutils_aao_reader_multiple():
     assert sp.xarr.unit.to_string() == 'Angstrom'
     assert all(sp.error==0)
 
+@pytest.mark.skipif("not SPECUTILS_OK")
+def test_specutils_aao_reader_dontallowmismatchdiffs():
+
+    filename = os.path.join(specutils.io.tests.__path__[0],
+                            'files/AAO.fits')
+
+    sp1d = specutils.io.read_fits.read_fits_spectrum1d(filename)
+    sp = Spectra.from_spectrum1d_list(sp1d)
+
     # TODO: make this an independent test
     # this is testing that you can't do arithmetic on axes that are different
     with pytest.raises(ValueError) as ex:

--- a/pyspeckit/spectrum/readers/tests/test_specutils_reading.py
+++ b/pyspeckit/spectrum/readers/tests/test_specutils_reading.py
@@ -10,7 +10,7 @@ import os
 
 from ... import Spectrum, Spectra
 
-@pytest.mark.skipif(not SPECUTILS_OK)
+@pytest.mark.skipif("not SPECUTILS_OK")
 def test_specutils_aao_reader_single():
 
     filename = os.path.join(specutils.io.tests.__path__[0],
@@ -23,7 +23,7 @@ def test_specutils_aao_reader_single():
     assert sp.xarr.unit.to_string() == 'Angstrom'
     assert all(sp.error==0)
 
-@pytest.mark.skipif(not SPECUTILS_OK)
+@pytest.mark.skipif("not SPECUTILS_OK")
 def test_specutils_aao_reader_multiple():
 
     filename = os.path.join(specutils.io.tests.__path__[0],

--- a/pyspeckit/spectrum/tests/test_units.py
+++ b/pyspeckit/spectrum/tests/test_units.py
@@ -6,6 +6,9 @@ import pytest
 from astropy import units as u
 
 convention = ['optical','radio','relativistic']
+convention_map = {'optical': u.doppler_optical,
+                  'radio': u.doppler_radio,
+                  'relativistic': u.doppler_relativistic}
 
 # these are used to populate a matrix for unit conversion tests
 # being complete is expensive, ~1+ minutes
@@ -54,30 +57,53 @@ params = [(a,b,c,d) for a in unit_type_dict if a not in ('unknown',None)
 
 class TestUnits(object):
 
-    def __init__(self):
-        self.x = units.SpectroscopicAxis(np.arange(5), unit=u.angstrom, velocity_convention='optical', equivalencies=u.doppler_optical(3*u.AA))
-        self.length = units.SpectroscopicAxis(np.arange(5), unit=u.nm)
-        self.frequency = units.SpectroscopicAxis(np.arange(5), unit=u.GHz)
-        self.speed = units.SpectroscopicAxis(np.arange(5), unit=u.km/u.s)
-
+    @classmethod
+    def setup_class(cls):
+        cls.x = units.SpectroscopicAxis(np.arange(5), unit=u.angstrom, velocity_convention='optical', equivalencies=u.doppler_optical(3*u.AA))
+        cls.length = units.SpectroscopicAxis(np.arange(5), unit=u.nm)
+        cls.frequency = units.SpectroscopicAxis(np.arange(5), unit=u.GHz)
+        cls.speed = units.SpectroscopicAxis(np.arange(5), unit=u.km/u.s)
+        return cls
 
     @pytest.mark.parametrize(('unit_from','unit_to','convention','ref_unit'),params)
     def test_convert_to(self, unit_from, unit_to, convention, ref_unit):
-        self.x.convert_to_unit(unit_to,convention=convention, make_dxarr=False)
-        assert self.x.unit == u.Unit(unit_to)
+        try:
+            self.x.convert_to_unit(unit_to,
+                                   velocity_convention=convention,
+                                   make_dxarr=False,
+                                  )
+            assert self.x.unit == u.Unit(unit_to)
+        except TypeError as ex:
+            if str(ex.args[0]) == ('cannot convert value type to array type '
+                                   'without precision loss'):
+                print("{0}->{1} with ref {2} is too imprecise".format(
+                    unit_from, unit_to, ref_unit))
+            else:
+                raise ex
 
     def test_equivalencies_1(self, ):
         assert self.x.equivalencies is not None # == u.doppler_optical(3*u.AA)
 
     @pytest.mark.parametrize(('velocity_convention'), convention)
     def test_equivalencies_2(self, velocity_convention):
-        x = SpectroscopicAxis(np.arange(5), unit=u.angstrom, refX=3*u.AA, velocity_convention=velocity_convention)
-        assert x.equivalencies == u.doppler_optical(3*u.AA)
+        ref = 3*u.AA
+        x = SpectroscopicAxis(np.arange(5), unit=u.angstrom, refX=ref,
+                              velocity_convention=velocity_convention)
+        expected = set(convention_map[velocity_convention](ref) + u.spectral())
+        eq_units = set([item[:2] for item in x.equivalencies])
+        eq_units_expected = set([item[:2] for item in expected])
+        assert eq_units == eq_units_expected
 
     @pytest.mark.parametrize(('velocity_convention'), convention)
     def test_equivalencies_3(self, velocity_convention):
-        x = SpectroscopicAxis(np.arange(5), unit=u.angstrom, refX=3, refX_unit='angstrom', velocity_convention=velocity_convention)
-        assert x.equivalencies == u.get('doppler_{0}'.format(velocity_convention))(3*u.AA)
+        # note that the ref has no unit; the unit is assumed to be the axis units
+        x = SpectroscopicAxis(np.arange(5), unit=u.angstrom, refX=3,
+                              refX_unit='angstrom',
+                              velocity_convention=velocity_convention)
+        expected = set(convention_map[velocity_convention](3*u.AA) + u.spectral())
+        eq_units = set([item[:2] for item in x.equivalencies])
+        eq_units_expected = set([item[:2] for item in expected])
+        assert eq_units == eq_units_expected
 
     def test_initialize_units(self, ):
         xarr = units.SpectroscopicAxis(np.linspace(1,10,10),unit=u.dimensionless_unscaled)
@@ -87,11 +113,11 @@ class TestUnits(object):
 
     @pytest.mark.parametrize(('unit_from','unit_to','convention','ref_unit'),params)
     def test_convert_units(self, unit_from, unit_to, convention, ref_unit):
-        xarr = units.SpectroscopicAxis(np.linspace(1, 10, 3), unit=unit_from,
+        xarr = units.SpectroscopicAxis(np.linspace(4.9, 5.1, 3), unit=unit_from,
                                        refX=5, refX_unit=ref_unit,
                                        velocity_convention=convention,
                                       )
-        xarr.convert_to_unit(unit_to, make_dxarr=False)
+        xarr.convert_to_unit(unit_to, make_dxarr=False,)
         assert xarr.unit == unit_to
 
     def test_convert_units2(self, ):
@@ -141,8 +167,10 @@ class TestUnits(object):
             refX = u.Quantity(5, ref_unit)
         xarr = units.SpectroscopicAxis(np.copy(xvals), unit=unit_from, refX=refX,
                                        velocity_convention=convention)
-        xarr.convert_to_unit(unit_to,convention=convention, make_dxarr=False)
-        xarr.convert_to_unit(unit_from,convention=convention, make_dxarr=False)
+        xarr.convert_to_unit(unit_to, velocity_convention=convention,
+                             make_dxarr=False)
+        xarr.convert_to_unit(unit_from, velocity_convention=convention,
+                             make_dxarr=False)
         infinites = np.isinf(xarr.value)
         assert all(np.abs((xarr.value - xvals)/xvals)[~infinites] < threshold)
         assert xarr.unit == unit_from

--- a/pyspeckit/spectrum/tests/test_units.py
+++ b/pyspeckit/spectrum/tests/test_units.py
@@ -1,5 +1,6 @@
 import pyspeckit
-from pyspeckit.spectrum import units
+from .. import units
+from ..units import SpectroscopicAxis
 import numpy as np
 import pytest
 from astropy import units as u
@@ -9,10 +10,10 @@ convention = ['optical','radio','relativistic']
 # these are used to populate a matrix for unit conversion tests
 # being complete is expensive, ~1+ minutes
 unit_type_dict = {
-    #'Hz' :'frequency', 'kHz':'frequency', 'MHz':'frequency', 
+    #'Hz' :'frequency', 'kHz':'frequency', 'MHz':'frequency',
     'GHz':'frequency',
     # not permitted by astropy 'hz' :'frequency', 'khz':'frequency', 'mhz':'frequency', 'ghz':'frequency',
-    #'THz':'frequency', 
+    #'THz':'frequency',
     'meter/second':'velocity',
     #'m/s':'velocity',
     #'kilometer/s':'velocity',
@@ -28,7 +29,7 @@ unit_type_dict = {
     #'m s-1':'velocity',
     'cm s-1':'velocity',
     #'ms-1':'velocity',
-    #'cm/s':'velocity', #'cms':'velocity', 
+    #'cm/s':'velocity', #'cms':'velocity',
     #'meter':'wavelength','m':'wavelength',
     'centimeter':'wavelength',
     #'cm':'wavelength',
@@ -47,9 +48,9 @@ unit_type_dict = {
 }
 
 params = [(a,b,c,d) for a in unit_type_dict if a not in ('unknown',None)
-                  for b in unit_type_dict if b not in ('unknown',None)
-                  for c in convention
-                  for d in ['GHz','cm']]
+          for b in unit_type_dict if b not in ('unknown',None)
+          for c in convention
+          for d in ['GHz','cm']]
 
 class TestUnits(object):
 
@@ -62,8 +63,8 @@ class TestUnits(object):
 
     @pytest.mark.parametrize(('unit_from','unit_to','convention','ref_unit'),params)
     def test_convert_to(self, unit_from, unit_to, convention, ref_unit):
-        x.convert_to_unit(unit_to,convention=convention, make_dxarr=False)
-        assert x.unit == u.Unit(unit_to)
+        self.x.convert_to_unit(unit_to,convention=convention, make_dxarr=False)
+        assert self.x.unit == u.Unit(unit_to)
 
     def test_equivalencies_1(self, ):
         assert self.x.equivalencies is not None # == u.doppler_optical(3*u.AA)
@@ -163,6 +164,27 @@ class TestUnits(object):
                                                  velocity_convention='radio')
         assert xarr.x_to_pix(100.001,u.GHz) == 23
 
+    def test_comparison(self):
+        # regression test for issue 153
+
+        xx = np.linspace(-50,50)*u.km/u.s
+
+        # test the quantity-only version first
+        # (so if it crashes here, we know it's not our fault)
+        print()
+        print("Astropy quantity tests\n")
+        mask1 = xx < 0*u.km/u.s
+        print("Resulting type: {0}".format(type(mask1)))
+        assert np.all(mask1[:25])
+        assert np.all(~mask1[25:])
+
+        print()
+        print("Pyspeckit xarr tests\n")
+        xarr = pyspeckit.units.SpectroscopicAxis(xx)
+        mask = xarr < 0*u.km/u.s
+        print("Resulting type: {0}".format(type(mask)))
+        assert np.all(mask[:25])
+        assert np.all(~mask[25:])
 
 
 if __name__=="__main__":

--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -726,7 +726,7 @@ class SpectroscopicAxis(u.Quantity):
         if isinstance(self.unit, str):
             self._unit = u.Unit(self.unit)
 
-        return self.to(unit, equivalencies=self.equivalencies)
+        return self.to(unit, equivalencies=self.equivalencies, **kwargs)
 
     def make_dxarr(self, coordinate_location='center'):
         """

--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -512,7 +512,7 @@ class SpectroscopicAxis(u.Quantity):
         self._equivalencies = getattr(obj, 'equivalencies', [])
         # moved from __init__ - needs to be done whenever viewed
         # (this is slow, though - may be better not to do this)
-        if self.shape: # check to make sure non-scalar
+        if self.shape and self.dtype != np.dtype('bool'): # check to make sure non-scalar
             # can't use make_dxarr here! infinite recursion =(
             self.dxarr = np.diff(np.array(self))
 
@@ -726,7 +726,7 @@ class SpectroscopicAxis(u.Quantity):
         if isinstance(self.unit, str):
             self._unit = u.Unit(self.unit)
 
-        return self.to(unit, equivalencies=self.equivalencies, **kwargs)
+        return self.to(unit, equivalencies=self.equivalencies)
 
     def make_dxarr(self, coordinate_location='center'):
         """

--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -99,7 +99,7 @@ class SmartCaseNoSpaceDict(dict):
             return dict.pop(self, key.lower().replace(" ",""),def_val)
         else:
             return cased
-    
+
 
 length_dict = {'meter':1.0,'m':1.0,
                'centimeter':1e-2,'cm':1e-2,
@@ -290,7 +290,7 @@ class SpectroscopicAxis(u.Quantity):
         """
         Make a new spectroscopic axis instance
         Default units Hz
-        
+
         Parameter
         ----------
         xarr : np.ndarray
@@ -340,7 +340,7 @@ class SpectroscopicAxis(u.Quantity):
             else:
                 log.debug("xarr owns its own data.  Continuing as normal.")
                 subarr = xarr
-        
+
         subarr = subarr.view(self)
 
         # Only need to set xarr's unit if it's not a quantity
@@ -400,16 +400,30 @@ class SpectroscopicAxis(u.Quantity):
 
     def __repr__(self):
         if self.shape is ():
-            rep = ("SpectroscopicAxis([%r], unit=%r, refX=%r, refX_unit=%r, frame=%r, redshift=%r, xtype=%r, velocity convention=%r)" %
-                (self.value, self.unit, self.refX, self.refX_unit, self.frame, self.redshift, self.xtype, self.velocity_convention))
+            rep = ("SpectroscopicAxis([%r], unit=%r, refX=%r,"
+                   " refX_unit=%r, frame=%r, redshift=%r, xtype=%r,"
+                   " velocity convention=%r)" % (self.value, self.unit,
+                                                 self.refX, self.refX_unit,
+                                                 self.frame, self.redshift,
+                                                 self.xtype,
+                                                 self.velocity_convention))
         else:
-            rep = ("SpectroscopicAxis([%r,...,%r], unit=%r, refX=%r, refX_unit=%r, frame=%r, redshift=%r, xtype=%r, velocity convention=%r)" %
-                (self[0].value, self[-1].value, self.unit, self.refX, self.refX_unit, self.frame, self.redshift, self.xtype, self.velocity_convention))
+            rep = ("SpectroscopicAxis([%r,...,%r], unit=%r,"
+                   " refX=%r, refX_unit=%r, frame=%r, redshift=%r,"
+                   " xtype=%r, velocity convention=%r)" % (self[0].value,
+                                                           self[-1].value,
+                                                           self.unit,
+                                                           self.refX,
+                                                           self.refX_unit,
+                                                           self.frame,
+                                                           self.redshift,
+                                                           self.xtype,
+                                                           self.velocity_convention))
         return rep
 
     def __str__(self):
-        selfstr = "SpectroscopicAxis with units %s and range %g:%g." % (
-                self.unit, self.umin().value, self.umax().value)
+        selfstr = ("SpectroscopicAxis with units %s and range %g:%g." % (
+            self.unit, self.umin().value, self.umax().value))
         if self.refX is not None:
             if not hasattr(self.refX, 'unit'):
                 selfstr += "Reference is %g %s" % (self.refX, self.refX_unit)
@@ -474,7 +488,7 @@ class SpectroscopicAxis(u.Quantity):
                                                    center_frequency=self.refX,
                                                    equivalencies=u.spectral())
             self.center_frequency, self._equivalencies = temp1,temp2
-    
+
     def __getattr__(self, name):
         # can't use getattr because it triggers infinite recursion
         object.__getattribute__(self, name)
@@ -507,7 +521,9 @@ class SpectroscopicAxis(u.Quantity):
         Do this when calling ufuncs
         (probably overridden by astropy.units.Quantity._wrap_function)
         """
-        ret = np.ndarray.__array_wrap__(self, out_arr, context)
+        # DEBUG print("ARRAY WRAP: pyspeckit.  context={0}".format(context))
+        ret = super(SpectroscopicAxis, self).__array_wrap__(out_arr, context=context)
+        #ret = np.ndarray.__array_wrap__(self, out_arr, context)
 
         # return scalar values for those that should be scalar
         if hasattr(ret, 'ndim') and ret.ndim == 0:
@@ -515,25 +531,6 @@ class SpectroscopicAxis(u.Quantity):
             return u.Quantity(ret)
 
         return ret
-
-    def _check_consistent_type(self):
-        """
-        Make sure self.xtype is unit_type_dict[unit]
-        if this is NOT true, can cause significant errors
-        """
-        if self.xtype is None:
-            OK = False
-        else:
-            OK = self.xtype.lower() == self.unit
-
-        if not OK:
-            raise InconsistentTypeError("Unit: %s Type[unit]: %s in %r" % (self.unit,unit_type_dict[self.unit],self))
-
-    def _fix_type(self):
-        try:
-            self._check_consistent_type()
-        except InconsistentTypeError:
-            self.xtype = unit_type_dict[self.unit]
 
     @classmethod
     def validate_unit(self, unit, bad_unit_response='raise'):
@@ -553,8 +550,9 @@ class SpectroscopicAxis(u.Quantity):
             elif bad_unit_response == "raise":
                 raise ValueError('Unit %s not recognized.' % unit)
             else:
-                raise ValueError('Unit %s not recognized. Invalid bad_unit_response, valid options: [%s/%s]' 
-                                % (unit, "raise", "pixel"))
+                raise ValueError('Unit %s not recognized. Invalid '
+                                 'bad_unit_response, valid options: [%s/%s]' %
+                                 (unit, "raise", "pixel"))
         return unit
 
     def set_unit(self, unit, bad_unit_response='raise'):
@@ -570,7 +568,7 @@ class SpectroscopicAxis(u.Quantity):
             # could be reversed
             return np.max([self.coord_to_x(self.max(), unit),
                            self.coord_to_x(self.min(),unit)])
-        else: 
+        else:
             return self.max()
 
     def umin(self, unit=None):
@@ -583,7 +581,7 @@ class SpectroscopicAxis(u.Quantity):
             # could be reversed
             return np.min([self.coord_to_x(self.max(), unit),
                            self.coord_to_x(self.min(),unit)])
-        else: 
+        else:
             return self.min()
 
     def x_to_pix(self, xval, xval_units=None, equivalencies=None):
@@ -638,7 +636,7 @@ class SpectroscopicAxis(u.Quantity):
         value converted to xunit
         e.g.:
         xarr.units = 'km/s'
-        xarr.refX = 5.0 
+        xarr.refX = 5.0
         xarr.refX_unit = GHz
         xarr.coord_to_x(6000,'GHz') == 5.1 # GHz
         """
@@ -677,7 +675,7 @@ class SpectroscopicAxis(u.Quantity):
                 **kwargs):
         """
         Convert the spectrum to the specified units.  This is a wrapper function
-        to convert between frequency/velocity/wavelength and simply change the 
+        to convert between frequency/velocity/wavelength and simply change the
         units of the X axis.  Frame conversion is... not necessarily implemented.
 
         Parameter
@@ -721,10 +719,10 @@ class SpectroscopicAxis(u.Quantity):
             center_frequency = None
 
         self.center_frequency, self._equivalencies = \
-            self.find_equivalencies(velocity_convention, 
+            self.find_equivalencies(velocity_convention,
                                     center_frequency,
                                     equivalencies)
-        
+
         if isinstance(self.unit, str):
             self._unit = u.Unit(self.unit)
 
@@ -885,6 +883,8 @@ class SpectroscopicAxis(u.Quantity):
         view.__array_finalize__(self)
         if unit is not None:
             view._unit = unit
+
+        #DEBUG print("unit is {1}, self.unit is {2}, class is {0}, viewtype={3}".format(subclass, unit, self.unit, type(view)))
         return view
 
 def merge_equivalencies(old_equivalencies, new_equivalencies):
@@ -978,7 +978,7 @@ class EchelleAxes(SpectroscopicAxis):
         velocity_convention = axislist[0].velocity_convention
         for ax in axislist:
             if ax.xtype != xtype:
-                try: 
+                try:
                     ax.change_xtype(xtype)
                 except:
                     ValueError("Axis had wrong xtype and could not be converted.")
@@ -1030,7 +1030,7 @@ def velocity_to_frequency(velocities, input_units, center_frequency=None,
         * Radio 	V = c (f0 - f)/f0 	f(V) = f0 ( 1 - V/c )
         * Optical 	V = c (f0 - f)/f 	f(V) = f0 ( 1 + V/c )^-1
         * Redshift 	z = (f0 - f)/f 	f(V) = f0 ( 1 + z )-1
-        * Relativistic 	V = c (f02 - f 2)/(f02 + f 2) 	f(V) = f0 { 1 - (V/c)2}1/2/(1+V/c) 
+        * Relativistic 	V = c (f02 - f 2)/(f02 + f 2) 	f(V) = f0 { 1 - (V/c)2}1/2/(1+V/c)
 
     """
     if input_units in frequency_dict:
@@ -1059,7 +1059,7 @@ def frequency_to_velocity(frequencies, input_units, center_frequency=None,
     """
     Conventions defined here:
     http://www.gb.nrao.edu/~fghigo/gbtdoc/doppler.html
-     
+
      * Radio 	V = c (f0 - f)/f0 	f(V) = f0 ( 1 - V/c )
      * Optical 	V = c (f0 - f)/f 	f(V) = f0 ( 1 + V/c )-1
      * Redshift 	z = (f0 - f)/f 	f(V) = f0 ( 1 + z )-1


### PR DESCRIPTION
This was always the intended behavior, but it broke during the transition to using astropy quantities in general.

TODO: 
 * [x] make a test