### PR TITLE
Don't require refX for line_id plotting

### DIFF
--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -639,7 +639,10 @@ class Plotter(object):
             assert velocity_offset.unit.is_equivalent(u.km/u.s)
 
         doppler = getattr(u, 'doppler_{0}'.format(velocity_convention))
-        equivalency = doppler(self.Spectrum.xarr.refX)
+        if self.Spectrum.xarr.refX is not None:
+            equivalency = doppler(self.Spectrum.xarr.refX)
+        else:
+            equivalency = doppler(self.Spectrum.xarr.as_unit(u.GHz)[0])
 
         xvals = []
         for xv in line_xvals:


### PR DESCRIPTION
This often resulted in annoying error messages of the form:

```
File "/Users/adam/repos/pyspeckit/pyspeckit/spectrum/plotters.py", line 642, in line_ids
equivalency = doppler(self.Spectrum.xarr.refX)
File "/Users/adam/repos/astropy/astropy/units/equivalencies.py", line 248, in doppler_radio
assert_is_spectral_unit(rest)
File "/Users/adam/repos/astropy/astropy/units/equivalencies.py", line 532, in assert_is_spectral_unit
raise UnitsError("The 'rest' value must be a spectral equivalent "
UnitsError: The 'rest' value must be a spectral equivalent (frequency, wavelength, or energy).
```