### PR TITLE
specfit does not always inherit its own Registry

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -549,7 +549,7 @@ class Cube(spectrum.Spectrum):
                                model_registry=self.Registry,
                               )
 
-        sp.specfit = self.specfit.copy(parent=sp)
+        sp.specfit = self.specfit.copy(parent=sp, registry=sp.Registry)
 
         return sp
 

--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -460,7 +460,7 @@ class Cube(spectrum.Spectrum):
                                model_registry=self.Registry,
                               )
 
-        sp.specfit = copy.copy(self.specfit)
+        sp.specfit = self.specfit.copy(parent=sp, registry=sp.Registry)
         # explicitly re-do this (test)
         sp.specfit.includemask = self.specfit.includemask.copy()
         sp.specfit.Spectrum = sp

--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -456,7 +456,9 @@ class Cube(spectrum.Spectrum):
                                header=header, error=(self.errorcube[:,y,x] if
                                                      self.errorcube is not None
                                                      else None),
-                               unit=self.unit,)
+                               unit=self.unit,
+                               model_registry=self.Registry,
+                              )
 
         sp.specfit = copy.copy(self.specfit)
         # explicitly re-do this (test)
@@ -543,7 +545,9 @@ class Cube(spectrum.Spectrum):
         sp = spectrum.Spectrum(xarr=self.xarr.copy(),
                                data=data,
                                error=error,
-                               header=header)
+                               header=header,
+                               model_registry=self.Registry,
+                              )
 
         sp.specfit = self.specfit.copy(parent=sp)
 

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -1,4 +1,5 @@
 from .. import cubes, Cube, CubeStack
+from ...spectrum.models import n2hp
 
 import numpy as np
 from astropy.io import fits
@@ -209,3 +210,23 @@ def test_get_modelcube_badpar(cubefile=None, parfile=None, sigma_threshold=5):
         spc.load_model_fit(parfile, npars=3, _temp_fit_loc=(0,0))
         spc.get_modelcube()
         resid_cube = spc.cube - spc._modelcube
+
+def test_registry_inheritance(cubefile='test.fits'):
+    """
+    Regression test for #166
+    """
+    # getting a dummy .fits file
+    if not os.path.exists(cubefile):
+        #download_test_cube(cubefile)
+        make_test_cube((100,9,9),cubefile)
+
+    spc = Cube(cubefile)
+
+    spc.xarr.velocity_convention = 'radio'
+    # spc.Registry.add_fitter('n2hp_vtau', n2hp.n2hp_vtau_fitter, 4)
+
+    sp = spc.get_spectrum(3,3)
+    sp.Registry.add_fitter('n2hp_vtau', n2hp.n2hp_vtau_fitter, 4)
+    assert 'n2hp_vtau' in sp.Registry.multifitters
+    assert 'n2hp_vtau' in sp.Registry.npars
+    sp.specfit(fittype='n2hp_vtau', guesses=[1,2,3,4])

--- a/pyspeckit/spectrum/classes.py
+++ b/pyspeckit/spectrum/classes.py
@@ -552,12 +552,12 @@ class BaseSpectrum(object):
         sp.xarr = sp.xarr.__getitem__(indx)
 
         # this should be done by deepcopy, but deepcopy fails with current pyfits
-        sp.plotter = copy.copy(self.plotter)
+        sp.plotter = self.plotter.copy(parent=sp)
         sp.plotter.Spectrum = sp
-        sp.specfit = copy.copy(self.specfit)
+        sp.specfit = self.specfit.copy(parent=sp)
         sp.specfit.Spectrum = sp
         sp.specfit.Spectrum.plotter = sp.plotter
-        sp.baseline = copy.copy(self.baseline)
+        sp.baseline = self.baseline.copy(parent=sp)
         sp.baseline.Spectrum = sp
         sp.baseline.Spectrum.plotter = sp.plotter
 

