### PR TITLE
Typo in upper limits error message

### DIFF
--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -2001,7 +2001,7 @@ class Specfit(interactive.Interactive):
                         any_out_of_range.append("gt:close")
                 else:
                     raise ValueError("{0} is greater than the upper limit {1}"
-                                     .format(param.value, param.limits[0]))
+                                     .format(param.value, param.limits[1]))
             elif mode == 'check':
                 any_out_of_range.append(False)
 


### PR DESCRIPTION
Got this error this morning, thought I was still asleep: 
`Fit number 0 at 25,51 failed on error 45.0 is greater than the upper limit 40.0`