### PR TITLE
Bug: When rescaling, the first iteration will scale many parameters incorrectly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,6 @@ matrix:
                PIP_DEPENDENCIES=''
         # Try older numpy versions
         - python: 2.7
-          env: NUMPY_VERSION=1.8 SETUP_CMD='test'
-        - python: 2.7
           env: NUMPY_VERSION=1.9 SETUP_CMD='test'
 
     allow_failures:

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -219,6 +219,7 @@ def test_get_modelcube_badpar(cubefile=None, parfile=None, sigma_threshold=5):
             fh.writeto('test_pars_bad.fits', overwrite=True)
         else:
             fh.writeto('test_pars_bad.fits', clobber=True)
+        fh.close()
         parfile  = 'test_pars_bad.fits'
         sp_cube = do_fiteach(save_cube=cubefile, save_pars=parfile)
     else:

--- a/pyspeckit/mpfit/mpfit.py
+++ b/pyspeckit/mpfit/mpfit.py
@@ -1137,6 +1137,7 @@ class mpfit:
             # Form (q transpose)*fvec and store the first n components in qtf
             catch_msg = 'forming (q transpose)*fvec'
             wa4 = fvec.copy()
+            log.log(5, 'Before optimizing wa4, value is ={0}'.format(wa4))
             try:
                 wa4._sharedmask = False # to deal with np1.11+ shared mask behavior: should not change anything
             except AttributeError:
@@ -1152,6 +1153,7 @@ class mpfit:
                     wa4[j:] = wj - fj * sum(fj*wj) / temp3
                 fjac[j,lj] = wa1[j]
                 qtf[j] = wa4[j]
+            log.log(5, 'After optimizing wa4, qtf={0}'.format(qtf))
             # From this point on, only the square matrix, consisting of the
             # triangle of R, is needed.
             fjac = fjac[0:n, 0:n]
@@ -1203,10 +1205,9 @@ class mpfit:
                                                    delta, wa1, wa2, par=par)
                 # Store the direction p and x+p. Calculate the norm of p
                 wa1 = -wa1
-                if debug:
-                    print("before parameter setting; wa1={0}".format(wa1))
-                    print("before parameter setting; wa2={0}".format(wa2))
-                    print("before parameter setting; params={0}".format(self.params))
+                log.log(5, "before parameter setting; wa1={0}".format(wa1))
+                log.log(5, "before parameter setting; wa2={0}".format(wa2))
+                log.log(5, "before parameter setting; params={0}".format(self.params))
 
                 if (qanylim == 0) and (qminmax == 0):
                     # No parameter limits, so just move to new position WA2
@@ -1961,7 +1962,7 @@ class mpfit:
     #
 
     def qrsolv(self, r, ipvt, diag, qtb, sdiag):
-        log.log(5, 'Entering qrsolv...')
+        log.log(5, 'Entering qrsolv... r={0} ipvt={1} diag={2} qtb={3}'.format(r, ipvt, diag, qtb))
         sz = r.shape
         # not used m = sz[0]
         n = sz[1]
@@ -2132,7 +2133,7 @@ class mpfit:
 
     def lmpar(self, r, ipvt, diag, qtb, delta, x, sdiag, par=None):
 
-        log.log(5, 'Entering lmpar...')
+        log.log(5, 'Entering lmpar... delta={0} x={1} sdiag={2} qtb={3}'.format(delta, x, sdiag, qtb))
         dwarf = self.machar.minnum
         machep = self.machar.machep
         sz = r.shape

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -318,10 +318,12 @@ class Specfit(interactive.Interactive):
                               annotate=annotate, parinfo=parinfo,
                               guesses=None, **kwargs)
             elif guesses is not None:
-                self.guesses = list(guesses) # always copy the input variable
+                if isinstance(guesses, tuple):
+                    guesses = list(guesses)
+                self.guesses = guesses
                 self.multifit(show_components=show_components, verbose=verbose,
                               debug=debug, use_lmfit=use_lmfit,
-                              guesses=list(guesses), annotate=annotate, **kwargs)
+                              guesses=guesses, annotate=annotate, **kwargs)
             else:
                 raise ValueError("Guess and parinfo were somehow invalid.")
         else:

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -321,7 +321,7 @@ class Specfit(interactive.Interactive):
                 self.guesses = list(guesses) # always copy the input variable
                 self.multifit(show_components=show_components, verbose=verbose,
                               debug=debug, use_lmfit=use_lmfit,
-                              guesses=guesses, annotate=annotate, **kwargs)
+                              guesses=list(guesses), annotate=annotate, **kwargs)
             else:
                 raise ValueError("Guess and parinfo were somehow invalid.")
         else:
@@ -617,9 +617,11 @@ class Specfit(interactive.Interactive):
                 del self.fitkwargs[kw]
 
         if guesses is None:
-            guesses = self.guesses
-        elif isinstance(guesses, string_types) and guesses in ('moment','moments'):
+            guesses = list(self.guesses)
+        elif isinstance(guesses, string_types) and guesses in ('moment', 'moments'):
             guesses = self.moments(vheight=False, **kwargs)
+        else:
+            guesses = list(guesses) # needs to be mutable, but needs to be a copy!!
 
         if parinfo is not None:
             if guesses is not None:
@@ -1633,9 +1635,9 @@ class Specfit(interactive.Interactive):
         """
         if fittype is None:
             fittype = self.fittype
-        return self.Registry.multifitters[fittype].moments(
-                self.Spectrum.xarr[self.xmin:self.xmax],
-                self.spectofit[self.xmin:self.xmax],  **kwargs)
+        return list(self.Registry.multifitters[fittype].moments(
+            self.Spectrum.xarr[self.xmin:self.xmax],
+            self.spectofit[self.xmin:self.xmax],  **kwargs))
 
     def button3action(self, event, debug=False, nwidths=1):
         """

--- a/pyspeckit/spectrum/models/model.py
+++ b/pyspeckit/spectrum/models/model.py
@@ -344,6 +344,12 @@ class SpectralModel(fitter.SimpleFitter):
         else:
             parvals = list(pars)
 
+        if np.any(np.isnan(parvals)):
+            raise ValueError("A parameter is NaN.  Unless you gave a NaN "
+                             "value directly, this is a bug and should be "
+                             "reported.  If you specified a NaN parameter, "
+                             "don't do that.")
+
         log.debug("pars to n_modelfunc: {0}, parvals:{1}".format(pars, parvals))
         def L(x):
             v = np.zeros(len(x))

--- a/pyspeckit/spectrum/tests/test_fitter.py
+++ b/pyspeckit/spectrum/tests/test_fitter.py
@@ -27,7 +27,7 @@ class TestFitter(object):
         with warnings.catch_warnings():
             # ignore warning about creating an empty header
             warnings.simplefilter('ignore')
-            self.sp_multi = Spectrum(xarr=x, data=y_multi_tiny)
+            self.sp_multi_tiny = Spectrum(xarr=x, data=y_multi_tiny)
 
 
     def test_init(self):


### PR DESCRIPTION
For optical spectra that have units <10^-9, e.g., ~10^-16 erg/s/cm^2/AA, the data are rescaled prior to fitting in order to minimize numerical issues when fitting (though I admit I don't know if that's still a reasonable concern any more).  There is a bug in the existing code in which, when performing a multi-peak fit, only the *first* peak will be scaled.  If you repeat the fit, in all subsequent fits, all of the peaks will be appropriately scaled.  This is because the scaling was determined based on a parameter that was not set properly.

Thanks @granttremblay for pointing this out.