### PR TITLE
Change the default integral=True to False in fiteach

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -599,11 +599,11 @@ class Cube(spectrum.Spectrum):
 
     def fiteach(self, errspec=None, errmap=None, guesses=(), verbose=True,
                 verbose_level=1, quiet=True, signal_cut=3, usemomentcube=None,
-                blank_value=0, integral=True, direct=False, absorption=False,
-                use_nearest_as_guess=False, use_neighbor_as_guess=False,
-                start_from_point=(0,0), multicore=1, position_order=None,
-                continuum_map=None, prevalidate_guesses=False, maskmap=None,
-                **fitkwargs):
+                blank_value=0, integral=False, direct_integral=False,
+                absorption=False, use_nearest_as_guess=False,
+                use_neighbor_as_guess=False, start_from_point=(0,0),
+                multicore=1, position_order=None, continuum_map=None,
+                prevalidate_guesses=False, maskmap=None, **fitkwargs):
         """
         Fit a spectrum to each valid pixel in the cube
 
@@ -674,7 +674,10 @@ class Cube(spectrum.Spectrum):
         integral : bool
             If set, the integral of each spectral fit will be computed and
             stored in the attribute ``.integralmap``
-
+        direct_integral : bool
+            Return the integral of the *spectrum* (as opposed to the fitted
+            model) over a range defined by the `integration_limits` if specified or
+            `threshold` otherwise 
         """
         if 'multifit' in fitkwargs:
             log.warning("The multifit keyword is no longer required.  All fits "
@@ -867,7 +870,7 @@ class Cube(spectrum.Spectrum):
 
                 # keep this out of the 'try' statement
                 if integral and success:
-                    self.integralmap[:,y,x] = sp.specfit.integral(direct=direct,
+                    self.integralmap[:,y,x] = sp.specfit.integral(direct=direct_integral,
                                                                   return_error=True)
                 self.has_fit[y,x] = success
             else:

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -313,10 +313,10 @@ class Specfit(interactive.Interactive):
             else:
                 raise ValueError("Guess and parinfo were somehow invalid.")
         else:
-            print("Can't fit with given fittype {0}:"
-                  " it is not Registered as a fitter.".format(self.fittype))
-            return
-        if save: self.savefit()
+            raise ValueError("Can't fit with given fittype {0}:"
+                             " it is not Registered as a fitter.".format(self.fittype))
+        if save:
+            self.savefit()
 
     def EQW(self, plot=False, plotcolor='g', fitted=True, continuum=None,
             components=False, annotate=False, alpha=0.5, loc='lower left',
@@ -1445,15 +1445,16 @@ class Specfit(interactive.Interactive):
             
             # the model considered here must NOT include the baseline!
             # if it does, you'll get the integral of the continuum
-            fullmodel = self.get_full_model(add_baseline=False)
+            #fullmodel = self.get_full_model(add_baseline=False)
 
             if self.Spectrum.xarr.cdelt() is not None:
                 dx = np.median(dx)
                 integ = self.fitter.integral(self.modelpars, dx=dx, **kwargs)
                 if return_error:
-                    if mycfg.WARN: print("WARNING: The computation of the error "
-                                         "on the integral is not obviously "
-                                         "correct or robust... it's just a guess.")
+                    if mycfg.WARN:
+                        warn("WARNING: The computation of the error "
+                             "on the integral is not obviously "
+                             "correct or robust... it's just a guess.")
                     OK = self.model_mask(threshold=threshold, add_baseline=False)
                     error = np.sqrt((self.errspec[OK]**2).sum()) * dx
                     #raise NotImplementedError("We haven't written up correct error estimation for integrals of fits")


### PR DESCRIPTION
It was producing too many warnings in tests and isn't often used, it just makes
computations more expensive.

@vlas-sokolov, you're one of the main users of this feature at present: any
opposition to this change?