### PR TITLE
fiteach doesn't fit certain pixels, specfit does

### DIFF
--- a/examples/n2hp_cube_example.py
+++ b/examples/n2hp_cube_example.py
@@ -43,7 +43,7 @@ if os.path.exists('n2hp_fitted_parameters.fits'):
 else:
     # Run the fitter
     # Estimated time to completion ~ 2 minutes
-    spc.fiteach(fittype='n2hp_vtau', multifit=True,
+    spc.fiteach(fittype='n2hp_vtau',
                 guesses=[5,0.5,3,1], # Tex=5K, tau=0.5, v_center=12, width=1 km/s
                 signal_cut=3, # minimize the # of pixels fit for the example
                 start_from_point=(2,2), # start at a pixel with signal

--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -774,8 +774,12 @@ class Cube(spectrum.Spectrum):
             elif errmap is not None:
                 sp.error = np.ones(sp.data.shape) * errmap[y,x]
             else:
-                if verbose_level > 1 and ii==0:
-                    log.warning("WARNING: using data std() as error.", PyspeckitWarning)
+                if ii==0:
+                    # issue the warning only once (ii==0), but always issue
+                    log.warning("WARNING: using data std() as error.  "
+                                "If signal_cut is set, this can result in "
+                                "some pixels not being fit.",
+                                PyspeckitWarning)
                 sp.error[:] = sp.data[sp.data==sp.data].std()
             if sp.error is not None and signal_cut > 0 and not all(sp.error == 0):
                 if continuum_map is not None:

--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -781,7 +781,10 @@ class Cube(spectrum.Spectrum):
                                 "some pixels not being fit.",
                                 PyspeckitWarning)
                 sp.error[:] = sp.data[sp.data==sp.data].std()
-            if sp.error is not None and signal_cut > 0 and not all(sp.error == 0):
+            if sp.error is None:
+                raise TypeError("The Spectrum's error is unset.  This should "
+                                "not be possible.  Please raise an Issue.")
+            if signal_cut > 0 and not all(sp.error == 0):
                 if continuum_map is not None:
                     snr = (sp.data-continuum_map[y,x]) / sp.error
                 else:

--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -677,8 +677,8 @@ class Cube(spectrum.Spectrum):
 
         """
         if 'multifit' in fitkwargs:
-            log.warning("The multifit keyword is no longer required.  All fits "
-                        "allow for multiple components.", DeprecationWarning)
+            warn("The multifit keyword is no longer required.  All fits "
+                 "allow for multiple components.", DeprecationWarning)
 
         if not hasattr(self.mapplot,'plane'):
             self.mapplot.makeplane()
@@ -776,10 +776,10 @@ class Cube(spectrum.Spectrum):
             else:
                 if ii==0:
                     # issue the warning only once (ii==0), but always issue
-                    log.warning("WARNING: using data std() as error.  "
-                                "If signal_cut is set, this can result in "
-                                "some pixels not being fit.",
-                                PyspeckitWarning)
+                    warn("Using data std() as error.  "
+                         "If signal_cut is set, this can result in "
+                         "some pixels not being fit.",
+                         PyspeckitWarning)
                 sp.error[:] = sp.data[sp.data==sp.data].std()
             if sp.error is None:
                 raise TypeError("The Spectrum's error is unset.  This should "

--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -777,7 +777,7 @@ class Cube(spectrum.Spectrum):
                 if verbose_level > 1 and ii==0:
                     log.warning("WARNING: using data std() as error.", PyspeckitWarning)
                 sp.error[:] = sp.data[sp.data==sp.data].std()
-            if sp.error is not None and signal_cut > 0:
+            if sp.error is not None and signal_cut > 0 and not all(sp.error == 0):
                 if continuum_map is not None:
                     snr = (sp.data-continuum_map[y,x]) / sp.error
                 else:

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -247,8 +247,10 @@ def test_noerror_cube(cubefile='test.fits'):
                     start_from_point=(4,4),
                    )
     assert "If signal_cut is set" in str(w[-1].message)
-
     assert not np.all(spc.has_fit)
 
-    spc.fiteach(fittype='gaussian', guesses=[0.7,0.5,0.8], signal_cut=0)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('default')
+        spc.fiteach(fittype='gaussian', guesses=[0.7,0.5,0.8], signal_cut=0)
+    assert "If signal_cut is set" in str(w[-1].message)
     assert np.all(spc.has_fit)

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -20,26 +20,27 @@ def make_test_cube(shape=(30,9,9), outfile='test.fits', sigma=None, seed=0):
         sigma1d, sigma2d = sigma
 
     gauss1d = Gaussian1DKernel(stddev=sigma1d, x_size=shape[0])
-    gauss2d = Gaussian2DKernel(stddev=sigma2d, x_size=shape[1], 
-                                               y_size=shape[2])
+    gauss2d = Gaussian2DKernel(stddev=sigma2d,
+                               x_size=shape[1],
+                               y_size=shape[2])
     test_cube = gauss1d.array[:,None,None] * gauss2d.array
     test_cube=test_cube/test_cube.max()
     # adding noise:
     np.random.seed(seed)
-    noise_cube = (np.random.random(test_cube.shape)-.5)* \
-                        np.median(test_cube.std(axis=0))
+    noise_cube = ((np.random.random(test_cube.shape)-.5) *
+                  np.median(test_cube.std(axis=0)))
     test_cube += noise_cube
     true_rms = noise_cube.std()
-    
+
     # making a simple header for the test cube:
     test_hdu = fits.PrimaryHDU(test_cube)
-    # the strange cdelt values are a workaround 
+    # the strange cdelt values are a workaround
     # for what seems to be a bug in wcslib:
     # https://github.com/astropy/astropy/issues/4555
     cdelt1, cdelt2, cdelt3 = -(4e-3+1e-8), 4e-3+1e-8, -0.1
     keylist = {'CTYPE1': 'RA---GLS', 'CTYPE2': 'DEC--GLS', 'CTYPE3': 'VRAD',
                'CDELT1': cdelt1, 'CDELT2': cdelt2, 'CDELT3': cdelt3,
-               'CRVAL1': 0, 'CRVAL2': 0, 'CRVAL3': 5, 
+               'CRVAL1': 0, 'CRVAL2': 0, 'CRVAL3': 5,
                'CRPIX1': 9, 'CRPIX2': 0, 'CRPIX3': 5,
                'CUNIT1': 'deg', 'CUNIT2': 'deg', 'CUNIT3': 'km s-1',
                'BUNIT' : 'K', 'EQUINOX': 2000.0}
@@ -85,8 +86,8 @@ def test_subimage_integ_header(cubefile='test.fits'):
 
     # saving results from subimage_integ:
     cutData, cutHead = cubes.subimage_integ(cube, xcen, xwidth, ycen, ywidth,
-                                            vrange=(0,header['NAXIS3']-1), 
-                                            zunits='pixels', units='pixels', 
+                                            vrange=(0,header['NAXIS3']-1),
+                                            zunits='pixels', units='pixels',
                                             header=header)
 
     assert cutHead['CRPIX1'] == 7.0
@@ -106,7 +107,7 @@ def do_fiteach(save_cube=None, save_pars=None, show_plot=False):
     if save_cube is None:
         save_cube = 'test.fits'
     test_sigma = 10 # in pixel values, each pixel is CDELT3 thick
-    make_test_cube((100,10,10), save_cube, 
+    make_test_cube((100,10,10), save_cube,
                       sigma=(test_sigma, 5) )
     # from .. import Cube
     spc = Cube(save_cube)

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -1,11 +1,12 @@
-from .. import cubes, Cube, CubeStack
-from ...spectrum.models import n2hp
-
+import os
+import warnings
 import numpy as np
 from astropy.io import fits
 from astropy import wcs
 
-import os
+from .. import cubes, Cube, CubeStack
+from ...spectrum.models import n2hp
+
 
 def make_test_cube(shape=(30,9,9), outfile='test.fits', sigma=None, seed=0):
     """
@@ -239,6 +240,11 @@ def test_noerror_cube(cubefile='test.fits'):
         make_test_cube((100,9,9),cubefile)
 
     spc = Cube(cubefile)
-    spc.fiteach(fittype='gaussian', guesses=[0.7,0.5,0.8])
+    with warnings.catch_warnings(record=True) as w:
+        spc.fiteach(fittype='gaussian', guesses=[0.7,0.5,0.8])
+    assert "If signal_cut is set" in str(w[-1].message)
 
+    assert not np.all(spc.has_fit)
+
+    spc.fiteach(fittype='gaussian', guesses=[0.7,0.5,0.8], signal_cut=0)
     assert np.all(spc.has_fit)

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -243,7 +243,9 @@ def test_noerror_cube(cubefile='test.fits'):
     spc = Cube(cubefile)
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('default')
-        spc.fiteach(fittype='gaussian', guesses=[0.7,0.5,0.8])
+        spc.fiteach(fittype='gaussian', guesses=[0.7,0.5,0.8],
+                    start_from_point=(4,4),
+                   )
     assert "If signal_cut is set" in str(w[-1].message)
 
     assert not np.all(spc.has_fit)

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -241,6 +241,7 @@ def test_noerror_cube(cubefile='test.fits'):
 
     spc = Cube(cubefile)
     with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('default')
         spc.fiteach(fittype='gaussian', guesses=[0.7,0.5,0.8])
     assert "If signal_cut is set" in str(w[-1].message)
 

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -230,3 +230,15 @@ def test_registry_inheritance(cubefile='test.fits'):
     assert 'n2hp_vtau' in sp.Registry.multifitters
     assert 'n2hp_vtau' in sp.Registry.npars
     sp.specfit(fittype='n2hp_vtau', guesses=[1,2,3,4])
+
+def test_noerror_cube(cubefile='test.fits'):
+    """
+    Regression test for #159
+    """
+    if not os.path.exists(cubefile):
+        make_test_cube((100,9,9),cubefile)
+
+    spc = Cube(cubefile)
+    spc.fiteach(fittype='gaussian', guesses=[0.7,0.5,0.8])
+
+    assert np.all(spc.has_fit)

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -252,5 +252,4 @@ def test_noerror_cube(cubefile='test.fits'):
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('default')
         spc.fiteach(fittype='gaussian', guesses=[0.7,0.5,0.8], signal_cut=0)
-    assert "If signal_cut is set" in str(w[-1].message)
     assert np.all(spc.has_fit)

--- a/pyspeckit/spectrum/classes.py
+++ b/pyspeckit/spectrum/classes.py
@@ -175,7 +175,7 @@ class BaseSpectrum(object):
             if error is not None:
                 self.error = error
             else:
-                self.error = data * 0
+                self.error = None
             if hasattr(header,'get'):
                 if not isinstance(header, pyfits.Header):
                     cards = [pyfits.Card(k, header[k]) for k in header]

--- a/pyspeckit/spectrum/classes.py
+++ b/pyspeckit/spectrum/classes.py
@@ -175,7 +175,7 @@ class BaseSpectrum(object):
             if error is not None:
                 self.error = error
             else:
-                self.error = None
+                self.error = np.zeros_like(data)
             if hasattr(header,'get'):
                 if not isinstance(header, pyfits.Header):
                     cards = [pyfits.Card(k, header[k]) for k in header]


### PR DESCRIPTION
I'm getting an unexpected behavior when running `fiteach` on a dummy gaussian cube. A fit with a good initial guess doesn't converge for a significant fraction of the pixels, despite good signal-to-noise ratios in them.

It doesn't seem to be an issue of the underlying non-linear least squares code too - if I just do a for-loop over all (x,y) positions and fit every spectrum using `specfit` with the same initial guesses, the issue disappears:

```python
import numpy as np
import matplotlib.pylab as plt
import pyspeckit
from pyspeckit.cubes.tests.test_cubetools import make_test_cube

make_test_cube((100,10,10), outfile='test.fits', sigma=(10,5))

# get sigma from fiteach()
spc = pyspeckit.Cube('test.fits')
spc.fiteach(fittype = 'gaussian',
            guesses=[0.7,0.5,0.8])
sigma_fiteach = spc.parcube[2].copy()

# get sigma from fitting individual spectra
for y,x in np.ndindex(spc.cube.shape[1:]):
    sp = spc.get_spectrum(x,y)
    sp.specfit(fittype='gaussian', guesses=[0.7,0.5,0.8])
    spc.parcube[:,y,x] = sp.specfit.parinfo.values
sigma_forloop = spc.parcube[2]

# the difference of sigma fits shows pixels ignored by fiteach()!
plt.imshow(sigma_fiteach / sigma_forloop, 
           cmap=plt.cm.get_cmap('Pastel1',2), 
           interpolation='none',
           vmin=-0.5, vmax=1.5)
plt.colorbar(ticks=[0,1])
plt.show()
```
Below is the ratio if the fitted sigma values - it illustrates the "holes" in the parcube resulting from `fiteach`:
![pyspeckit-issue159](https://cloud.githubusercontent.com/assets/11835115/14495095/4c7e3c7c-018e-11e6-82b3-2b20576df6b0.png)
