### PR TITLE
cube slice now updates header!

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -289,7 +289,7 @@ class Cube(spectrum.Spectrum):
         self.header.update(newhead)
 
     def slice(self, start=None, stop=None, unit='pixel', preserve_fits=False,
-              copy=True):
+              copy=True, update_header=False):
         """
         Slice a cube along the spectral axis
         (equivalent to "spectral_slab" from the spectral_cube package)
@@ -302,6 +302,8 @@ class Cube(spectrum.Spectrum):
             stop of slice
         unit : str
             allowed values are any supported physical unit, 'pixel'
+        update_header : bool
+            modifies the header of the spectral cube according to the slice
         """
 
         x_in_units = self.xarr.as_unit(unit)
@@ -334,7 +336,8 @@ class Cube(spectrum.Spectrum):
             newcube.baseline.order = self.baseline.order
 
         # modify the header in the new cube
-        newcube._update_header_from_xarr()
+        if update_header:
+            newcube._update_header_from_xarr()
 
         # TODO: update the wcs as well
 

--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -274,6 +274,7 @@ class Cube(spectrum.Spectrum):
         self.xarr._make_header()
         sp_naxis = self._spectral_axis_number
 
+        # change keywords in xarr._make_header from, e.g., CRPIX1 to CRPIX3
         newhead = {(key.replace('1', str(sp_naxis))
                     if key.endswith('1') else key): val
                    for key, val in self.xarr.wcshead.iteritems()}

--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -339,8 +339,12 @@ class Cube(spectrum.Spectrum):
         # modify the header in the new cube
         if update_header:
             newcube._update_header_from_xarr()
-
-        # TODO: update the wcs as well
+            # create a new wcs instance from the updated header
+            newcube.wcs = wcs.WCS(newcube.header)
+            newcube.wcs.wcs.fix()
+            newcube._spectral_axis_number = newcube.wcs.wcs.spec + 1
+            newcube._first_cel_axis_num = np.where(newcube.wcs.wcs.axis_types
+                                                   // 1000 == 2)[0][0] + 1
 
         return newcube
 

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -263,7 +263,7 @@ def test_slice_header(cubefile='test.fits'):
 
     spc = Cube(cubefile)
 
-    spc_cut = spc.slice(-1, 1, 'km/s')
+    spc_cut = spc.slice(-1, 1, 'km/s', update_header = True)
     naxis3 = spc_cut.header['NAXIS3']
     crval3 = spc_cut.header['CRVAL3']
     crpix3 = spc_cut.header['CRPIX3']

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -253,3 +253,16 @@ def test_noerror_cube(cubefile='test.fits'):
         warnings.simplefilter('default')
         spc.fiteach(fittype='gaussian', guesses=[0.7,0.5,0.8], signal_cut=0)
     assert np.all(spc.has_fit)
+
+def test_slice_header(cubefile='test.fits'):
+    """
+    Regression test for [make a PR!]
+    """
+    if not os.path.exists(cubefile):
+        make_test_cube((100,9,9),cubefile)
+
+    spc = Cube(cubefile)
+    spc_cut = spc.slice(-1, 1, 'km/s')
+
+    # TODO: this lets *bad* headers through, make another check
+    assert spc_cut.header['NAXIS3'] == spc_cut.xarr.size

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -262,9 +262,12 @@ def test_slice_header(cubefile='test.fits'):
         make_test_cube((100,9,9),cubefile)
 
     spc = Cube(cubefile)
-    spc_cut = spc.slice(-1, 1, 'km/s')
 
-    assert spc_cut.header['NAXIS3'] == spc_cut.xarr.size
-    assert (spc_cut.xarr.x_to_pix(spc_cut.header['CRVAL3'],
-                                  spc_cut.header['CUNIT3']) + 1
-            == spc_cut.header['CRPIX3'])
+    spc_cut = spc.slice(-1, 1, 'km/s')
+    naxis3 = spc_cut.header['NAXIS3']
+    crval3 = spc_cut.header['CRVAL3']
+    crpix3 = spc_cut.header['CRPIX3']
+    cunit3 = spc_cut.header['CUNIT3']
+
+    assert naxis3 == spc_cut.xarr.size
+    assert spc_cut.xarr.x_to_pix(crval3, cunit3) + 1 == crpix3

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -264,5 +264,7 @@ def test_slice_header(cubefile='test.fits'):
     spc = Cube(cubefile)
     spc_cut = spc.slice(-1, 1, 'km/s')
 
-    # TODO: this lets *bad* headers through, make another check
     assert spc_cut.header['NAXIS3'] == spc_cut.xarr.size
+    assert (spc_cut.xarr.x_to_pix(spc_cut.header['CRVAL3'],
+                                  spc_cut.header['CUNIT3']) + 1
+            == spc_cut.header['CRPIX3'])

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -256,7 +256,7 @@ def test_noerror_cube(cubefile='test.fits'):
 
 def test_slice_header(cubefile='test.fits'):
     """
-    Regression test for [make a PR!]
+    Regression test for 184
     """
     if not os.path.exists(cubefile):
         make_test_cube((100,9,9),cubefile)


### PR DESCRIPTION
Cube headers and cube wcs's were untouched by the likes of `spc.slice()`. This PR brings header modification into the fold. If we're good to go I'll write up the update for a new wcs instance as well. Is slice() the only place the spectral axis needs to be modified?

Most importantly, this time it comes with a test!