### PR TITLE
Prevent divide-by-zero renormalization

### DIFF
--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -631,6 +631,9 @@ class Specfit(interactive.Interactive):
                 scalefactor = np.nanmedian(np.abs(self.spectofit))
                 if not np.isfinite(scalefactor):
                     raise ValueError("non-finite scalefactor = {0} encountered.".format(scalefactor))
+                elif scalefactor == 0:
+                    raise ValueError("scalefactor = {0} encountered, which will result "
+                                     "in divide-by-zero errors".format(scalefactor))
                 log.info("Renormalizing data by factor %e to improve fitting procedure"
                          % scalefactor)
                 self.spectofit /= scalefactor

--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -607,15 +607,16 @@ class SpectroscopicAxis(u.Quantity):
         Given an X coordinate in SpectroscopicAxis' units, return whether the pixel is in range
         """
         if hasattr(xval, 'unit'):
-            # note that the .value's are outside: if you compare a Quantity, it
-            # will return an array of booleans, which always evaluates to True
-            # even if that 0-dimensional array (scalar) is False
-            return bool((xval > self.min()) and (xval < self.max()))
+            return bool((xval > self.as_unit(xval.unit).min()) and
+                        (xval < self.as_unit(xval.unit).max()))
         else:
             warnings.warn("The xvalue being compared in "
                           "SpectroscopicAxis.in_range has no unit.  "
                           "Assuming the unit is the same as the current "
                           "axis unit.")
+            # note that the .value's are outside: if you compare a Quantity, it
+            # will return an array of booleans, which always evaluates to True
+            # even if that 0-dimensional array (scalar) is False
             return bool((xval > self.min().value) and (xval < self.max().value))
 
     def x_to_coord(self, xval, xunit, verbose=False):


### PR DESCRIPTION
This can come up with all-zero spectra, which are basically invalid anyway, or those corner cases where the median is actually zero