### PR TITLE
MM H2CO fix

### DIFF
--- a/pyspeckit/spectrum/models/formaldehyde_mm.py
+++ b/pyspeckit/spectrum/models/formaldehyde_mm.py
@@ -169,7 +169,8 @@ def formaldehyde_mm_radex(xarr,
     spec = np.sum([
         (formaldehyde_mm_vtau(xarr, Tex=float(tex[ii]), tau=float(tau[ii]),
             xoff_v=xoff_v, width=width, **kwargs)
-        * (xarr.as_unit('GHz')>minfreq[ii]) * (xarr.as_unit('GHz')<maxfreq[ii])) for ii in xrange(len(tex))],
+        * (xarr.as_unit('GHz').value>minfreq[ii]) * 
+         (xarr.as_unit('GHz').value<maxfreq[ii])) for ii in xrange(len(tex))],
                 axis=0)
   
     return spec


### PR DESCRIPTION
@keflavich -- I think there was a change to units that wasn't passed down to the mmh2co fitter.  Comparing values seems to work.  Probably some PEP8 stuff is wrong that python can't handle.  