### PR TITLE
Fitting float32 spectra will result in gnorm=0 errors

### DIFF
--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -648,9 +648,11 @@ class Specfit(interactive.Interactive):
                     if par.scaleable:
                         guesses[jj] /= scalefactor
 
-        xtofit = self.Spectrum.xarr[self.xmin:self.xmax][~self.mask_sliced]
-        spectofit = self.spectofit[self.xmin:self.xmax][~self.mask_sliced]
-        err = self.errspec[self.xmin:self.xmax][~self.mask_sliced]
+        # all fit data must be float64, otherwise the optimizers may take steps
+        # less than the precision of the data and get stuck
+        xtofit = self.Spectrum.xarr[self.xmin:self.xmax][~self.mask_sliced].astype('float64')
+        spectofit = self.spectofit[self.xmin:self.xmax][~self.mask_sliced].astype('float64')
+        err = self.errspec[self.xmin:self.xmax][~self.mask_sliced].astype('float64')
 
         if parinfo is not None:
             self._validate_parinfo(parinfo, mode='fix')
@@ -697,7 +699,8 @@ class Specfit(interactive.Interactive):
         for par in self.parinfo:
             if par.scaleable:
                 par.value = par.value * scalefactor
-                par.error = par.error * scalefactor
+                if par.error is not None:
+                    par.error = par.error * scalefactor
 
         self.modelpars = self.parinfo.values
         self.modelerrs = self.parinfo.errors

--- a/pyspeckit/spectrum/models/lte_molecule.py
+++ b/pyspeckit/spectrum/models/lte_molecule.py
@@ -40,6 +40,12 @@ def line_tau_cgs(tex, total_column, partition_function, degeneracy, frequency,
     # equation 29 in Mangum 2015
     #taudnu = (eightpicubed * frequency * dipole_moment**2 / threehc *
     #             (np.exp(frequency*h_cgs/(kb_cgs*tex))-1) * N_upper)
+
+    # substitute eqn 11:
+    # Aij = 64 pi^4 nu^3 / (3 h c^3) |mu ul|^2
+    # becomes
+    # dipole_moment^2 = 3 h c^3 Aij / ( 64 pi^4 nu^3 )
+
     taudnu = ((c_cgs**2/(8*np.pi*frequency**2) * einstein_A * N_upper)*
               (np.exp(frequency*h_cgs/(kb_cgs*tex))-1))
 


### PR DESCRIPTION
As reported by E. Mills: if you load data with dtype=float32, it will fail to
fit (with either mpfit or lmfit) because the step size is equivalent to zero
when expressed as a 32-bit float.  This PR fixes the issue.