### PR TITLE
Partial fix for Issue 210: register cold_ammonia_model

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ CHANGES
 Version 0.1.20 (unreleased)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
- - none yet
+    * Minor #210: add cold_ammonia to the registry
 
 Version 0.1.19 (2016-06-12)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -131,6 +131,7 @@ The default is gaussian ('g'), all options are listed below:
 # Declare default registry built in for all spectra
 default_Registry = Registry()
 default_Registry.add_fitter('ammonia',models.ammonia_model(),6,key='a')
+default_Registry.add_fitter('cold_ammonia',models.cold_ammonia_model(),6)
 default_Registry.add_fitter('ammonia_tau',models.ammonia_model_vtau(),6)
 # not implemented default_Registry.add_fitter(Registry,'ammonia',models.ammonia_model( ),6, ,key='A')
 default_Registry.add_fitter('formaldehyde',models.formaldehyde_fitter,3,key='F') # CAN'T USE f!  reserved for fitting

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -131,7 +131,7 @@ The default is gaussian ('g'), all options are listed below:
 # Declare default registry built in for all spectra
 default_Registry = Registry()
 default_Registry.add_fitter('ammonia',models.ammonia_model(),6,key='a')
-default_Registry.add_fitter('cold_ammonia',models.cold_ammonia_model(),6)
+default_Registry.add_fitter('cold_ammonia',models.ammonia.cold_ammonia_model(),6)
 default_Registry.add_fitter('ammonia_tau',models.ammonia_model_vtau(),6)
 # not implemented default_Registry.add_fitter(Registry,'ammonia',models.ammonia_model( ),6, ,key='A')
 default_Registry.add_fitter('formaldehyde',models.formaldehyde_fitter,3,key='F') # CAN'T USE f!  reserved for fitting


### PR DESCRIPTION
Just as it says, register the ammonia model.

This would normally have been attached to issue #210 but there seems to be a
bug in my `hub`.