--- a/pyspeckit/spectrum/classes.py
+++ b/pyspeckit/spectrum/classes.py
@@ -65,7 +65,8 @@ class BaseSpectrum(object):
 
     def __init__(self, filename=None, filetype=None, xarr=None, data=None,
                  error=None, header=None, doplot=False, maskdata=True,
-                 unit=None, plotkwargs={}, xarrkwargs={}, **kwargs):
+                 unit=None, plotkwargs={}, xarrkwargs={}, model_registry=None,
+                 **kwargs):
         """
         Create a Spectrum object.
 
@@ -206,8 +207,8 @@ class BaseSpectrum(object):
         # it is very important that this be done BEFORE the spectofit is set!
         self._sort()
         self.plotter = plotters.Plotter(self)
-        self._register_fitters()
-        self.specfit = fitters.Specfit(self,Registry=self.Registry)
+        self._register_fitters(registry=model_registry)
+        self.specfit = fitters.Specfit(self, Registry=self.Registry)
         self.baseline = baseline.Baseline(self)
         self.speclines = speclines
 
@@ -508,7 +509,7 @@ class BaseSpectrum(object):
 
         if copy:
             # create new specfit / baseline instances (otherwise they'll be the wrong length)
-            sp._register_fitters()
+            sp._register_fitters(registry=self.Registry)
             sp.baseline = baseline.Baseline(sp)
             sp.specfit = fitters.Specfit(sp,Registry=sp.Registry)
         else:
@@ -659,7 +660,7 @@ class BaseSpectrum(object):
 
         newspec.header = copy.copy(self.header)
         newspec.plotter = self.plotter.copy(parent=newspec)
-        newspec._register_fitters()
+        newspec._register_fitters(registry=self.Registry)
         newspec.specfit = self.specfit.copy(parent=newspec)
         newspec.specfit.Spectrum.plotter = newspec.plotter
         newspec.baseline = self.baseline.copy(parent=newspec)
@@ -865,7 +866,7 @@ class Spectra(BaseSpectrum):
     """
     __class_name__ = 'Spectra'
 
-    def __init__(self, speclist, xunit=None, **kwargs):
+    def __init__(self, speclist, xunit=None, model_registry=None, **kwargs):
         """
         """
         log.info("Creating spectra")
@@ -898,7 +899,7 @@ class Spectra(BaseSpectrum):
                     warn("Could not update header KEY=%s to VALUE=%s" % (key,value))
 
         self.plotter = plotters.Plotter(self)
-        self._register_fitters()
+        self._register_fitters(registry=model_registry)
         self.specfit = fitters.Specfit(self,Registry=self.Registry)
         self.baseline = baseline.Baseline(self)
 
@@ -1019,7 +1020,8 @@ class ObsBlock(Spectra):
     ObsBlocks can be indexed like python lists.
     """
 
-    def __init__(self, speclist, xtype='frequency', xarr=None, force=False, **kwargs):
+    def __init__(self, speclist, xtype='frequency', xarr=None, force=False,
+                 model_registry=None, **kwargs):
 
         if xarr is None:
             self.xarr = speclist[0].xarr
@@ -1050,8 +1052,8 @@ class ObsBlock(Spectra):
         self.error = np.array([sp.error for sp in self.speclist]).swapaxes(0,1).squeeze()
 
         self.plotter = plotters.Plotter(self)
-        self._register_fitters()
-        self.specfit = fitters.Specfit(self,Registry=self.Registry)
+        self._register_fitters(registry=model_registry)
+        self.specfit = fitters.Specfit(self, Registry=self.Registry)
         self.baseline = baseline.Baseline(self)
 
     def average(self, weight=None, inverse_weight=False, error='erravgrtn', debug=False):

--- a/pyspeckit/spectrum/classes.py
+++ b/pyspeckit/spectrum/classes.py
@@ -554,7 +554,7 @@ class BaseSpectrum(object):
         # this should be done by deepcopy, but deepcopy fails with current pyfits
         sp.plotter = self.plotter.copy(parent=sp)
         sp.plotter.Spectrum = sp
-        sp.specfit = self.specfit.copy(parent=sp)
+        sp.specfit = self.specfit.copy(parent=sp, registry=sp.Registry)
         sp.specfit.Spectrum = sp
         sp.specfit.Spectrum.plotter = sp.plotter
         sp.baseline = self.baseline.copy(parent=sp)
@@ -661,7 +661,7 @@ class BaseSpectrum(object):
         newspec.header = copy.copy(self.header)
         newspec.plotter = self.plotter.copy(parent=newspec)
         newspec._register_fitters(registry=self.Registry)
-        newspec.specfit = self.specfit.copy(parent=newspec)
+        newspec.specfit = self.specfit.copy(parent=newspec, registry=newspec.Registry)
         newspec.specfit.Spectrum.plotter = newspec.plotter
         newspec.baseline = self.baseline.copy(parent=newspec)
         newspec.baseline.Spectrum.plotter = newspec.plotter

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -1591,7 +1591,7 @@ class Specfit(interactive.Interactive):
                 self.multifit(use_window_limits=True)
                 for p in self.button2plot + self.button1plot:
                     p.set_visible(False)
-            else: 
+            else:
                 log.error("Wrong # of parameters")
 
         # disconnect interactive window (and more importantly, reconnect to
@@ -1603,13 +1603,15 @@ class Specfit(interactive.Interactive):
         Create a copy of the spectral fit - includes copies of the _full_model,
         the registry, the fitter, parinfo, modelpars, modelerrs, model, npeaks
 
-        [ parent ] 
+        Parameters
+        ----------
+        parent : `pyspeckit.classes.Spectrum`
             A `~Spectrum` instance that is the parent of the specfit
             instance.  This needs to be specified at some point, but defaults
             to None to prevent overwriting a previous plot.
         """
 
