### PR TITLE
Correct dxarr creation on cropping

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -17,6 +17,8 @@ The 'grunt work' is performed by the :py:mod:`cubes` module
 from __future__ import print_function
 
 import time
+import sys
+import traceback
 import numpy as np
 import types
 import copy
@@ -847,7 +849,12 @@ class Cube(spectrum.Spectrum):
                     self.errcube[:,y,x] = sp.specfit.modelerrs
                     success = True
                 except Exception as ex:
+                    exc_traceback = sys.exc_info()[2]
                     log.exception("Fit number %i at %i,%i failed on error %s" % (ii,x,y, str(ex)))
+                    log.exception("Failure was in file {0} at line {1}".format(
+                        exc_traceback.tb_frame.f_code.co_filename,
+                        exc_traceback.tb_lineno,))
+                    traceback.print_tb(exc_traceback)
                     log.exception("Guesses were: {0}".format(str(gg)))
                     log.exception("Fitkwargs were: {0}".format(str(fitkwargs)))
                     success = False

--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -1313,7 +1313,7 @@ class CubeStack(Cube):
         self.xarr = SpectroscopicAxes([sp.xarr for sp in cubelist])
         self.cube = np.ma.concatenate([icube.cube for icube in cubelist])
 
-        if any([icube.errorcube is not None for icube in cubelist]):
+        if np.any([icube.errorcube is not None for icube in cubelist]):
             if all([icube.errorcube is not None for icube in cubelist]):
                 self.errorcube = np.ma.concatenate([icube.errorcube for icube in cubelist])
             else:

--- a/pyspeckit/spectrum/classes.py
+++ b/pyspeckit/spectrum/classes.py
@@ -269,7 +269,7 @@ class BaseSpectrum(object):
             self.data = self.data[argsort]
             self.error = self.error[argsort]
             self.xarr = self.xarr[argsort]
