### PR TITLE
force roundsmooth to int for numpy deprecation of non-int indices.

### DIFF
--- a/pyspeckit/spectrum/smooth.py
+++ b/pyspeckit/spectrum/smooth.py
@@ -28,10 +28,10 @@ def smooth(data, smooth, smoothtype='gaussian', downsample=True,
         'data' (assuming data is larger than the kernel)
     """
     
-    roundsmooth = round(smooth) # can only downsample by integers
+    roundsmooth = int(round(smooth)) # can only downsample by integers
 
     if downsample_factor is None and downsample:
-        downsample_factor = int(roundsmooth)
+        downsample_factor = roundsmooth
     elif downsample_factor is None:
         downsample_factor = 1
 


### PR DESCRIPTION
Fixes #213 

I moved the int() typecasting to surround `round`. I tested this change with a quick reduction and boxcar smoothing worked with the numpy 1.12.0 indexing.