### PR TITLE
Should get_modelcube() filter out NaN values?

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -581,7 +581,7 @@ class Cube(spectrum.Spectrum):
             yy,xx = np.indices(self.parcube.shape[1:])
             nanvals = np.any(~np.isfinite(self.parcube),axis=0)
             isvalid = np.any(self.parcube, axis=0) & ~nanvals
-            self._modelcube = np.zeros_like(self.cube)
+            self._modelcube = np.full_like(self.cube, np.nan)
             # progressbar doesn't work with zip; I'm therefore giving up on
             # "efficiency" in memory by making a list here.
             for x,y in ProgressBar(list(zip(xx[isvalid],

--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -579,7 +579,8 @@ class Cube(spectrum.Spectrum):
         """
         if self._modelcube is None or update:
             yy,xx = np.indices(self.parcube.shape[1:])
-            isvalid = np.any(self.parcube, axis=0)
+            nanvals = np.any(~np.isfinite(self.parcube),axis=0)
+            isvalid = np.any(self.parcube, axis=0) & ~nanvals
             self._modelcube = np.zeros_like(self.cube)
             # progressbar doesn't work with zip; I'm therefore giving up on
             # "efficiency" in memory by making a list here.


### PR DESCRIPTION
A follow-up on #163 - didn't think about it before. If get_modelcube() gets an ammonia parcube to crunch, it will break a tooth on any `NaN` values passed along with it, so it should probably just ignore those pixels.

```python
In [7]: sp.specfit.get_full_model(pars=[np.nan]*12)

ValueError: ntot, the logarithmic total column density, must be in the range 5 - 25
```

Also, is there any particular reason to fill the model cube with zeros instead of `NaN` values? Just curious.