-            self.xarr.dxarr = np.diff(self.xarr.value)
+            self.xarr.make_dxarr()
 
     def write(self,filename,type=None,**kwargs):
         """

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -627,7 +627,7 @@ class Specfit(interactive.Interactive):
         if renormalize in ('auto',True):
             datarange = np.nanmax(self.spectofit[self.xmin:self.xmax]) - np.nanmin(self.spectofit[self.xmin:self.xmax])
             if abs(datarange) < 1e-9:
-                scalefactor = np.median(np.abs(self.spectofit))
+                scalefactor = np.nanmedian(np.abs(self.spectofit))
                 if not np.isfinite(scalefactor):
                     raise ValueError("non-finite scalefactor = {0} encountered.".format(scalefactor))
                 log.info("Renormalizing data by factor %e to improve fitting procedure"

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -378,7 +378,7 @@ class Specfit(interactive.Interactive):
         else:
             xmax = self.Spectrum.xarr.x_to_pix(xmax, xval_units=xunits)
 
-        dx = np.abs(self.Spectrum.xarr[xmin:xmax].cdelt(approx=True))
+        dx = np.abs(self.Spectrum.xarr[xmin:xmax].cdelt(approx=True).value)
 
         log.debug("xmin={0} xmax={1} dx={2} continuum={3}"
                   .format(xmin, xmax, dx, continuum))
@@ -393,10 +393,11 @@ class Specfit(interactive.Interactive):
                     continuum = self.Spectrum.baseline.basespec[center_pix]
                 elif continuum_as_baseline:
                     integrals[-1] += -(self.Spectrum.baseline.basespec[xmin:xmax] - continuum).sum() * dx
-                eqw.append( -integ / continuum)
+                eqw.append(-integ / continuum)
             if plot:
                 plot = False
-                if mycfg.WARN: warn( "Cannot plot multiple Equivalent Widths" )
+                if mycfg.WARN:
+                    warn("Cannot plot multiple Equivalent Widths")
         elif fitted:
             model = self.get_model(self.Spectrum.xarr[xmin:xmax],
                                    add_baseline=False)
@@ -467,7 +468,7 @@ class Specfit(interactive.Interactive):
             if annotate:
                 self.Spectrum.plotter.axis.legend(
                         [(matplotlib.collections.CircleCollection([0],facecolors=[plotcolor],edgecolors=[plotcolor]))],
-                        [('EQW: %0.3g' % eqw)], 
+                        [('EQW: %0.3g' % eqw)],
                         markerscale=0.01, borderpad=0.1, handlelength=0.1,
                         handletextpad=0.1, loc=loc)
             if self.Spectrum.plotter.autorefresh:
@@ -1408,14 +1409,14 @@ class Specfit(interactive.Interactive):
                     for x in integration_limits]
 
         if xmax - xmin > 1: # can only get cdelt if there's more than 1 pixel
-            dx = self.Spectrum.xarr[xmin:xmax].cdelt()
+            dx = self.Spectrum.xarr[xmin:xmax].cdelt().value
         else:
             dx = None
         if dx is None:
             #dx = np.abs(np.concatenate([np.diff(self.Spectrum.xarr),[0]]))
             #warn("Irregular X-axis.  The last pixel is ignored.")
             self.Spectrum.xarr.make_dxarr()
-            dx = self.Spectrum.xarr.dxarr
+            dx = self.Spectrum.xarr.dxarr.value
         else:
             # shouldn't shape be a 'property'?
             dx = np.repeat(np.abs(dx), self.Spectrum.shape)
@@ -1908,9 +1909,9 @@ class Specfit(interactive.Interactive):
         cd = xarr.dxarr.min()
         
         if interpolate_factor > 1:
-            newxarr = units.SpectroscopicAxis(np.arange(xarr.min().value-cd,
-                                                        xarr.max().value+cd,
-                                                        cd /
+            newxarr = units.SpectroscopicAxis(np.arange(xarr.min().value-cd.value,
+                                                        xarr.max().value+cd.value,
+                                                        cd.value /
                                                         float(interpolate_factor)
                                                        ),
                                               unit=xarr.unit,

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -625,9 +625,11 @@ class Specfit(interactive.Interactive):
         
         scalefactor = 1.0
         if renormalize in ('auto',True):
-            datarange = self.spectofit[self.xmin:self.xmax].max() - self.spectofit[self.xmin:self.xmax].min()
+            datarange = np.nanmax(self.spectofit[self.xmin:self.xmax]) - np.nanmin(self.spectofit[self.xmin:self.xmax])
             if abs(datarange) < 1e-9:
                 scalefactor = np.median(np.abs(self.spectofit))
+                if not np.isfinite(scalefactor):
+                    raise ValueError("non-finite scalefactor = {0} encountered.".format(scalefactor))
                 log.info("Renormalizing data by factor %e to improve fitting procedure"
                          % scalefactor)
                 self.spectofit /= scalefactor

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -1804,6 +1804,8 @@ class Specfit(interactive.Interactive):
         >>> p0 = emcee_ensemble.p0 * (np.random.randn(*emcee_ensemble.p0.shape) / 10. + 1.0)
         >>> pos,logprob,state = emcee_ensemble.run_mcmc(p0,100)
         """
