### PR TITLE
Ammonia model in Python 3 with npeaks>1

### DIFF
--- a/pyspeckit/spectrum/models/ammonia.py
+++ b/pyspeckit/spectrum/models/ammonia.py
@@ -12,6 +12,8 @@ Module API
 ^^^^^^^^^^
 
 """
+from __future__ import division
+
 import numpy as np
 from ...mpfit import mpfit
 from ...spectrum.parinfo import ParinfoList,Parinfo
@@ -425,7 +427,7 @@ class ammonia_model(model.SpectralModel):
             # (n_modelfuncs = n_ammonia can be called directly)
             # n_modelfuncs doesn't care how many peaks there are
             if len(pars) % len(parnames) == 0:
-                parnames = [p for ii in range(len(pars)/len(parnames)) for p in parnames]
+                parnames = [p for ii in range(len(pars)//len(parnames)) for p in parnames]
                 npars = len(parvals) / self.npeaks
             else:
                 raise ValueError("Wrong array lengths passed to n_ammonia!")

--- a/pyspeckit/spectrum/models/tests/test_ammonia.py
+++ b/pyspeckit/spectrum/models/tests/test_ammonia.py
@@ -132,6 +132,29 @@ def test_cold_ammonia2():
 
     return spc
 
+def test_ammonia_x2():
+    kwargs = dict(lte=False, tkin=None, lines=('oneone', 'twotwo'))
+    redhot = dict(trot=25, tex=10, column=13, width=1, vcen=1)
+    bluecold = dict(trot=12, tex=7, column=13, width=.2, vcen=-1)
+    redhot.update(kwargs)
+    bluecold.update(kwargs)
+    sp_redhot = make_synthspec(**redhot)
+    sp_bluecold = make_synthspec(**bluecold)
+
+    sp = sp_redhot.copy()
+    sp.Registry.add_fitter('ammonia', ammonia.ammonia_model(), 6)
+    sp.specfit.fitter = sp.specfit.Registry.multifitters['ammonia']
+    sp.specfit.fitter.npeaks = 2
+    sp.data = sp_redhot.data + sp_bluecold.data
+    assert np.allclose(sp.data.max(), 0.301252, rtol=1e-5)
+
+    unpack_pars = lambda d: [d[key] for key in ['trot', 'tex',
+                             'column', 'width', 'vcen']]+[0]
+
+    model = sp.specfit.get_full_model(pars=unpack_pars(redhot)
+                                      +unpack_pars(bluecold))
+    assert np.allclose(sp.data, model, rtol=1e-5)
+
 """
 # debug work to make sure synthspectra look the same
 from pyspeckit.spectrum.models.tests import test_ammonia


### PR DESCRIPTION
Looks like python2-style division caused `n_ammonia` method of `ammonia_model` to break when ran in Python 3. Here's a snippet (added to tests) that reproduces the issue:
```python
from pyspeckit.spectrum.models.tests.test_ammonia import make_synthspec
from pyspeckit.spectrum.models import ammonia
import numpy as np

kwargs = dict(lte=False, tkin=None, lines=('oneone', 'twotwo'))
redhot = dict(trot=25, tex=10, column=13, width=1, vcen=1)
bluecold = dict(trot=12, tex=7, column=13, width=.2, vcen=-1)
redhot.update(kwargs)
bluecold.update(kwargs)
sp_redhot = make_synthspec(**redhot)
sp_bluecold = make_synthspec(**bluecold)

sp = sp_redhot.copy()
sp.Registry.add_fitter('ammonia', ammonia.ammonia_model(), 6)
sp.specfit.fitter = sp.specfit.Registry.multifitters['ammonia']
sp.specfit.fitter.npeaks = 2 
sp.data = sp_redhot.data + sp_bluecold.data
assert np.allclose(sp.data.max(), 0.301252, rtol=1e-5)

unpack_pars = lambda d: [d[key] for key in ['trot', 'tex',
                         'column', 'width', 'vcen']]+[0]

model = sp.specfit.get_full_model(pars=unpack_pars(redhot)
                                  +unpack_pars(bluecold))
assert np.allclose(sp.data, model, rtol=1e-5)
```

causing the following to be raised:

```
    426             # n_modelfuncs doesn't care how many peaks there are
    427             if len(pars) % len(parnames) == 0:
--> 428                 parnames = [p for ii in range(len(pars)/len(parnames)) for p in parnames]
    429                 npars = len(parvals) / self.npeaks
    430             else:

TypeError: 'float' object cannot be interpreted as an integer
```

So now we're importing division from the future - hope it doesn't break anything elsewhere. Also, am I adding single-spectra tests in right place?