### PR TITLE
use_nearest_as_guess=True gives error message

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -706,7 +706,7 @@ class Cube(spectrum.Spectrum):
             d_from_start = ((xx-start_from_point[1])**2 + (yy-start_from_point[0])**2)**0.5
             sort_distance = np.argsort(d_from_start.flat)
 
-        if use_neighbor_as_guess:
+        if use_neighbor_as_guess or use_nearest_as_guess:
             distance = ((xx)**2 + (yy)**2)**0.5
 
         valid_pixels = list(zip(xx.flat[sort_distance][OK.flat[sort_distance]],


### PR DESCRIPTION
Hello! I've recently started working with pyspeckit with @jpinedaf, but I'm still quite a beginner.  I want to fit an ammonia spectrum (1-1) but for some reason the `use_nearest_as_guess = True` parameter in the `.fiteach()` function gives me the following error message:

> Traceback (most recent call last):
>   File "test_linefitting.py", line 70, in <module>
>     errmap=errmap, position_order = 1/peaksnr, maskmap=planemask, multicore=2)
>   File "/home/USER/miniconda3/envs/python2/lib/python2.7/site-packages/pyspeckit-0.1.19.dev2315-py2.7.egg/pyspeckit/cubes/SpectralCube.py", line 940, in fiteach
>     result = parallel_map(fit_a_pixel, sequence, numcores=multicore)
>   File "/home/USER/miniconda3/envs/python2/lib/python2.7/site-packages/pyspeckit-0.1.19.dev2315-py2.7.egg/pyspeckit/parallel_map/parallel_map.py", line 160, in parallel_map
>     return run_tasks(procs, err_q, out_q, numcores)
>   File "/home/USER/miniconda3/envs/python2/lib/python2.7/site-packages/pyspeckit-0.1.19.dev2315-py2.7.egg/pyspeckit/parallel_map/parallel_map.py", line 87, in run_tasks
>     raise err_q.get()
> NameError: free variable 'distance' referenced before assignment in enclosing scope

Here is a part of my line fitting script:

```python
import pyspeckit
import matplotlib.pylab as plt
import numpy as np
from astropy import units as u
from pyspeckit.spectrum.units import SpectroscopicAxis
from spectral_cube import SpectralCube
from astropy.io import fits

cube = SpectralCube.read('cube.fits')
parameter_maps = 'cube_parameter_maps.fits'
pcube = pyspeckit.Cube(cube=cube)

ammo_freq = 23.6944955*u.GHz
snr_min = 20

xarr = SpectroscopicAxis(np.linspace(22,24)*u.GHz, refX=ammo_freq,
                         velocity_convention= 'radio')
pcube.xarr.refX = ammo_freq
pcube.xarr.velocity_convention = 'radio' 
pcube.xarr.convert_to_unit(u.km/u.s)
freq_to_vel = u.doppler_radio(ammo_freq)

pcube.plotter()

# Get a measurement of the error per pixel
errmap = (pcube.slice(20, 26, unit='km/s')).cube.std(axis=0)
Tpeak=cube.max(axis=0).value
# print min and max of rms distribution
errmap[np.isfinite(errmap)].min()
errmap[np.isfinite(errmap)].max()

peaksnr = Tpeak/errmap
planemask = peaksnr > snr_min

pcube.fiteach(fittype='gaussian', guesses=[5e-3, 37.0, 2.0], use_nearest_as_guess=True, 
              errmap=errmap, position_order = 1/peaksnr, maskmap=planemask, multicore=2)
```

The fit runs properly when `use_nearest_as_guess` is either set to `False` or when it's excluded from the parameter list. We can't find a mistake in the syntax, so is this bug?
I am using Conda's python version 2.7.11 with the following packages: astropy 1.1.2, pyspeckit 0.1.19.dev2315 and spectral-cube 0.3.2.dev1088.

Thank you for your help!
Kristina