### PR TITLE
Non-uniform channel weights for fiteach

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -835,6 +835,10 @@ class Cube(spectrum.Spectrum):
             if errspec is not None:
                 sp.error = errspec
             elif errmap is not None:
+                if self.errorcube is not None:
+                    raise ValueError("Either the 'errmap' argument or"
+                                     " self.errorcube attribute should be"
+                                     " specified, but not both.")
                 if errmap.shape == self.cube.shape[1:]:
                     sp.error = np.ones(sp.data.shape) * errmap[int(y),int(x)]
                 elif errmap.shape == self.cube.shape:

--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -839,6 +839,8 @@ class Cube(spectrum.Spectrum):
                     sp.error = np.ones(sp.data.shape) * errmap[int(y),int(x)]
                 elif errmap.shape == self.cube.shape:
                     sp.error = errmap[:, int(y), int(x)]
+            elif self.errorcube is not None:
+                sp.error = self.errorcube[:, int(y), int(x)]
             else:
                 if ii==0:
                     # issue the warning only once (ii==0), but always issue

--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -704,6 +704,10 @@ class Cube(spectrum.Spectrum):
         blank_value: float
             Value to replace non-fitted locations with.  A good alternative is
             numpy.nan
+        errmap: ndarray[naxis=2] or ndarray[naxis=3]
+            A map of errors used for the individual pixels of the spectral
+            cube. 2D errmap results in an equal weighting of each given
+            spectrum, while a 3D array sets individual weights of each channel
         verbose: bool
         verbose_level: int
             Controls how much is output.
@@ -831,7 +835,10 @@ class Cube(spectrum.Spectrum):
             if errspec is not None:
                 sp.error = errspec
             elif errmap is not None:
-                sp.error = np.ones(sp.data.shape) * errmap[int(y),int(x)]
+                if errmap.shape == self.cube.shape[1:]:
+                    sp.error = np.ones(sp.data.shape) * errmap[int(y),int(x)]
+                elif errmap.shape == self.cube.shape:
+                    sp.error = errmap[:, int(y), int(x)]
             else:
                 if ii==0:
                     # issue the warning only once (ii==0), but always issue


### PR DESCRIPTION
Okay, so this should fix #224. We now allow `Cube.fiteach` to take error cubes as input, via two ways:

1. The `errmap=` argument can take both 2D- and 3D-arrays now.
2. I also wrote in a check for the `errorcube` attribute for the `errmap is None` case, which is probably a more preferable way to specify errors anyway, because in that way the errors don't get lost during things like cube stacking, smoothing, and extracting spectra.

The regression test is inspired by #220, and checks if the errors from the non-uniform weighting case are reasonable for an ammonia fit with a very noisy (2,2) line.
