### PR TITLE
better fiteach + moments functionality

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -880,8 +880,9 @@ class Cube(spectrum.Spectrum):
         # try a first fit for exception-catching
         try0 = fit_a_pixel((0,valid_pixels[0][0],valid_pixels[0][1]))
         try:
-            assert len(try0[1]) == len(guesses) == len(self.parcube) == len(self.errcube)
-            assert len(try0[2]) == len(guesses) == len(self.parcube) == len(self.errcube)
+            len_guesses = len(self.momentcube) if usemomentcube else len(guesses)
+            assert len(try0[1]) == len_guesses == len(self.parcube) == len(self.errcube)
+            assert len(try0[2]) == len_guesses == len(self.parcube) == len(self.errcube)
         except TypeError as ex:
             if try0 is None:
                 raise AssertionError("The first fitted pixel did not yield a "

--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -713,6 +713,7 @@ class Cube(spectrum.Spectrum):
             log.debug("Number of valid pixels: %i" % len(valid_pixels))
 
         if usemomentcube:
+            if not hasattr(self, 'momentcube'): self.momenteach()
             npars = self.momentcube.shape[0]
         else:
             npars = len(guesses)

--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -1012,6 +1012,9 @@ class Cube(spectrum.Spectrum):
         if not hasattr(self.mapplot,'plane'):
             self.mapplot.makeplane()
 
+        if 'vheight' not in kwargs:
+            kwargs['vheight'] = False
+
         yy,xx = np.indices(self.mapplot.plane.shape)
         if isinstance(self.mapplot.plane, np.ma.core.MaskedArray):
             OK = (~self.mapplot.plane.mask) * self.maskmap


### PR DESCRIPTION
For review: a few changes that make it much cleaner to use moments as guesses for cubes:
* 24553aa allows `momenteach()` to pass `vheight=False` as default. If set to true, calling `fiteach(usemomentcube=True)` will grab a guess from the `momentcube` that is one element longer than needed. This change is consistent with the [1d fitter](https://github.com/pyspeckit/pyspeckit/blob/master/pyspeckit/spectrum/fitters.py#L602) case, which also passes `vheight=False` to `moments`.
* currently, the `TEST BLOCK` in `fiteach` doesn't actually give a chance for `usemomentcube=True` to set the guesses from the momentcube if the guesses aren't set or are of the wrong length. This diminishes the need for the keyword in the first place, as one could just pass `guesses=spc.momentcube` instead. I added a workaround (f2eb90d), so that instead of
```python
spc.fiteach(fittype = 'gaussian',
            guesses = ['this','is','ignored'], # a valid input
            usemomentcube = True,
            errmap = rmsmap)
```
this could be run:
```python
spc.fiteach(fittype = 'gaussian', usemomentcube = True, errmap = rmsmap)
```
* finally, 79e8b71 would generate a momentcube if it `momenteach` was not run prior to a call to `fiteach`. I am not actually sure if it's necessary, but my reasoning is that it mimics the `1d` spectral fitting approach, where it's enough to just pass `guesses='moments'` to the fitter.