### PR TITLE
Fix issue 247 - Initialize includemask

### DIFF
--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -511,7 +511,6 @@ class Specfit(interactive.Interactive):
         input spectrum or determine the error using the RMS of the residuals,
         depending on whether the residuals exist.
         """
-        log.debug("Error spectrum is being set")
         if (self.Spectrum.error is not None) and not usestd:
             if (self.Spectrum.error == 0).all():
                 if self.residuals is not None and useresiduals:
@@ -534,7 +533,6 @@ class Specfit(interactive.Interactive):
             self.errspec = np.ones(self.spectofit.shape[0]) * self.residuals.std()
         else:
             self.errspec = np.ones(self.spectofit.shape[0]) * self.spectofit.std()
-        log.debug("Mean of error spectrum is {0}".format(self.errspec.mean()))
 
     def setfitspec(self):
         """

--- a/pyspeckit/spectrum/interactive.py
+++ b/pyspeckit/spectrum/interactive.py
@@ -258,7 +258,7 @@ class Interactive(object):
             widthguess = (abs(event.xdata-self.guesses[-1-nwidths]) /
                           numpy.sqrt(2*numpy.log(2)))
             if numpy.isnan(widthguess) or widthguess <= 0:
-                newwidthguess = numpy.abs(self.Spectrum.xarr.diff()).min()
+                newwidthguess = numpy.abs(self.Spectrum.xarr.diff()).min().value
                 if newwidthguess <= 0:
                     raise ValueError("A width guess could not be determined.")
                 log.exception("Error: width guess was {0}.  It is being forced to {1}."

--- a/pyspeckit/spectrum/interactive.py
+++ b/pyspeckit/spectrum/interactive.py
@@ -122,10 +122,12 @@ class Interactive(object):
                 # exclude/delete/remove
                 self._selectregion_interactive(event, mark_include=False, debug=debug)
             elif button in ('m','M','2',2): # m for mark
-                if debug or self._debug: log.debug("Button 2 action")
+                if debug or self._debug:
+                    log.debug("Button 2 action")
                 self.button2action(event,debug=debug,nwidths=nwidths)
             elif button in ('d','D','3',3): # d for done
-                if debug or self._debug: log.debug("Button 3 action")
+                if debug or self._debug:
+                    log.debug("Button 3 action")
                 self.button3action(event,debug=debug,nwidths=nwidths)
             elif button in ('?'):
                 # print statement: we really want this to go to the terminal
@@ -191,7 +193,8 @@ class Interactive(object):
         self._update_xminmax()
 
     def highlight_fitregion(self,  drawstyle='steps-mid', color=(0,0.8,0,0.5),
-            linewidth=2, alpha=0.5, clear_highlights=True, **kwargs):
+                            linewidth=2, alpha=0.5, clear_highlights=True,
+                            **kwargs):
         """
         Re-highlight the fitted region
 


### PR DESCRIPTION
If an interactive `guesspeakwidth` session is started, includemask is reset to
be all False by default.  If no clicks are made to select regions, we should
assume *all* data are included.