### PR TITLE
Change print statement to print function

### DIFF
--- a/pyspeckit/spectrum/toolbar.py
+++ b/pyspeckit/spectrum/toolbar.py
@@ -4,7 +4,7 @@ from matplotlib.backend_bases import NavigationToolbar2
 class NavigationToolbar3(NavigationToolbar2):
 
     def press_pan(self, event):
-        print "pan pressed"
+        print("pan pressed")
         super(NavigationToolbar3,self).press_pan(self,event)
 
 class MyNavToolbar(NavigationToolbar2):

--- a/pyspeckit/spectrum/velocity_frames.py
+++ b/pyspeckit/spectrum/velocity_frames.py
@@ -19,7 +19,7 @@ def header_to_vlsr(header,**kwargs):
     elif 'DATE-OBS' in header:
         datestr =  header['DATE-OBS']
     else:
-        print "Not sure what date keywords exist..."
+        print("Not sure what date keywords exist...")
     jd = date_to_JD(datestr)
     if 'EQUINOX' in header:
         epoch = header['EQUINOX']


### PR DESCRIPTION
In trying to build pyspeckit locally I found a couple places where print statements are still used. 