### PR TITLE
CubeStack.__init__ can get trapped in an infinite loop

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -1385,9 +1385,11 @@ class CubeStack(Cube):
         self.data = self.cube[:,y0,x0]
         self.error = self.errorcube[:,y0,x0] if self.errorcube is not None else None
 
-        self.header = cubelist[0].header
+        self.header = cubelist[0].header.copy()
         for cube in cubelist:
             for key,value in cube.header.items():
+                if key in ['HISTORY', 'COMMENT']:
+                    continue
                 self.header[key] = value
 
         if self.header:


### PR DESCRIPTION
Squashing two spectral cubes via `CubeStack` class can sometimes break in Python 3. If in the following example the header of `nh311.fits` contains either `HISTORY` or `COMMENT` keywords, calling `CubeStack` results in an infinite loop:

```python
from pyspeckit import Cube, CubeStack
nh311, nh322 = Cube('nh311.fits'), Cube('nh322.fits')
cubes = CubeStack([nh311, nh322])
```

The new header is a shallow copy of the original one in the init method. Essentially, this is what happens when `CubeStack()` is called:

```python
# dummy "original" header
from astropy.io import fits
head = fits.Header()
head['foo'] = "just a regular keyword", "nothing to worry about"
head['HISTORY'] = "you can't contain me!"

# this is what happens when CubeStack is created:
head_new = head
for key, val in head.items():
        head_new[key] = val
```

Now for Python 2 this simply results in a duplicate `HISTORY` or `COMMENT` keywords (that get a [special treatment](http://docs.astropy.org/en/stable/io/fits/api/headers.html) in astropy), but for Python 3 and its `head.items()` generator the snippet above is forever stuck rewriting `HISTORY` keywords.