### PR TITLE
hydrogen.find_lines has an incompatibility with astropy

### DIFF
--- a/pyspeckit/spectrum/models/extinction.py
+++ b/pyspeckit/spectrum/models/extinction.py
@@ -5,7 +5,7 @@ Returns multiplicative factors...
 """
 from pyspeckit.spectrum import units
 
-def extinction_function(wavelength, tau0=0, alpha=0, lambda0=2.5, lambda_units='microns'):
+def extinction_function(wavelength, tau0=0, alpha=0, lambda0=2.5, lambda_units='micron'):
     """
     Returns a model with modelfunc replaced...
     """

--- a/pyspeckit/spectrum/models/hydrogen.py
+++ b/pyspeckit/spectrum/models/hydrogen.py
@@ -211,7 +211,7 @@ def find_lines(xarr):
     Given a :class:`pyspeckit.units.SpectrosopicAxis` instance, finds all the
     lines that are in bounds.  Returns a list of line names.
     """
-    return [linename for (linename,lam) in iteritems(wavelength) if xarr.as_unit('microns').in_range(lam)]
+    return [linename for (linename,lam) in iteritems(wavelength) if xarr.as_unit('micron').in_range(lam)]
 
 def hydrogen_fitter(sp, temperature=10000, tiedwidth=False):
     """
@@ -241,8 +241,8 @@ def hydrogen_fitter(sp, temperature=10000, tiedwidth=False):
 
     dx = np.median(sp.xarr.dxarr)
 
-    subguesses = [[ sp.data[sp.xarr.as_unit('microns').x_to_pix(wavelength[line])],
-        sp.xarr.x_to_coord(wavelength[line],'microns'),
+    subguesses = [[ sp.data[sp.xarr.as_unit('micron').x_to_pix(wavelength[line])],
+        sp.xarr.x_to_coord(wavelength[line],'micron'),
         dx*2.0 ] for line in lines]
     guesses = [g for sublist in subguesses for g in sublist]
 
@@ -283,7 +283,7 @@ def hydrogen_model(xarr, amplitude=1.0, width=0.0, velocity=0.0, a_k=0.0, temper
     reference_line = lines[0]
 
     model = np.array(xarr * 0)
-    xarr = xarr.as_unit('microns')
+    xarr = xarr.as_unit('micron')
 
 
     lw = width / units.speedoflight_kms * wavelength[reference_line]
@@ -314,7 +314,7 @@ def add_to_registry(sp):
             parnames=['amplitude','width','velocity','extinction'],
             parlimited=[(True,False),(True,False),(False,False), (True,False)], 
             parlimits=[(0,0), (0,0), (0,0), (0,0)],
-            fitunits='microns')
+            fitunits='micron')
 
     sp.Registry.add_fitter('hydrogen', extincted_hydrogen_emission,
             extincted_hydrogen_emission.npars)

--- a/pyspeckit/spectrum/readers/read_class.py
+++ b/pyspeckit/spectrum/readers/read_class.py
@@ -1421,7 +1421,7 @@ def read_class(filename, downsample_factor=None, sourcename=None,
 def downsample_header(hdr, downsample_factor):
     for k in ('NCHAN','NPOIN','DATALEN'):
         if k in hdr:
-            hdr[k] = hdr[k] / downsample_factor
+            hdr[k] = int((hdr[k] / downsample_factor))
     # maybe wrong? h['RCHAN'] = (h['RCHAN']-1) / downsample_factor + 1
     scalefactor = 1./downsample_factor
     hdr['RCHAN'] = (hdr['RCHAN']-1)*scalefactor + 0.5 + scalefactor/2.


### PR DESCRIPTION
trying to use:

pyspeckit.spectrum.models.hydrogen.find_lines(sp.xarr)

returned an error (traceback below) which has nothing to do with my input spectrum. It stems from hydrogen.py changing the xarr to 'microns', while astropy is looking for 'micron' (no s).

changing 'microns' -> 'micron' on line 214 of hydrogen.py (and re-compiling) fixed the problem in my installation (pyspeckit-c8c7ab014df0, downloaded from bitbucket 21-dec-2016, astropy version 1.2.1)

---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-6-ea0c808fc7c8> in <module>()
----> 1 execfile('quantify_h30a.py')

/RESEARCH/BitBucket/msf_disks/quantify_h30a.py in <module>()
     86 
     87 pyspeckit.spectrum.models.hydrogen.add_to_registry(sp)
---> 88 pyspeckit.spectrum.models.hydrogen.find_lines(sp.xarr)
     89 
     90 

/Users/pamelaklaassen/anaconda/lib/python2.7/site-packages/pyspeckit/spectrum/models/hydrogen.pyc in find_lines(xarr)
    212     lines that are in bounds.  Returns a list of line names.
    213     """
--> 214     return [linename for (linename,lam) in iteritems(wavelength) if xarr.as_unit('microns').in_range(lam)]
    215 
    216 def hydrogen_fitter(sp, temperature=10000, tiedwidth=False):

/Users/pamelaklaassen/anaconda/lib/python2.7/site-packages/pyspeckit/spectrum/units.pyc in as_unit(self, unit, equivalencies, velocity_convention, refX, refX_unit, center_frequency, center_frequency_unit, **kwargs)
    729             self._unit = u.Unit(self.unit)
    730 
--> 731         return self.to(unit, equivalencies=self.equivalencies)
    732 
    733     @property

/Users/pamelaklaassen/anaconda/lib/python2.7/site-packages/astropy/units/quantity.pyc in to(self, unit, equivalencies)
    649         if equivalencies == []:
    650             equivalencies = self._equivalencies
--> 651         unit = Unit(unit)
    652         new_val = self.unit.to(unit, self.view(np.ndarray),
    653                                equivalencies=equivalencies)

/Users/pamelaklaassen/anaconda/lib/python2.7/site-packages/astropy/units/core.pyc in __call__(self, s, represents, format, namespace, doc, parse_strict)
   1815                            .format(s, format_clause, six.text_type(e)))
   1816                     if parse_strict == 'raise':
-> 1817                         raise ValueError(msg)
   1818                     elif parse_strict == 'warn':
   1819                         warnings.warn(msg, UnitsWarning)

ValueError: 'microns' did not parse as unit: At col 0, microns is not a valid unit. Did you mean micron?

