### PR TITLE
Update astropy-helpers to v2.0.2

### DIFF
--- a/pyspeckit/spectrum/classes.py
+++ b/pyspeckit/spectrum/classes.py
@@ -618,10 +618,6 @@ class BaseSpectrum(object):
 
         Documentation from the :mod:`smooth` module:
 
-        Parameters
-        ----------
-        downsample: bool
-            Downsample the spectrum by the smoothing factor?
         """
         smooth = int(round(smooth))
         self.data = sm.smooth(self.data,smooth,downsample=downsample,**kwargs)


### PR DESCRIPTION
This is an automated update of the astropy-helpers submodule to v2.0.2. This includes both the update of the astropy-helpers sub-module, and the ``ah_bootstrap.py`` file, if needed.

*This is intended to be helpful, but if you would prefer to manage these updates yourself, or if you notice any issues with this automated update, please let @bsipocz or @astrofrog know!*