### PR TITLE
Spectral smoothing for cubes

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -1287,7 +1287,7 @@ class Cube(spectrum.Spectrum):
         Documentation from the :mod:`cubes.spectral_smooth` module:
 
         """
-        factor = round(factor)
+        factor = int(round(factor))
         self.cube = cubes.spectral_smooth(self.cube,factor,**kwargs)
         self.xarr = self.xarr[::factor]
         if hasattr(self,'data'):

--- a/pyspeckit/cubes/cubes.py
+++ b/pyspeckit/cubes/cubes.py
@@ -730,11 +730,15 @@ def spectral_smooth(cube, smooth_factor, downsample=True, parallel=True,
     # need to make the cube "flat" along dims 1&2 for iteration in the "map"
     flatshape = (cube.shape[0],cube.shape[1]*cube.shape[2])
 
-    Ssmooth = lambda x: sm.smooth(x, smooth_factor, downsample=downsample, **kwargs)
+    Ssmooth = lambda x: sm.smooth(x, smooth_factor,
+                                  downsample=downsample, **kwargs)
     if parallel:
-        newcube = numpy.array(parallel_map(Ssmooth, cube.reshape(flatshape).T, numcores=numcores)).T.reshape(newshape)
+        res = parallel_map(Ssmooth, cube.reshape(flatshape).T,
+                           numcores=numcores)
     else:
-        newcube = numpy.array(map(Ssmooth, cube.reshape(flatshape).T)).T.reshape(newshape)
+        res = list(map(Ssmooth, cube.reshape(flatshape).T))
+
+    newcube = np.array(res).T.reshape(newshape)
 
     #naive, non-optimal version
     # for (x,y) in zip(xx.flat,yy.flat):

--- a/pyspeckit/cubes/cubes.py
+++ b/pyspeckit/cubes/cubes.py
@@ -37,6 +37,7 @@ except ImportError:
 
 from . import posang # agpy code
 from ..parallel_map import parallel_map
+from ..spectrum import smooth as sm
 
 dtor = pi/180.0
 
@@ -729,7 +730,7 @@ def spectral_smooth(cube, smooth_factor, downsample=True, parallel=True,
     # need to make the cube "flat" along dims 1&2 for iteration in the "map"
     flatshape = (cube.shape[0],cube.shape[1]*cube.shape[2])
 
-    Ssmooth = lambda x: smooth.smooth(x, smooth_factor, downsample=downsample, **kwargs)
+    Ssmooth = lambda x: sm.smooth(x, smooth_factor, downsample=downsample, **kwargs)
     if parallel:
         newcube = numpy.array(parallel_map(Ssmooth, cube.reshape(flatshape).T, numcores=numcores)).T.reshape(newshape)
     else:
@@ -737,7 +738,7 @@ def spectral_smooth(cube, smooth_factor, downsample=True, parallel=True,
 
     #naive, non-optimal version
     # for (x,y) in zip(xx.flat,yy.flat):
-    #     newcube[:,y,x] = smooth.smooth(cube[:,y,x], smooth_factor,
+    #     newcube[:,y,x] = sm.smooth(cube[:,y,x], smooth_factor,
     #             downsample=downsample, **kwargs)
 
     return newcube

--- a/pyspeckit/spectrum/smooth.py
+++ b/pyspeckit/spectrum/smooth.py
@@ -8,7 +8,7 @@ def smoothed(spectrum, **kwargs):
     return sp
 
 def smooth(data, smooth, smoothtype='gaussian', downsample=True,
-           downsample_factor=None, convmode='same'):
+           downsample_factor=None, convmode='same', **kwargs):
     """
     Smooth and downsample the data array.  NaN data points will be replaced
     with interpolated values
@@ -47,9 +47,9 @@ def smooth(data, smooth, smoothtype='gaussian', downsample=True,
         if len(kernel) > len(data):
             lengthdiff = len(kernel)-len(data)
             if lengthdiff % 2 == 0: # make kernel same size as data
-                kernel = kernel[lengthdiff/2:-lengthdiff/2]
+                kernel = kernel[lengthdiff//2:-lengthdiff//2]
             else: # make kernel 1 pixel smaller than data but still symmetric
-                kernel = kernel[lengthdiff/2+1:-lengthdiff/2-1]
+                kernel = kernel[lengthdiff//2+1:-lengthdiff//2-1]
     elif smoothtype == 'boxcar':
         kernel = np.ones(roundsmooth)/float(roundsmooth)
 


### PR DESCRIPTION
Two fixes for spectral cube smoothing.

1. The smooth function was not imported properly (not sure why, I could've sworn that it was all good up until recently...)
2. Force `int` type for the smoothing factor. Is needed because in python2, `round(2)` returns `2.0`. Also not sure why I didn't see it before, maybe because I always import numpy routines together with pylab?