### PR TITLE
parallelize get_modelcube

### DIFF
--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -168,7 +168,7 @@ def test_fiteach(save_cube=None, save_pars=None, show_plot=False):
     assert map_seed == 0
     assert err_frac == 0.34
 
-def test_get_modelcube(cubefile=None, parfile=None):
+def test_get_modelcube(cubefile=None, parfile=None, multicore=1):
     """
     Tests get_modelcube() method for Cube and CubeStack classes.
     If either cubefile or parfile isn't set, fill generate and
@@ -197,12 +197,13 @@ def test_get_modelcube(cubefile=None, parfile=None):
         spc.load_model_fit(parfile, npars=3)
         # calling CubeStack converted xarr units to GHz
         spc.xarr.convert_to_unit('km/s')
-        spc.get_modelcube()
+        spc.get_modelcube(multicore=multicore)
         resid_cube = spc.cube - spc._modelcube
         above1sig = (resid_cube.std(axis=0) > map_rms).flatten()
         assert above1sig[above1sig].size == 31
 
-def test_get_modelcube_badpar(cubefile=None, parfile=None, sigma_threshold=5):
+def test_get_modelcube_badpar(cubefile=None, parfile=None, sigma_threshold=5,
+                              multicore=1):
     """
     Test loading a model cube that has at least one invalid parameter.
     Regression test for #163
@@ -232,7 +233,7 @@ def test_get_modelcube_badpar(cubefile=None, parfile=None, sigma_threshold=5):
     # assuming one gaussian component
     for spc in [sp_cube, sp_stack]:
         spc.load_model_fit(parfile, npars=3, _temp_fit_loc=(0,0))
-        spc.get_modelcube()
+        spc.get_modelcube(multicore=multicore)
         resid_cube = spc.cube - spc._modelcube
 
 def test_registry_inheritance(cubefile='test.fits'):


### PR DESCRIPTION
Pooling functionality already exists for several methods of `SpectralCube` class, and can be fairly easily ported to the `get_modelcube` method - which is what's being done in this PR.

All in all, this can achieve significant speed-ups for fairly large cubes and/or high values of `npeaks`:
```python
In [67]: %timeit spc._modelcube=None;spc.get_modelcube(multicore=8)
1 loop, best of 3: 1.47 s per loop

In [68]: %timeit spc._modelcube=None;spc.get_modelcube(multicore=1)
|===================================================================| 9.7k/9.7k (100.00%)         5s
|===================================================================| 9.7k/9.7k (100.00%)         5s
|===================================================================| 9.7k/9.7k (100.00%)         5s
|===================================================================| 9.7k/9.7k (100.00%)         5s
1 loop, best of 3: 5.42 s per loop
```
A note on tests: as `get_modelcube` already had its tests already, I simply added a `multicore` option to the relevant ones.