### PR TITLE
Ammonia models are now faster!

### DIFF
--- a/pyspeckit/mpfit/mpfit.py
+++ b/pyspeckit/mpfit/mpfit.py
@@ -1149,8 +1149,10 @@ class mpfit:
                 if temp3 != 0:
                     fj = fjac[j:,lj]
                     wj = wa4[j:]
+                    # vsokolov 21 Mar 2017: switched to numpy's sum(),
+                    #                       as both are numpy arrays.
                     # *** optimization wa4(j:*)
-                    wa4[j:] = wj - fj * sum(fj*wj) / temp3
+                    wa4[j:] = wj - fj * numpy.sum(fj*wj) / temp3
                 fjac[j,lj] = wa1[j]
                 qtf[j] = wa4[j]
             log.log(5, 'After optimizing wa4, qtf={0}'.format(qtf))
@@ -1871,7 +1873,9 @@ class mpfit:
                     # *** Note optimization a(j:*,lk)
                     # (corrected 20 Jul 2000)
                     if a[j,lj] != 0:
-                        a[j:,lk] = ajk - ajj * sum(ajk*ajj)/a[j,lj]
+                        # vsokolov 21 Mar 2017: switched to numpy's sum(),
+                        #                       as both are numpy arrays.
+                        a[j:,lk] = ajk - ajj * numpy.sum(ajk*ajj)/a[j,lj]
                         if (pivot != 0) and (rdiag[k] != 0):
                             temp = a[j,lk]/rdiag[k]
                             rdiag[k] = rdiag[k] * numpy.sqrt(numpy.max([(1.-temp**2), 0.]))

--- a/pyspeckit/spectrum/models/ammonia.py
+++ b/pyspeckit/spectrum/models/ammonia.py
@@ -527,6 +527,8 @@ class ammonia_model(model.SpectralModel):
                                           'fixed', 'limitedmin', 'limitedmax',
                                           'minpars', 'maxpars', 'tied',
                                           'max_tem_step'))
+        fitfun_kwargs.update(self.modelfunc_kwargs)
+
         if 'use_lmfit' in fitfun_kwargs:
             raise KeyError("use_lmfit was specified in a location where it "
                            "is unacceptable")

--- a/pyspeckit/spectrum/models/ammonia.py
+++ b/pyspeckit/spectrum/models/ammonia.py
@@ -98,7 +98,7 @@ def ammonia(xarr, trot=20, tex=None, ntot=14, width=1, xoff_v=0.0,
                                     Jortho, Jpara, Brot, Crot)
 
     # Convert X-units to frequency in GHz
-    if xarr.unit.name != 'GHz':
+    if xarr.unit.to_string() != 'GHz':
         xarr = xarr.as_unit('GHz')
 
     if tex is None:

--- a/pyspeckit/spectrum/models/ammonia.py
+++ b/pyspeckit/spectrum/models/ammonia.py
@@ -98,7 +98,8 @@ def ammonia(xarr, trot=20, tex=None, ntot=14, width=1, xoff_v=0.0,
                                     Jortho, Jpara, Brot, Crot)
 
     # Convert X-units to frequency in GHz
-    xarr = xarr.as_unit('GHz')
+    if xarr.unit.name != 'GHz':
+        xarr = xarr.as_unit('GHz')
 
     if tex is None:
         log.warning("Assuming tex=trot")


### PR DESCRIPTION
So I've been profiling the ammonia model performance in `pyspeckit`, and, long story short, found out that both models and spectral fits can be improved to yield a large speed boost.

Here are the two areas I've addressed so far:

First of all, whenever `ammonia` function gets called, it tries to convert `xarr` into `GHz`. Somehow, this isn't optimized for speed in `astropy`, so in the end it ends up eating up a significant chunck of CPU power. This is fixed in 01142ec, and the `%timeit` results are given below in rows 2 and 3.

Now on to the largest performance boost. There's a `line_names` argument that gets passed to `ammonia` function, that, in turn, gets inherited by `_ammonia_spectrum`, specifying the inversion levels to calculate over. There are a few issues with this:

- [feature, not a bug] Because `line_names` defaults to all lines in (1,1)-(8,8) range, the default model that is registered under `Registry.multifitters['ammonia']` is slower than it should be for cubes that have, for example, only (1,1) and (2,2) lines. This can, of course, be solved by registering a new fitter with `function=ammonia_model(line_names=['oneone', 'twotwo'])` passed to the `add_fitter` method, but... I suspect that not many users figured it out. In fact, when I look over to the some data analysis pipelines for NH3 (e.g. GAS survey repo), they don't really use it. if you check the table below, the second and third columns show the time it takes to run `get_full_model` on the (1,1) and (2,2) ammonia spectrum from a typical GBT spectral setup. Clearly, the `ammonia_model` with matching 
`line_names` wins the race!

- However, selecting a proper `ammonia_model` had no effect on the fitting performance. That was, probably, a bug - the fitting function didn't pick up the model `kwargs` that were stored under `fitter.modelfunc_kwargs`. Therefore, even for `line_names=['oneone', 'twotwo']`, the fitter ran with all the inversion lines up to (8,8) regardless of the ammonia model registered, taking the defaults from the ammonia function. I set up the fitting kwargs to update from model ones in 508d946.

| `faster-ammonia` branch commit         | `get_full_model` for `line_names`=(1,1)-(2,2) | `get_full_model` for `line_names`=(1,1)-(8,8) | Fitting a dummy cube for `line_names`=(1,1)-(2,2) | Fitting a dummy cube for `line_names`=(1,1)-(8,8) |
|----------------------------------------|-----------------------------------------------|-----------------------------------------------|---------------------------------------------------|---------------------------------------------------|
| 71552fd (current master)      | 4.62 ms                                       | 9.76 ms                                       | 51.4 s                                            | 51.4 s                                            |
| 01142ec (condition call to as_unit)  | 3.33 ms                                       | 8.44 ms                                       | 40.8 s                                            | 40.8 s                                            |
| 508d946 (fitter inherits model kwargs) | -                                             | -                                             |  **26.7 s**   | 40.9 s                                            |


So, main takeaway is that fitting ammonia cubes can be twice as fast now in some cases!

@keflavich  I am still working on more improvements, so please don't merge just yet.