### PR TITLE
[don't merge] Narrowing down the worm-like structures from fiteach

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -704,6 +704,10 @@ class Cube(spectrum.Spectrum):
         blank_value: float
             Value to replace non-fitted locations with.  A good alternative is
             numpy.nan
+        errmap: ndarray[naxis=2] or ndarray[naxis=3]
+            A map of errors used for the individual pixels of the spectral
+            cube. 2D errmap results in an equal weighting of each given
+            spectrum, while a 3D array sets individual weights of each channel
         verbose: bool
         verbose_level: int
             Controls how much is output.
@@ -831,7 +835,10 @@ class Cube(spectrum.Spectrum):
             if errspec is not None:
                 sp.error = errspec
             elif errmap is not None:
-                sp.error = np.ones(sp.data.shape) * errmap[int(y),int(x)]
+                if errmap.shape == self.cube.shape[1:]:
+                    sp.error = np.ones(sp.data.shape) * errmap[int(y),int(x)]
+                elif errmap.shape == self.cube.shape:
+                    sp.error = errmap[:, int(y), int(x)]
             else:
                 if ii==0:
                     # issue the warning only once (ii==0), but always issue

--- a/pyspeckit/mpfit/mpfit.py
+++ b/pyspeckit/mpfit/mpfit.py
@@ -1149,8 +1149,10 @@ class mpfit:
                 if temp3 != 0:
                     fj = fjac[j:,lj]
                     wj = wa4[j:]
+                    # vsokolov 21 Mar 2017: switched to numpy's sum(),
+                    #                       as both are numpy arrays.
                     # *** optimization wa4(j:*)
-                    wa4[j:] = wj - fj * sum(fj*wj) / temp3
+                    wa4[j:] = wj - fj * numpy.sum(fj*wj) / temp3
                 fjac[j,lj] = wa1[j]
                 qtf[j] = wa4[j]
             log.log(5, 'After optimizing wa4, qtf={0}'.format(qtf))
@@ -1871,7 +1873,9 @@ class mpfit:
                     # *** Note optimization a(j:*,lk)
                     # (corrected 20 Jul 2000)
                     if a[j,lj] != 0:
-                        a[j:,lk] = ajk - ajj * sum(ajk*ajj)/a[j,lj]
+                        # vsokolov 21 Mar 2017: switched to numpy's sum(),
+                        #                       as both are numpy arrays.
+                        a[j:,lk] = ajk - ajj * numpy.sum(ajk*ajj)/a[j,lj]
                         if (pivot != 0) and (rdiag[k] != 0):
                             temp = a[j,lk]/rdiag[k]
                             rdiag[k] = rdiag[k] * numpy.sqrt(numpy.max([(1.-temp**2), 0.]))

--- a/pyspeckit/spectrum/models/ammonia.py
+++ b/pyspeckit/spectrum/models/ammonia.py
@@ -98,7 +98,8 @@ def ammonia(xarr, trot=20, tex=None, ntot=14, width=1, xoff_v=0.0,
                                     Jortho, Jpara, Brot, Crot)
 
     # Convert X-units to frequency in GHz
-    xarr = xarr.as_unit('GHz')
+    if xarr.unit.to_string() != 'GHz':
+        xarr = xarr.as_unit('GHz')
 
     if tex is None:
         log.warning("Assuming tex=trot")
@@ -526,6 +527,8 @@ class ammonia_model(model.SpectralModel):
                                           'fixed', 'limitedmin', 'limitedmax',
                                           'minpars', 'maxpars', 'tied',
                                           'max_tem_step'))
+        fitfun_kwargs.update(self.modelfunc_kwargs)
+
         if 'use_lmfit' in fitfun_kwargs:
             raise KeyError("use_lmfit was specified in a location where it "
                            "is unacceptable")


### PR DESCRIPTION
Testing branch for #220. Further changes and fixes can be discussed/appended here.

Performance improvements from other PRs apart, two new features are available:

1. The `errmap` argument to `fiteach` can now be three-dimensional.

2. There's a new attribute of the `SpectralCube` class generated after `fiteach` run, called `guesscube`. It stores guesses that have been used internally during the fitting loop. Useful for keeping trace of the guesses that have been generated on the fly.