+        import emcee
+
         if hasattr(self.fitter,'get_emcee_ensemblesampler'):
             nwalkers = (self.fitter.npars * self.fitter.npeaks + self.fitter.vheight) * 2
             emc = self.fitter.get_emcee_ensemblesampler(self.Spectrum.xarr,

--- a/pyspeckit/spectrum/interactive.py
+++ b/pyspeckit/spectrum/interactive.py
@@ -488,6 +488,9 @@ class Interactive(object):
                     x1 = self.Spectrum.xarr.x_to_pix(x1)
                     # WCS units should be end-inclusive
                     x2 = self.Spectrum.xarr.x_to_pix(x2)+1
+                log.debug("Exclusion pixels: {0} to {1}".format(x1,x2))
+                if x1 > x2:
+                    x1,x2 = x2,x1
                 self.includemask[x1:x2] = False
         elif exclude is not None:
             log.error("An 'exclude' keyword was specified with an odd number "

--- a/pyspeckit/spectrum/interactive.py
+++ b/pyspeckit/spectrum/interactive.py
@@ -488,9 +488,12 @@ class Interactive(object):
                     x1 = self.Spectrum.xarr.x_to_pix(x1)
                     # WCS units should be end-inclusive
                     x2 = self.Spectrum.xarr.x_to_pix(x2)+1
+                    # correct for order if WCS units are used
+                    # if pixel units are being used, we assume the user has
+                    # done so intentionally
+                    if x1 > x2:
+                        x1,x2 = x2,x1
                 log.debug("Exclusion pixels: {0} to {1}".format(x1,x2))
-                if x1 > x2:
-                    x1,x2 = x2,x1
                 self.includemask[x1:x2] = False
         elif exclude is not None:
             log.error("An 'exclude' keyword was specified with an odd number "

--- a/pyspeckit/spectrum/tests/test_units.py
+++ b/pyspeckit/spectrum/tests/test_units.py
@@ -218,20 +218,20 @@ class TestUnits(object):
         # regression for issue 175
 
         xx = np.linspace(-50,50)*u.km/u.s
-        dx = np.mean(np.diff(xx)).value
+        dx = np.mean(np.diff(xx))
         xarr = pyspeckit.units.SpectroscopicAxis(xx, refX=5*u.GHz)
 
-        assert xarr.cdelt() == dx
+        np.testing.assert_almost_equal(xarr.cdelt().value, dx.value)
         assert len(xarr.dxarr) == len(xarr)
 
         xarr = pyspeckit.units.SpectroscopicAxis(xx, refX=5*u.GHz)
 
         # check both orders: dxarr is a property, so this could be different
         assert len(xarr.dxarr) == len(xarr)
-        assert xarr.cdelt() == dx
+        np.testing.assert_almost_equal(xarr.cdelt().value, dx.value)
 
         xarr2 = xarr[10:-10]
-        assert xarr2.cdelt() == dx
+        np.testing.assert_almost_equal(xarr2.cdelt().value, dx.value)
         assert len(xarr2) == len(xarr2.dxarr)
 
 

--- a/pyspeckit/spectrum/tests/test_units.py
+++ b/pyspeckit/spectrum/tests/test_units.py
@@ -214,6 +214,28 @@ class TestUnits(object):
         assert np.all(mask[:25])
         assert np.all(~mask[25:])
 
+    def test_cdelt(self):
+        # regression for issue 175
+
+        xx = np.linspace(-50,50)*u.km/u.s
+        dx = np.mean(np.diff(xx)).value
+        xarr = pyspeckit.units.SpectroscopicAxis(xx, refX=5*u.GHz)
+
+        assert xarr.cdelt() == dx
+        assert len(xarr.dxarr) == len(xarr)
+
+        xarr = pyspeckit.units.SpectroscopicAxis(xx, refX=5*u.GHz)
+
+        # check both orders: dxarr is a property, so this could be different
+        assert len(xarr.dxarr) == len(xarr)
+        assert xarr.cdelt() == dx
+
+        xarr2 = xarr[10:-10]
+        assert xarr2.cdelt() == dx
+        assert len(xarr2) == len(xarr2.dxarr)
+
+
+
 
 if __name__=="__main__":
     unit_from='GHz'

--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -739,7 +739,9 @@ class SpectroscopicAxis(u.Quantity):
 
     def make_dxarr(self, coordinate_location='center'):
         """
-        Create a "delta-x" array corresponding to the X array.
+        Create a "delta-x" array corresponding to the X array.  It will have
+        the same length as the input array, which is achieved by concatenating
+        an extra pixel somewhere.
 
         Parameter
         ----------
@@ -759,6 +761,7 @@ class SpectroscopicAxis(u.Quantity):
             self._dxarr = np.concatenate([dxarr[:1],dxarr])
         else:
             raise ValueError("Invalid coordinate location.")
+        self._dxarr._unit = self.unit
 
     def cdelt(self, tolerance=1e-8, approx=False):
         """

--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -510,11 +510,12 @@ class SpectroscopicAxis(u.Quantity):
         self.center_frequency = getattr(obj, 'center_frequency', None)
         self.center_frequency_unit = getattr(obj, 'center_frequency_unit', None)
         self._equivalencies = getattr(obj, 'equivalencies', [])
+        # instead of making dxarr on init, make it on first use (see property dxarr)
         # moved from __init__ - needs to be done whenever viewed
         # (this is slow, though - may be better not to do this)
-        if self.shape and self.dtype != np.dtype('bool'): # check to make sure non-scalar
-            # can't use make_dxarr here! infinite recursion =(
-            self.dxarr = np.diff(np.array(self))
+        #if self.shape and self.dtype != np.dtype('bool'): # check to make sure non-scalar
+        #    # can't use make_dxarr here! infinite recursion =(
+        #    self.dxarr = np.diff(np.array(self))
 
     def __array_wrap__(self,out_arr,context=None):
         """
@@ -665,9 +666,9 @@ class SpectroscopicAxis(u.Quantity):
         self.flags.writeable=False
         if make_dxarr:
             self.make_dxarr()
-        elif hasattr(self, 'dxarr'):
+        elif hasattr(self, '_dxarr'):
             # remove the old, wrong one
-            del self.dxarr
+            del self._dxarr
 
 
     def as_unit(self, unit, equivalencies=[], velocity_convention=None, refX=None,
@@ -728,6 +729,14 @@ class SpectroscopicAxis(u.Quantity):
 
         return self.to(unit, equivalencies=self.equivalencies)
 
+    @property
+    def dxarr(self):
+        if hasattr(self, '_dxarr'):
+            return self._dxarr
+        else:
+            self.make_dxarr()
+            return self._dxarr
+
     def make_dxarr(self, coordinate_location='center'):
         """
         Create a "delta-x" array corresponding to the X array.
@@ -743,11 +752,11 @@ class SpectroscopicAxis(u.Quantity):
         """
         dxarr = np.diff(self)
         if self.size <= 2:
-            self.dxarr = np.ones(self.size)*dxarr
+            self._dxarr = np.ones(self.size)*dxarr
         elif coordinate_location in ['left','center']:
-            self.dxarr = np.concatenate([dxarr,dxarr[-1:]])
+            self._dxarr = np.concatenate([dxarr,dxarr[-1:]])
         elif coordinate_location in ['right']:
-            self.dxarr = np.concatenate([dxarr[:1],dxarr])
+            self._dxarr = np.concatenate([dxarr[:1],dxarr])
         else:
             raise ValueError("Invalid coordinate location.")
 
@@ -763,12 +772,15 @@ class SpectroscopicAxis(u.Quantity):
         approx : bool
             Return the mean DX even if it is inaccurate
         """
-        if not hasattr(self,'dxarr'): # if cropping happens...
+        if not hasattr(self,'_dxarr'): # if cropping happens...
             self.make_dxarr()
         if len(self) <= 1:
             raise ValueError("Cannot have cdelt of length-%i array" % len(self))
         if approx or abs(self.dxarr.max()-self.dxarr.min())/abs(self.dxarr.min()) < tolerance:
             return self.dxarr.mean().flat[0]
+        else:
+            raise ValueError("Spectral axis is not linear to within {0}.  "
+                             "cdelt is not well-defined.".format(tolerance))
 
     def _make_header(self, tolerance=1e-8):
         """
@@ -884,6 +896,10 @@ class SpectroscopicAxis(u.Quantity):
         if unit is not None:
             view._unit = unit
 
+        # any slice needs to regenerate its dxarr
+        if hasattr(view, '_dxarr'):
+            del view._dxarr
+
         #DEBUG print("unit is {1}, self.unit is {2}, class is {0}, viewtype={3}".format(subclass, unit, self.unit, type(view)))
         return view
 
@@ -898,7 +914,8 @@ def merge_equivalencies(old_equivalencies, new_equivalencies):
 
     for equivalency in total_equivalencies:
         equivalency_id = equivalency[0].to_string()+equivalency[1].to_string()
-        if equivalency_id in seen: continue
+        if equivalency_id in seen:
+            continue
         seen[equivalency_id] = 1
         result.append(equivalency)
     return result


### PR DESCRIPTION
If you cropped a spectrum or sliced an `xarr`, the resulting `dxarr` (and therefore `cdelt`) would be incorrect.