-        newspecfit = Specfit(parent, copy.deepcopy(self.Registry))
+        newspecfit = Specfit(parent, Registry=copy.deepcopy(self.Registry))
         newspecfit.parinfo = copy.deepcopy(self.parinfo)
         if newspecfit.parinfo is None:
             newspecfit.modelpars = None
@@ -1617,11 +1619,11 @@ class Specfit(interactive.Interactive):
         else:
             newspecfit.modelpars = newspecfit.parinfo.values
             newspecfit.modelerrs = newspecfit.parinfo.errors
-        newspecfit.includemask = self.includemask.copy() 
-        newspecfit.model = copy.copy( self.model )
+        newspecfit.includemask = self.includemask.copy()
+        newspecfit.model = copy.copy(self.model)
         newspecfit.npeaks = self.npeaks
         if hasattr(self,'fitter'):
-            newspecfit.fitter = copy.deepcopy( self.fitter )
+            newspecfit.fitter = copy.deepcopy(self.fitter)
             newspecfit.fitter.parinfo = newspecfit.parinfo
         if hasattr(self,'fullmodel'):
             newspecfit._full_model()

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -1598,7 +1598,7 @@ class Specfit(interactive.Interactive):
         # original interactive cmds)
         self.clear_all_connections()
 
-    def copy(self, parent=None):
+    def copy(self, parent=None, registry=None):
         """
         Create a copy of the spectral fit - includes copies of the _full_model,
         the registry, the fitter, parinfo, modelpars, modelerrs, model, npeaks
@@ -1611,7 +1611,15 @@ class Specfit(interactive.Interactive):
             to None to prevent overwriting a previous plot.
         """
 
-        newspecfit = Specfit(parent, Registry=copy.deepcopy(self.Registry))
+        if registry is None:
+            if hasattr(parent, 'Registry'):
+                registry = parent.Registry
+            else:
+                # only make a copy if we're not already given a specific registry
+                # to inherit
+                copy.deepcopy(self.Registry)
+
+        newspecfit = Specfit(parent, Registry=registry)
         newspecfit.parinfo = copy.deepcopy(self.parinfo)
         if newspecfit.parinfo is None:
             newspecfit.modelpars = None

--- a/pyspeckit/spectrum/tests/test_fitter.py
+++ b/pyspeckit/spectrum/tests/test_fitter.py
@@ -17,6 +17,15 @@ class TestFitter(object):
             warnings.simplefilter('ignore')
             self.sp = Spectrum(xarr=x, data=y)
 
+    def test_copy(self):
+        """
+        Regression test for #166: make sure that a Spectrum's Registry is the
+        same as its fitter's registry
+        """
+        spcopy = self.sp.copy()
+        assert self.sp.Registry is self.sp.specfit.Registry
+        assert spcopy.Registry is spcopy.specfit.Registry
+
     def test_fitter(self):
         self.sp.specfit(fittype='gaussian', guesses=(-1, 0, 0.5),
                         limitedmin=(False,False,True), minpars=(0,0,1e-10))


### PR DESCRIPTION
When getting a spectrum from `Cube.get_spectrum` method, the models added to the spectrum seem to get lost when specfit is called. Having a hard time understanding why this happens. Doesn't a `Spectrum` object just pass own its own Registry to `Specfit` one?

Adding a fitter directly to the parent `Cube` object before calling `get_spectrum` - a commented line in a script below - is a workaround for the issue.

```python
import pyspeckit
from pyspeckit.spectrum.models import n2hp

spc = pyspeckit.Cube(filename)
spc = spc.slice(*spc_cut, unit='km/s')
spc.xarr.velocity_convention = 'radio'
# spc.Registry.add_fitter('n2hp_vtau', n2hp.n2hp_vtau_fitter, 4)

sp=spc.get_spectrum(*start_yx[::-1])
sp.Registry.add_fitter('n2hp_vtau', n2hp.n2hp_vtau_fitter, 4)
assert 'n2hp_vtau' in sp.Registry.multifitters
assert 'n2hp_vtau' in sp.Registry.npars
sp.specfit(fittype='n2hp_vtau', guesses=guesses)
```
```
in multifit(self, fittype, renormalize, annotate, show_components, verbose, color, guesses, parinfo, reset_fitspec, use_window_limits, use_lmfit, plot, **kwargs)
    605             guesses = parinfo.values
    606 
--> 607         if len(guesses) < self.Registry.npars[self.fittype]:
    608             raise ValueError("Too few parameters input.  Need at least %i for %s models" % (self.Registry.npars[self.fittype],self.fittype))
    609 

KeyError: 'n2hp_vtau'
```

Also, changing the last line to
```python
sp.specfit(fittype='n2hp_vtau', guesses=guesses, Registry=sp.Registry)
```
still causes a `KeyError` to be thrown.