### PR TITLE
Changes in Cube tests

### DIFF
--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -170,7 +170,7 @@ def test_fiteach(save_cube=None, save_pars=None, show_plot=False):
     err_frac = map_in_bounds[~map_in_bounds].size / float(map_sigma_post.size)
 
     assert map_seed == 0
-    assert err_frac == 0.39
+    assert err_frac == 0.34
 
 def test_get_modelcube(cubefile=None, parfile=None):
     """

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -50,7 +50,6 @@ def make_test_cube(shape=(30,9,9), outfile='test.fits', snr=30,
     noise_cube = np.random.normal(loc = 0, scale = noise_std,
                                   size = signal_cube.shape)
     test_cube = signal_cube + noise_cube
-
     # making a simple header for the test cube:
     test_hdu = fits.PrimaryHDU(test_cube)
     # the strange cdelt values are a workaround
@@ -63,7 +62,7 @@ def make_test_cube(shape=(30,9,9), outfile='test.fits', snr=30,
                'CRPIX1': 9, 'CRPIX2': 0, 'CRPIX3': 5,
                'CUNIT1': 'deg', 'CUNIT2': 'deg', 'CUNIT3': 'km s-1',
                'BMAJ': cdelt2 * 3, 'BMIN': cdelt2 * 3, 'BPA': 0.0,
-               'BUNIT' : 'K', 'EQUINOX': 2000.0}
+               'BUNIT' : 'K', 'EQUINOX': 2000.0, 'RESTFREQ': 300e9}
     # write out some values used to generate the cube:
     keylist['SIGMA' ] = abs(sigma1d*cdelt3), 'in units of CUNIT3'
     keylist['RMSLVL'] = noise_std


### PR DESCRIPTION
The noise for the test cube was uniformly - not normally - distributed. I edited the `make_test_cube` function to sample noise from Gaussian distribution and updated the tests to reflect the change. For instance, `test_get_modelcube` check now makes much more sense - after the fit, the cube residuals are broadly consistent with 1σ noise level.

Apart from that, I moved some import statements around, made minor edits, and added a docstring for `make_test_cube` function.