### PR TITLE
Fix parameter cube loading issues

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -1168,13 +1168,13 @@ class Cube(spectrum.Spectrum):
 
         try:
             sp.specfit(fittype=fittype, guesses=guesses.values)
-            self.specfit.fitter = sp.specfit.fitter
         except Exception as ex:
             log.error("Fitting the pixel at location {0} failed with error: {1}.  "
                       "This is probably harmless, it just means the default pixel "
                       "has no signal or bad signal.  "
                       "Try setting _temp_fit_loc to a valid pixel".format(_temp_fit_loc, ex))
 
+        self.specfit.fitter = sp.specfit.fitter
         self.specfit.fittype = sp.specfit.fittype
         self.specfit.parinfo = sp.specfit.parinfo
 

--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -1154,6 +1154,13 @@ class Cube(spectrum.Spectrum):
         self.parcube = cube[:npars*npeaks,:,:]
         self.errcube = cube[npars*npeaks:npars*npeaks*2,:,:]
 
+        nanvals = ~np.isfinite(self.parcube)
+        nanvals_flat = np.any(nanvals, axis=0)
+        if np.any(nanvals):
+            log.warn("NaN or infinite values encountered in parameter cube.  ",
+                     PyspeckitWarning)
+            
+
         # make sure params are within limits
         fitter = self.specfit.Registry.multifitters[fittype]
         guesses,throwaway = fitter._make_parinfo(npeaks=npeaks)
@@ -1165,7 +1172,7 @@ class Cube(spectrum.Spectrum):
             sp.specfit(fittype=fittype, guesses=guesses.values)
         except Exception as ex1:
             try:
-                OKmask = np.any(self.parcube, axis=0)
+                OKmask = np.any(self.parcube, axis=0) & ~nanvals_flat
                 whereOK = np.where(OKmask)
                 x,y = whereOK[1][0],whereOK[0][0]
                 sp = self.get_spectrum(x,y)

--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -579,8 +579,12 @@ class Cube(spectrum.Spectrum):
         """
         if self._modelcube is None or update:
             yy,xx = np.indices(self.parcube.shape[1:])
+            isvalid = np.any(self.parcube, axis=0)
             self._modelcube = np.zeros_like(self.cube)
-            for x,y in zip(xx.flat,yy.flat):
+            # progressbar doesn't work with zip; I'm therefore giving up on
+            # "efficiency" in memory by making a list here.
+            for x,y in ProgressBar(list(zip(xx[isvalid],
+                                            yy[isvalid]))):
                 self._modelcube[:,y,x] = self.specfit.get_full_model(pars=self.parcube[:,y,x])
 
         return self._modelcube
@@ -1167,6 +1171,8 @@ class Cube(spectrum.Spectrum):
             self.specfit.fitter = sp.specfit.fitter
         except Exception as ex:
             log.error("Fitting the pixel at location {0} failed with error: {1}.  "
+                      "This is probably harmless, it just means the default pixel "
+                      "has no signal or bad signal.  "
                       "Try setting _temp_fit_loc to a valid pixel".format(_temp_fit_loc, ex))
 
         self.specfit.fittype = sp.specfit.fittype


### PR DESCRIPTION
Fix the issue noted by @jpinedaf here: https://github.com/GBTAmmoniaSurvey/GAS/pull/119/files/00412053986274dc07ddd8ad17ed19e3ec78721e#r61290961

The fix isn't 100% guaranteed to work; it doesn't check the validity of the
parameters for each pixel.  However, if the parameters were written by a valid
fit from `fiteach`, then they all should be in bounds and should therefore be
valid.  The only check performed here is that *at least one* of the parameters
is nonzero for each pixel.

Also added a progressbar.