### PR TITLE
remove deprecated plural units

### DIFF
--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -432,26 +432,6 @@ class SpectroscopicAxis(u.Quantity):
         return selfstr
 
     @property
-    def units(self):
-        log.warning("'units' is deprecated; please use 'unit'", DeprecationWarning)
-        return self._unit
-
-    @units.setter
-    def units(self, value):
-        log.warning("'units' is deprecated; please use 'unit'", DeprecationWarning)
-        self.set_unit(value)
-
-    @property
-    def refX_units(self):
-        log.warning("'refX_units' is deprecated; please use 'refX_unit'", DeprecationWarning)
-        return self.refX_unit
-
-    @refX_units.setter
-    def refX_units(self, value):
-        log.warning("'refX_units' is deprecated; please use 'refX_unit'", DeprecationWarning)
-        self.refX_unit = value
-
-    @property
     def refX_unit(self):
         if hasattr(self.refX, 'unit'):
             return self.refX.unit


### PR DESCRIPTION
I was getting ridiculous errors like these when tab completing:
```
WARNING: 'units' is deprecated; please use 'unit' [pyspeckit.spectrum.classes]
--- Logging error ---
Traceback (most recent call last):
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/jedi/cache.py", line 119, in wrapper
    return dct[key]
KeyError: (('units',), frozenset())

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/logging/__init__.py", line 980, in emit
    msg = self.format(record)
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/logging/__init__.py", line 830, in format
    return fmt.format(record)
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/logging/__init__.py", line 567, in format
    record.message = record.getMessage()
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/logging/__init__.py", line 330, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Call stack:
  File "/Users/adam/anaconda/envs/astropy35/bin/ipython", line 11, in <module>
    sys.exit(start_ipython())
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/IPython/__init__.py", line 125, in start_ipython
    return launch_new_instance(argv=argv, **kwargs)
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/traitlets/config/application.py", line 658, in launch_instance
    app.start()
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/IPython/terminal/ipapp.py", line 356, in start
    self.shell.mainloop()
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/rlipython/shell.py", line 454, in mainloop
    self.interact(display_banner=display_banner)
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/rlipython/shell.py", line 536, in interact
    line = self.raw_input(prompt)
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/rlipython/shell.py", line 605, in raw_input
    line = py3compat.cast_unicode_py2(self.raw_input_original(prompt))
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/rlipython/completer.py", line 60, in rlcomplete
    self.complete(text, line_buffer, cursor_pos)
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/IPython/core/completer.py", line 1840, in complete
    return self._complete(line_buffer=line_buffer, cursor_pos=cursor_pos, text=text, cursor_line=0)[:2]
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/IPython/core/completer.py", line 1913, in _complete
    cursor_pos, cursor_line, full_text)
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/IPython/core/completer.py", line 1297, in _jedi_matches
    return filter(completion_filter, interpreter.completions())
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/jedi/api/__init__.py", line 179, in completions
    completions = completion.completions()
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/jedi/api/completion.py", line 96, in completions
    completion_names = self._get_context_completions()
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/jedi/api/completion.py", line 169, in _get_context_completions
    completion_names += self._trailer_completions(dot.get_previous_leaf())
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/jedi/api/completion.py", line 210, in _trailer_completions
    completion_names += filter.values()
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/jedi/evaluate/compiled/__init__.py", line 345, in values
    names += self.get(name)
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/jedi/cache.py", line 121, in wrapper
    result = method(self, *args, **kwargs)
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/jedi/evaluate/compiled/__init__.py", line 328, in get
    getattr(obj, name)
  File "/Users/adam/repos/pyspeckit/pyspeckit/spectrum/classes.py", line 239, in units
    log.warning("'units' is deprecated; please use 'unit'", DeprecationWarning)
Message: "'units' is deprecated; please use 'unit'"
Arguments: (<class 'DeprecationWarning'>,)
```