### PR TITLE
New ammonia model with fitted T_r - T_ex, and examples

### DIFF
--- a/docs/example_pymc.rst
+++ b/docs/example_pymc.rst
@@ -19,97 +19,10 @@ The example below shows the results of a gaussian fit to noisy data (S/N ~ 6).
 The parameter space is then explored with `pymc` and `emcee` in order to examine
 the correlation between width and amplitude.
 
-:: 
-
-    import pyspeckit
-
-    # Create our own gaussian centered at 0 with width 1, amplitude 5, and
-    # gaussian noise with amplitude 1
-    x = pyspeckit.units.SpectroscopicAxis(np.linspace(-10,10,50), unit='km/s')
-    e = np.random.randn(50)
-    d = np.exp(-np.asarray(x)**2/2.)*5 + e
-
-    # create the spectrum object
-    sp = pyspeckit.Spectrum(data=d, xarr=x, error=np.ones(50)*e.std())
-    # fit it
-    sp.specfit(fittype='gaussian',multifit=None,guesses=[1,0,1])
-    # then get the pymc values
-    MCuninformed = sp.specfit.get_pymc()
-    MCwithpriors = sp.specfit.get_pymc(use_fitted_values=True)
-    MCuninformed.sample(101000,burn=1000,tune_interval=250)
-    MCwithpriors.sample(101000,burn=1000,tune_interval=250)
-
-    # MC vs least squares:
-    print sp.specfit.parinfo
-    # Param #0   AMPLITUDE0 =         4.51708 +/-        0.697514 
-    # Param #1       SHIFT0 =       0.0730243 +/-        0.147537 
-    # Param #2       WIDTH0 =        0.846578 +/-        0.147537   Range:   [0,inf)
-    
-
-    print MCuninformed.stats()['AMPLITUDE0'],MCuninformed.stats()['WIDTH0']
-    #  {'95% HPD interval': array([ 2.9593463 ,  5.65258618]),
-    #   'mc error': 0.0069093803546614969,
-    #   'mean': 4.2742994714387068,
-    #   'n': 100000,
-    #   'quantiles': {2.5: 2.9772782318342288,
-    #    25: 3.8023115438555615,
-    #    50: 4.2534542126311479,
-    #    75: 4.7307441549353229,
-    #    97.5: 5.6795448148793293},
-    #   'standard deviation': 0.68803712503362213},
-    #  {'95% HPD interval': array([ 0.55673242,  1.13494423]),
-    #   'mc error': 0.0015457954546501554,
-    #   'mean': 0.83858499779600593,
-    #   'n': 100000,
-    #   'quantiles': {2.5: 0.58307734425381375,
-    #    25: 0.735072721596429,
-    #    50: 0.824695077252244,
-    #    75: 0.92485225882530664,
-    #    97.5: 1.1737067304111048},
-    #   'standard deviation': 0.14960171537498618} 
-    
-    
-    print MCwithpriors.stats()['AMPLITUDE0'],MCwithpriors.stats()['WIDTH0']
-    #  {'95% HPD interval': array([ 3.45622857,  5.28802497]),
-    #   'mc error': 0.0034676818027776788,
-    #   'mean': 4.3735547007147595,
-    #   'n': 100000,
-    #   'quantiles': {2.5: 3.4620369729291913,
-    #    25: 4.0562790782065052,
-    #    50: 4.3706408236777481,
-    #    75: 4.6842793868186332,
-    #    97.5: 5.2975444315549947},
-    #   'standard deviation': 0.46870135068815683},
-    #  {'95% HPD interval': array([ 0.63259418,  1.00028015]),
-    #   'mc error': 0.00077504289680683364,
-    #   'mean': 0.81025043433745358,
-    #   'n': 100000,
-    #   'quantiles': {2.5: 0.63457050661326331,
-    #    25: 0.7465422649464849,
-    #    50: 0.80661741451336577,
-    #    75: 0.87067288601310233,
-    #    97.5: 1.0040591994661381},
-    #   'standard deviation': 0.093979950317277294} 
-    
+.. literalinclude:: ../examples/example_pymc.py
+    :language: python
 
 
-    # optional
-    import agpy.pymc_plotting
-    import pylab
-    agpy.pymc_plotting.hist2d(MCuninformed,'AMPLITUDE0','WIDTH0',clear=True,bins=[25,25])
-    agpy.pymc_plotting.hist2d(MCwithpriors,'AMPLITUDE0','WIDTH0',contourcmd=pylab.contour,colors=[(0,1,0,1),(0,0.5,0.5,1),(0,0.75,0.75,1),(0,1,1,1),(0,0,1,1)],clear=False,bins=[25,25])
-    pylab.plot([5],[1],'k+',markersize=25)
-
-
-    # Now do the same with emcee
-    emcee_ensemble = sp.specfit.get_emcee()
-    p0 = emcee_ensemble.p0 * (np.random.randn(*emcee_ensemble.p0.shape) / 10. + 1.0)
-    pos,logprob,state = emcee_ensemble.run_mcmc(p0,100000)
-
-    plotdict = {'AMPLITUDE0':emcee_ensemble.chain[:,:,0].ravel(),
-                'WIDTH0':emcee_ensemble.chain[:,:,2].ravel()}
-    agpy.pymc_plotting.hist2d(plotdict,'AMPLITUDE0','WIDTH0',fignum=2,bins=[25,25],clear=True)
-    pylab.plot([5],[1],'k+',markersize=25)
 
 .. figure:: images/pymc_params_example.png 
     :alt: Examples of the pymc Monte Carlo two-dimensional parameter histogram

--- a/docs/example_pymc_ammonia.rst
+++ b/docs/example_pymc_ammonia.rst
@@ -1,0 +1,13 @@
+.. include:: <isogrk3.txt>
+
+Ammonia Monte Carlo examples
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This example shows the same process as in `<example_pymc>`_, but for
+the ammonia model.  Here we emphasize the degeneracy between
+the excitation temperature and the total column density.
+
+
+.. literalinclude:: ../examples/example_pymc_ammonia.py
+    :language: python
+

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -50,6 +50,7 @@ Want your image or example included?  `E-mail us <mailto:pyspeckit@gmail.com>`_.
    Optical MUSE Spectral Cube <example_MUSE>
    Template Fitting <example_template>
    Monte Carlo <example_pymc>
+   Monte Carlo for NH3 <example_pymc_ammonia>
 
 .. toctree::
    :maxdepth: 3

--- a/docs/fitting.rst
+++ b/docs/fitting.rst
@@ -6,3 +6,7 @@ Model Fitting
     :members:
     :inherited-members:
     :undoc-members:
+
+
+.. toctree::
+   fit_custom_model

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -62,3 +62,6 @@ You can also check out the `source code <https://github.com/pyspeckit/pyspeckit>
 .. note ::
    pyspeckit is hosted on both bitbucket and github.  Both versions are kept up
    to date, so it should not matter which one you choose to install.
+
+.. toctree::
+   install_via_GitHub

--- a/examples/example_pymc.py
+++ b/examples/example_pymc.py
@@ -1,0 +1,91 @@
+import pyspeckit
+import numpy as np
+
+# Create our own gaussian centered at 0 with width 1, amplitude 5, and
+# gaussian noise with amplitude 1
+x = pyspeckit.units.SpectroscopicAxis(np.linspace(-10,10,50), unit='km/s')
+e = np.random.randn(50)
+d = np.exp(-np.asarray(x)**2/2.)*5 + e
+
+# create the spectrum object
+sp = pyspeckit.Spectrum(data=d, xarr=x, error=np.ones(50)*e.std())
+# fit it
+sp.specfit(fittype='gaussian', guesses=[1,0,1])
+# then get the pymc values
+MCuninformed = sp.specfit.get_pymc()
+MCwithpriors = sp.specfit.get_pymc(use_fitted_values=True)
+MCuninformed.sample(101000,burn=1000,tune_interval=250)
+MCwithpriors.sample(101000,burn=1000,tune_interval=250)
+
+# MC vs least squares:
+print(sp.specfit.parinfo)
+# Param #0   AMPLITUDE0 =         4.51708 +/-        0.697514
+# Param #1       SHIFT0 =       0.0730243 +/-        0.147537
+# Param #2       WIDTH0 =        0.846578 +/-        0.147537   Range:   [0,inf)
+
+
+print(MCuninformed.stats()['AMPLITUDE0'],MCuninformed.stats()['WIDTH0'])
+#  {'95% HPD interval': array([ 2.9593463 ,  5.65258618]),
+#   'mc error': 0.0069093803546614969,
+#   'mean': 4.2742994714387068,
+#   'n': 100000,
+#   'quantiles': {2.5: 2.9772782318342288,
+#    25: 3.8023115438555615,
+#    50: 4.2534542126311479,
+#    75: 4.7307441549353229,
+#    97.5: 5.6795448148793293},
+#   'standard deviation': 0.68803712503362213},
+#  {'95% HPD interval': array([ 0.55673242,  1.13494423]),
+#   'mc error': 0.0015457954546501554,
+#   'mean': 0.83858499779600593,
+#   'n': 100000,
+#   'quantiles': {2.5: 0.58307734425381375,
+#    25: 0.735072721596429,
+#    50: 0.824695077252244,
+#    75: 0.92485225882530664,
+#    97.5: 1.1737067304111048},
+#   'standard deviation': 0.14960171537498618}
+
+
+print(MCwithpriors.stats()['AMPLITUDE0'],MCwithpriors.stats()['WIDTH0'])
+#  {'95% HPD interval': array([ 3.45622857,  5.28802497]),
+#   'mc error': 0.0034676818027776788,
+#   'mean': 4.3735547007147595,
+#   'n': 100000,
+#   'quantiles': {2.5: 3.4620369729291913,
+#    25: 4.0562790782065052,
+#    50: 4.3706408236777481,
+#    75: 4.6842793868186332,
+#    97.5: 5.2975444315549947},
+#   'standard deviation': 0.46870135068815683},
+#  {'95% HPD interval': array([ 0.63259418,  1.00028015]),
+#   'mc error': 0.00077504289680683364,
+#   'mean': 0.81025043433745358,
+#   'n': 100000,
+#   'quantiles': {2.5: 0.63457050661326331,
+#    25: 0.7465422649464849,
+#    50: 0.80661741451336577,
+#    75: 0.87067288601310233,
+#    97.5: 1.0040591994661381},
+#   'standard deviation': 0.093979950317277294}
+
+
+
+# optional
+from mpl_plot_templates import pymc_plotting
+import pylab
+pymc_plotting.hist2d(MCuninformed,'AMPLITUDE0','WIDTH0',clear=True,bins=[25,25])
+pymc_plotting.hist2d(MCwithpriors,'AMPLITUDE0','WIDTH0',contourcmd=pylab.contour,colors=[(0,1,0,1),(0,0.5,0.5,1),(0,0.75,0.75,1),(0,1,1,1),(0,0,1,1)],clear=False,bins=[25,25])
+pylab.plot([5],[1],'k+',markersize=25, zorder=1000)
+pylab.savefig("pymc_example_Gaussian_amplitude_vs_width.pdf")
+
+# Now do the same with emcee
+emcee_ensemble = sp.specfit.get_emcee()
+p0 = emcee_ensemble.p0 * (np.random.randn(*emcee_ensemble.p0.shape) / 10. + 1.0)
+pos,logprob,state = emcee_ensemble.run_mcmc(p0,100000)
+
+plotdict = {'AMPLITUDE0':emcee_ensemble.chain[:,:,0].ravel(),
+            'WIDTH0':emcee_ensemble.chain[:,:,2].ravel()}
+pymc_plotting.hist2d(plotdict,'AMPLITUDE0','WIDTH0',fignum=2,bins=[25,25],clear=True)
+pylab.plot([5],[1],'k+',markersize=25)
+pylab.savefig("emcee_example_Gaussian_amplitude_vs_width.pdf")

--- a/examples/example_pymc_ammonia.py
+++ b/examples/example_pymc_ammonia.py
@@ -48,7 +48,8 @@ MCwithpriors.sample(10100,burn=100,tune_interval=250)
 # MC vs least squares:
 print(sp.specfit.parinfo)
 
-print(MCwithpriors.stats()['tex0'],MCwithpriors.stats()['ntot0'])
+print(MCwithpriors.stats()['tex0'],
+      MCwithpriors.stats()['ntot0'])
 
 
 

--- a/examples/example_pymc_ammonia.py
+++ b/examples/example_pymc_ammonia.py
@@ -1,0 +1,83 @@
+import numpy as np
+from astropy import units as u
+import itertools
+from operator import itemgetter
+import pyspeckit
+import scipy.stats
+
+from pyspeckit.spectrum.models import ammonia, ammonia_constants
+
+import pylab as pl
+pl.close('all')
+pl.figure(1).clf()
+
+oneonefreq = ammonia_constants.freq_dict['oneone']
+twotwofreq = ammonia_constants.freq_dict['twotwo']
+# create an axis that covers the 1-1 and 2-2 inversion lines
+xaxis = pyspeckit.units.SpectroscopicAxis(np.linspace(oneonefreq*(1-50/3e5),
+                                                      twotwofreq*(1+50/3e5),
+                                                      1000.),
+                                          unit=u.Hz)
+sigma = 2.
+center = 0.
+trot = 15.
+ntot = 14.7
+# Adopting an NLTE model: T_ex < T_rot (this case is better for the default fitter)
+# pyradex.Radex(species='p-nh3', column=5e14, collider_densities={'h2':5000}, temperature=15)()[8:10]
+tex = {'oneone':8.5, 'twotwo':5.5}
+synth_data = ammonia.ammonia(xaxis, trot=trot, tex=tex, width=sigma,
+                             xoff_v=center, ntot=ntot)
+
+# Add noise
+stddev = 0.1
+noise = np.random.randn(xaxis.size)*stddev
+error = stddev*np.ones_like(synth_data)
+data = u.Quantity(noise+synth_data, u.K)
+
+# create the spectrum object
+sp = pyspeckit.Spectrum(data=data,
+                        xarr=xaxis,
+                        error=np.ones_like(synth_data)*stddev)
+# fit it
+sp.specfit(fittype='ammonia', guesses=[35,10,15,5,5,0],
+           fixed=[False,False,False,False,False,True])
+# then get the pymc values
+MCwithpriors = sp.specfit.get_pymc(use_fitted_values=True)
+MCwithpriors.sample(10100,burn=100,tune_interval=250)
+
+# MC vs least squares:
+print(sp.specfit.parinfo)
+
+print(MCwithpriors.stats()['tex0'],MCwithpriors.stats()['ntot0'])
+
+
+
+# optional plotting
+from mpl_plot_templates import pymc_plotting
+import pylab
+pylab.figure(1).clf()
+pymc_plotting.hist2d(MCwithpriors, 'tex0', 'ntot0',
+                     bins=[25,25])
+pylab.plot([tex['oneone']],[ntot],'k+',markersize=25)
+pylab.axis([6,10.5,14.6,14.9])
+pylab.savefig("tex_vs_ntot_pymc_example.pdf")
+
+
+# Now do the same with emcee
+emcee_ensemble = sp.specfit.get_emcee()
+p0 = emcee_ensemble.p0 * (np.random.randn(*emcee_ensemble.p0.shape) / 50. + 1.0)
+pos,logprob,state = emcee_ensemble.run_mcmc(p0,10000)
+
+plotdict = {'tex0':emcee_ensemble.chain[:,1000:,1].ravel(),
+            'ntot0':emcee_ensemble.chain[:,1000:,2].ravel()}
+# one of the samplers went off the hook and got locked at high ntot
+OK = (plotdict['ntot0'] < 20)
+plotdict['tex0'] = plotdict['tex0'][OK]
+plotdict['ntot0'] = plotdict['ntot0'][OK]
+
+pylab.figure(2).clf()
+pymc_plotting.hist2d(plotdict, 'tex0', 'ntot0', fignum=2, bins=[25,25],
+                     clear=True)
+pylab.plot([tex['oneone']],[ntot],'k+',markersize=25)
+pylab.axis([6,10.5,14.6,14.9])
+pylab.savefig("tex_vs_ntot_emcee_example.pdf")

--- a/examples/synthetic_LTE_ammonia_spectrum_example_witherrorestimates.py
+++ b/examples/synthetic_LTE_ammonia_spectrum_example_witherrorestimates.py
@@ -1,0 +1,346 @@
+import numpy as np
+from astropy import units as u
+import itertools
+from operator import itemgetter
+import pyspeckit
+import scipy.stats
+
+from pyspeckit.spectrum.models import ammonia, ammonia_constants
+
+import pylab as pl
+pl.close('all')
+pl.figure(1).clf()
+
+oneonefreq = ammonia_constants.freq_dict['oneone']
+twotwofreq = ammonia_constants.freq_dict['twotwo']
+# create an axis that covers the 1-1 and 2-2 inversion lines
+xaxis = pyspeckit.units.SpectroscopicAxis(np.linspace(oneonefreq*(1-50/3e5),
+                                                      twotwofreq*(1+50/3e5),
+                                                      1000.),
+                                          unit=u.Hz)
+sigma = 2.
+center = 0.
+trot = 35.
+ntot = 15.
+tex = 35. # Adopting an LTE model
+synth_data = ammonia.ammonia(xaxis, trot=trot, tex=tex, width=sigma,
+                             xoff_v=center, ntot=ntot)
+
+# Add noise
+stddev = 0.1
+noise = np.random.randn(xaxis.size)*stddev
+error = stddev*np.ones_like(synth_data)
+data = noise+synth_data
+
+# this will give a "blank header" warning, which is fine
+sp = pyspeckit.Spectrum(data=data, error=error, xarr=xaxis,
+                        xarrkwargs={'unit':'km/s'},
+                        unit=u.erg/u.s/u.cm**2/u.AA)
+
+sp.plotter(figure=pl.figure(1), errstyle='fill')
+
+# fit with some vague initial guesses and a fixed ortho/para
+# fraction of 1 (it is unconstrained in our data)
+sp.specfit(fittype='ammonia',
+           #guesses=[20, 15, 15.5, 3, 2, 1],
+           guesses=[30, 25, 15.5, 3, 2, 0],
+           fixed=[False,False,False,False,False,True])
+
+# do it again to set the errors neatly
+sp.specfit(fittype='ammonia',
+           #guesses=[20, 15, 15.5, 3, 2, 1],
+           guesses=[30, 25, 15.5, 3, 2, 0],
+           fixed=[False,False,False,False,False,True])
+
+
+sp.plotter(errstyle='fill')
+sp.specfit.plot_fit()
+
+
+sp.plotter.savefig('oned_ammonia_LTE_fit_example.pdf')
+
+
+# do a deeper examination of the likelihood function
+
+def chi2(sp, pars):
+    """
+    Given a spectrum and some parameters, calculate the chi^2 value
+    """
+    return ((sp.specfit.get_model_frompars(sp.xarr, pars) -
+             sp.specfit.spectofit)**2 /
+            (sp.specfit.errspec**2)
+           ).sum()
+
+def replace(lst, eltid, value):
+    """
+    Helper function to make new parameter value lists below
+    """
+    lstcopy = list(lst)
+    lstcopy[eltid] = value
+    return lstcopy
+
+
+fig = pl.figure(2, figsize=(12,12))
+fig.clf()
+
+for ii,par in enumerate(sp.specfit.parinfo):
+    if par.fixed:
+        continue
+    par_vals = np.linspace(par.value - par.error * 2,
+                           par.value + par.error * 2,
+                           10)
+
+    par_likes = np.array([chi2(sp, replace(sp.specfit.parinfo.values, ii, val))
+                          for val in par_vals])
+
+    pct68 = scipy.stats.chi2.cdf(1, 1)
+
+    # this is for the full 3-parameter case
+    delta_chi2 = scipy.stats.chi2.ppf(pct68, sp.specfit.fitter.npars - sum(sp.specfit.parinfo.fixed))
+
+    # this is the one we're actually using (which is just 1) because we're
+    # marginalizing over the other parameters
+    delta_chi2 = scipy.stats.chi2.ppf(pct68, 1)
+
+    ax = fig.add_subplot(5,5,1+ii*6)
+    ax.plot(par_vals, par_likes)
+    xmin, xmax = ax.get_xlim()
+    ymin, ymax = ax.get_ylim()
+    ax.hlines(par_likes.min() + delta_chi2, xmin, xmax, 'k', '--')
+    ax.vlines([par.value - par.error,
+               par.value + par.error,], ymin, ymax, 'k', '--')
+    ax.set_ylabel("$\Delta \chi^2$")
+    ax.set_xlabel("{0} Value".format(par.parname))
+    pl.setp(ax.get_xticklabels(), rotation=90)
+
+    ax.set_xlim(xmin, xmax,)
+    ax.set_ylim(ymin, ymax,)
+
+fig.tight_layout()
+
+
+nsigma_range = 2
+nsteps = 15.
+
+plotinds = {0:6, 1:11, 2:12, 3:16, 4:17, 5:18, 6:21, 7:22, 8:23, 9:24}
+for ii,(par1,par2) in enumerate(itertools.combinations(sp.specfit.parinfo[:5],2)):
+
+    if par1.limited[0] and par1.value-par1.error*nsigma_range < par1.limits[0]:
+        start1 = par1.limits[0]+par1.limits[0]*1e-3
+    else:
+        start1 = par1.value - par1.error*nsigma_range
+    if par1.limited[1] and par1.value+par1.error*nsigma_range > par1.limits[1]:
+        end1 = par1.limits[1]-par1.limits[1]*1e-3
+    else:
+        end1 = par1.value + par1.error*nsigma_range
+
+    step1 = (end1 - start1) / nsteps
+
+    if par2.limited[0] and par2.value-par2.error*nsigma_range < par2.limits[0]:
+        start2 = par2.limits[0]+par2.limits[0]*1e-3
+    else:
+        start2 = par2.value - par2.error*nsigma_range
+    if par2.limited[1] and par2.value+par2.error*nsigma_range > par2.limits[1]:
+        end2 = par2.limits[1]-par2.limits[1]*1e-3
+    else:
+        end2 = par2.value + par2.error*nsigma_range
+
+    step2 = (end2 - start2) / nsteps
+
+    assert end1 > start1
+    assert end2 > start2
+
+    p1vals, p2vals = np.mgrid[start1:end1:step1,
+                              start2:end2:step2]
+
+
+    par_likes = np.array([chi2(sp, replace(replace(sp.specfit.parinfo.values, par1.n, val1), par2.n, val2))
+                          for val1,val2 in zip(p1vals.ravel(), p2vals.ravel())]).reshape(p1vals.shape)
+
+    pct68 = 1-scipy.stats.norm.sf(1)*2
+    pct95 = 1-scipy.stats.norm.sf(2)*2
+    pct997 = 1-scipy.stats.norm.sf(3)*2
+
+    # marginalize over only one parameter; we now have two free parameters
+    delta_chi2_68 = scipy.stats.chi2.ppf(pct68, 2)
+    delta_chi2_95 = scipy.stats.chi2.ppf(pct95, 2)
+    delta_chi2_997 = scipy.stats.chi2.ppf(pct997, 2)
+
+    ax = fig.add_subplot(5,5,plotinds[ii])
+    ax.contour(p1vals, p2vals, par_likes,
+               levels=[par_likes.min()+delta_chi2_68,
+                       par_likes.min()+delta_chi2_95,
+                       par_likes.min()+delta_chi2_997])
+    xmin, xmax = ax.get_xlim()
+    ymin, ymax = ax.get_ylim()
+    ax.plot(par1.value, par2.value, 'kx')
+    ax.hlines([par2.value - par2.error,
+               par2.value + par2.error,], xmin, xmax, 'k', '--')
+    ax.vlines([par1.value - par1.error,
+               par1.value + par1.error,], ymin, ymax, 'k', '--')
+    ax.set_xlabel("{0} Value".format(par1.parname))
+    ax.set_ylabel("{0} Value".format(par2.parname))
+    pl.setp(ax.get_xticklabels(), rotation=90)
+
+    ax.set_xlim(xmin, xmax,)
+    ax.set_ylim(ymin, ymax,)
+
+fig.tight_layout()
+
+fig.savefig("ammonia_LTE_default_error_estimate_demonstration.pdf")
+
+
+# fit with restricted delta-T instead of restricted T
+
+sp.specfit.Registry.add_fitter('ammonia_dtex',
+                               ammonia.ammonia_model_restricted_tex(), 7,
+                               multisingle='multi')
+
+sp.specfit(fittype='ammonia_dtex',
+           guesses=[30, 25, 15.5, 3, 2, 0, 5],
+           fixed=[False,False,False,False,False,True,False])
+
+sp.plotter.savefig('oned_ammonia_LTE_fit_example_deltaT.pdf')
+
+
+# do a deeper examination of the likelihood function
+
+def chi2(sp, pars):
+    """
+    Given a spectrum and some parameters, calculate the chi^2 value
+    """
+    return ((sp.specfit.get_model_frompars(sp.xarr, pars) -
+             sp.specfit.spectofit)**2 /
+            (sp.specfit.errspec**2)
+           ).sum()
+
+def replace(lst, eltid, value):
+    """
+    Helper function to make new parameter value lists below
+    """
+    lstcopy = list(lst)
+    lstcopy[eltid] = value
+    return lstcopy
+
+
+fig = pl.figure(2, figsize=(12,12))
+fig.clf()
+
+nsteps = 10
+dd = 0
+for ii,par in enumerate(sp.specfit.parinfo):
+    if par.fixed or par.tied:
+        dd = dd + 1
+        continue
+    par_vals = np.linspace(par.value - par.error * 2,
+                           par.value + par.error * 2,
+                           nsteps)
+
+    if par.parname == 'delta0':
+        start, step, end = 0, 5/nsteps, 5
+        par_vals = np.linspace(start, end, nsteps)
+
+    par_likes = np.array([chi2(sp, replace(sp.specfit.parinfo.values, ii, val))
+                          for val in par_vals])
+
+    pct68 = scipy.stats.chi2.cdf(1, 1)
+
+    # this is for the full 3-parameter case
+    delta_chi2 = scipy.stats.chi2.ppf(pct68, sp.specfit.fitter.npars - sum(sp.specfit.parinfo.fixed))
+
+    # this is the one we're actually using (which is just 1) because we're
+    # marginalizing over the other parameters
+    delta_chi2 = scipy.stats.chi2.ppf(pct68, 1)
+
+    ax = fig.add_subplot(5,5,1+(ii-dd)*6)
+    ax.plot(par_vals, par_likes)
+    xmin, xmax = ax.get_xlim()
+    ymin, ymax = ax.get_ylim()
+    ax.hlines(par_likes.min() + delta_chi2, xmin, xmax, 'k', '--')
+    ax.vlines([par.value - par.error,
+               par.value + par.error,], ymin, ymax, 'k', '--')
+    ax.set_ylabel("$\Delta \chi^2$")
+    ax.set_xlabel("{0} Value".format(par.parname))
+    pl.setp(ax.get_xticklabels(), rotation=90)
+
+    ax.set_xlim(xmin, xmax,)
+    ax.set_ylim(ymin, ymax,)
+
+fig.tight_layout()
+
+
+nsigma_range = 2
+nsteps = 15.
+
+
+plotinds = {0:6, 1:11, 2:12, 3:16, 4:17, 5:18, 6:21, 7:22, 8:23, 9:24}
+for ii,(par1,par2) in enumerate(itertools.combinations(itemgetter(0,2,3,4,6)(sp.specfit.parinfo),2)):
+
+    if par1.limited[0] and par1.value-par1.error*nsigma_range < par1.limits[0]:
+        start1 = par1.limits[0]+par1.limits[0]*1e-3
+    else:
+        start1 = par1.value - par1.error*nsigma_range
+    if par1.limited[1] and par1.value+par1.error*nsigma_range > par1.limits[1]:
+        end1 = par1.limits[1]-par1.limits[1]*1e-3
+    else:
+        end1 = par1.value + par1.error*nsigma_range
+
+    step1 = (end1 - start1) / nsteps
+
+    if par2.limited[0] and par2.value-par2.error*nsigma_range < par2.limits[0]:
+        start2 = par2.limits[0]+par2.limits[0]*1e-3
+    else:
+        start2 = par2.value - par2.error*nsigma_range
+    if par2.limited[1] and par2.value+par2.error*nsigma_range > par2.limits[1]:
+        end2 = par2.limits[1]-par2.limits[1]*1e-3
+    else:
+        end2 = par2.value + par2.error*nsigma_range
+
+    step2 = (end2 - start2) / nsteps
+
+    if par1.parname == 'delta0':
+        start1, step1, end1 = 0, 5/nsteps, 5
+    if par2.parname == 'delta0':
+        start2, step2, end2 = 0, 5/nsteps, 5
+
+    assert end1 > start1
+    assert end2 > start2
+
+    p1vals, p2vals = np.mgrid[start1:end1:step1,
+                              start2:end2:step2]
+
+
+    par_likes = np.array([chi2(sp, replace(replace(sp.specfit.parinfo.values, par1.n, val1), par2.n, val2))
+                          for val1,val2 in zip(p1vals.ravel(), p2vals.ravel())]).reshape(p1vals.shape)
+
+    pct68 = 1-scipy.stats.norm.sf(1)*2
+    pct95 = 1-scipy.stats.norm.sf(2)*2
+    pct997 = 1-scipy.stats.norm.sf(3)*2
+
+    # marginalize over only one parameter; we now have two free parameters
+    delta_chi2_68 = scipy.stats.chi2.ppf(pct68, 2)
+    delta_chi2_95 = scipy.stats.chi2.ppf(pct95, 2)
+    delta_chi2_997 = scipy.stats.chi2.ppf(pct997, 2)
+
+    ax = fig.add_subplot(5,5,plotinds[ii])
+    ax.contour(p1vals, p2vals, par_likes,
+               levels=[par_likes.min()+delta_chi2_68,
+                       par_likes.min()+delta_chi2_95,
+                       par_likes.min()+delta_chi2_997])
+    xmin, xmax = ax.get_xlim()
+    ymin, ymax = ax.get_ylim()
+    ax.plot(par1.value, par2.value, 'kx')
+    ax.hlines([par2.value - par2.error,
+               par2.value + par2.error,], xmin, xmax, 'k', '--')
+    ax.vlines([par1.value - par1.error,
+               par1.value + par1.error,], ymin, ymax, 'k', '--')
+    ax.set_xlabel("{0} Value".format(par1.parname))
+    ax.set_ylabel("{0} Value".format(par2.parname))
+    pl.setp(ax.get_xticklabels(), rotation=90)
+
+    ax.set_xlim(xmin, xmax,)
+    ax.set_ylim(ymin, ymax,)
+
+fig.tight_layout()
+
+fig.savefig("ammonia_LTE_restricteddelta_error_estimate_demonstration.pdf")

--- a/examples/synthetic_LTE_ammonia_spectrum_example_witherrorestimates.py
+++ b/examples/synthetic_LTE_ammonia_spectrum_example_witherrorestimates.py
@@ -35,7 +35,7 @@ data = noise+synth_data
 # this will give a "blank header" warning, which is fine
 sp = pyspeckit.Spectrum(data=data, error=error, xarr=xaxis,
                         xarrkwargs={'unit':'km/s'},
-                        unit=u.erg/u.s/u.cm**2/u.AA)
+                        unit=u.K)
 
 sp.plotter(figure=pl.figure(1), errstyle='fill')
 

--- a/examples/synthetic_LTE_ammonia_spectrum_example_witherrorestimates.py
+++ b/examples/synthetic_LTE_ammonia_spectrum_example_witherrorestimates.py
@@ -49,7 +49,7 @@ sp.specfit(fittype='ammonia',
 # do it again to set the errors neatly
 sp.specfit(fittype='ammonia',
            #guesses=[20, 15, 15.5, 3, 2, 1],
-           guesses=[30, 25, 15.5, 3, 2, 0],
+           guesses=sp.specfit.parinfo.values,
            fixed=[False,False,False,False,False,True])
 
 
@@ -237,7 +237,8 @@ for ii,par in enumerate(sp.specfit.parinfo):
                            nsteps)
 
     if par.parname == 'delta0':
-        start, step, end = 0, 5/nsteps, 5
+        maxdelta = 10
+        start, step, end = 0, maxdelta/nsteps, maxdelta
         par_vals = np.linspace(start, end, nsteps)
 
     par_likes = np.array([chi2(sp, replace(sp.specfit.parinfo.values, ii, val))
@@ -299,9 +300,9 @@ for ii,(par1,par2) in enumerate(itertools.combinations(itemgetter(0,2,3,4,6)(sp.
     step2 = (end2 - start2) / nsteps
 
     if par1.parname == 'delta0':
-        start1, step1, end1 = 0, 5/nsteps, 5
+        start1, step1, end1 = 0, maxdelta/nsteps, maxdelta
     if par2.parname == 'delta0':
-        start2, step2, end2 = 0, 5/nsteps, 5
+        start2, step2, end2 = 0, maxdelta/nsteps, maxdelta
 
     assert end1 > start1
     assert end2 > start2

--- a/examples/synthetic_nLTE_ammonia_spectrum_example_witherrorestimates.py
+++ b/examples/synthetic_nLTE_ammonia_spectrum_example_witherrorestimates.py
@@ -1,0 +1,347 @@
+import numpy as np
+from astropy import units as u
+import itertools
+from operator import itemgetter
+import pyspeckit
+import scipy.stats
+
+from pyspeckit.spectrum.models import ammonia, ammonia_constants
+
+import pylab as pl
+pl.close('all')
+pl.figure(1).clf()
+
+oneonefreq = ammonia_constants.freq_dict['oneone']
+twotwofreq = ammonia_constants.freq_dict['twotwo']
+# create an axis that covers the 1-1 and 2-2 inversion lines
+xaxis = pyspeckit.units.SpectroscopicAxis(np.linspace(oneonefreq*(1-50/3e5),
+                                                      twotwofreq*(1+50/3e5),
+                                                      1000.),
+                                          unit=u.Hz)
+sigma = 2.
+center = 0.
+trot = 35.
+ntot = 15.
+# Adopting an NLTE model: T_ex < T_rot (this case is better for the default fitter)
+# pyradex.Radex(species='p-nh3', column=10e14, collider_densities={'h2':10000}, temperature=35)()[8:10]
+tex = {'oneone':16.4, 'twotwo':12.6}
+synth_data = ammonia.ammonia(xaxis, trot=trot, tex=tex, width=sigma,
+                             xoff_v=center, ntot=ntot)
+
+# Add noise
+stddev = 0.1
+noise = np.random.randn(xaxis.size)*stddev
+error = stddev*np.ones_like(synth_data)
+data = noise+synth_data
+
+# this will give a "blank header" warning, which is fine
+sp = pyspeckit.Spectrum(data=data, error=error, xarr=xaxis,
+                        xarrkwargs={'unit':'km/s'},
+                        unit=u.erg/u.s/u.cm**2/u.AA)
+
+sp.plotter(figure=pl.figure(1), errstyle='fill')
+
+# fit with some vague initial guesses and a fixed ortho/para
+# fraction of 1 (it is unconstrained in our data)
+sp.specfit(fittype='ammonia',
+           #guesses=[20, 15, 15.5, 3, 2, 1],
+           guesses=[30, 25, 15.5, 3, 2, 0],
+           fixed=[False,False,False,False,False,True])
+
+# do it again to set the errors neatly
+sp.specfit(fittype='ammonia',
+           #guesses=[20, 15, 15.5, 3, 2, 1],
+           guesses=[30, 25, 15.5, 3, 2, 0],
+           fixed=[False,False,False,False,False,True])
+
+
+sp.plotter(errstyle='fill')
+sp.specfit.plot_fit()
+
+
+sp.plotter.savefig('oned_ammonia_nLTE_fit_example.pdf')
+
+
+# do a deeper examination of the likelihood function
+
+def chi2(sp, pars):
+    """
+    Given a spectrum and some parameters, calculate the chi^2 value
+    """
+    return ((sp.specfit.get_model_frompars(sp.xarr, pars) -
+             sp.specfit.spectofit)**2 /
+            (sp.specfit.errspec**2)
+           ).sum()
+
+def replace(lst, eltid, value):
+    """
+    Helper function to make new parameter value lists below
+    """
+    lstcopy = list(lst)
+    lstcopy[eltid] = value
+    return lstcopy
+
+
+fig = pl.figure(2, figsize=(12,12))
+fig.clf()
+
+for ii,par in enumerate(sp.specfit.parinfo):
+    if par.fixed:
+        continue
+    par_vals = np.linspace(par.value - par.error * 2,
+                           par.value + par.error * 2,
+                           10)
+
+    par_likes = np.array([chi2(sp, replace(sp.specfit.parinfo.values, ii, val))
+                          for val in par_vals])
+
+    pct68 = scipy.stats.chi2.cdf(1, 1)
+
+    # this is for the full 3-parameter case
+    delta_chi2 = scipy.stats.chi2.ppf(pct68, sp.specfit.fitter.npars - sum(sp.specfit.parinfo.fixed))
+
+    # this is the one we're actually using (which is just 1) because we're
+    # marginalizing over the other parameters
+    delta_chi2 = scipy.stats.chi2.ppf(pct68, 1)
+
+    ax = fig.add_subplot(5,5,1+ii*6)
+    ax.plot(par_vals, par_likes)
+    xmin, xmax = ax.get_xlim()
+    ymin, ymax = ax.get_ylim()
+    ax.hlines(par_likes.min() + delta_chi2, xmin, xmax, 'k', '--')
+    ax.vlines([par.value - par.error,
+               par.value + par.error,], ymin, ymax, 'k', '--')
+    ax.set_ylabel("$\Delta \chi^2$")
+    ax.set_xlabel("{0} Value".format(par.parname))
+    pl.setp(ax.get_xticklabels(), rotation=90)
+
+    ax.set_xlim(xmin, xmax,)
+    ax.set_ylim(ymin, ymax,)
+
+fig.tight_layout()
+
+
+nsigma_range = 2
+nsteps = 15.
+
+plotinds = {0:6, 1:11, 2:12, 3:16, 4:17, 5:18, 6:21, 7:22, 8:23, 9:24}
+for ii,(par1,par2) in enumerate(itertools.combinations(sp.specfit.parinfo[:5],2)):
+
+    if par1.limited[0] and par1.value-par1.error*nsigma_range < par1.limits[0]:
+        start1 = par1.limits[0]+par1.limits[0]*1e-3
+    else:
+        start1 = par1.value - par1.error*nsigma_range
+    if par1.limited[1] and par1.value+par1.error*nsigma_range > par1.limits[1]:
+        end1 = par1.limits[1]-par1.limits[1]*1e-3
+    else:
+        end1 = par1.value + par1.error*nsigma_range
+
+    step1 = (end1 - start1) / nsteps
+
+    if par2.limited[0] and par2.value-par2.error*nsigma_range < par2.limits[0]:
+        start2 = par2.limits[0]+par2.limits[0]*1e-3
+    else:
+        start2 = par2.value - par2.error*nsigma_range
+    if par2.limited[1] and par2.value+par2.error*nsigma_range > par2.limits[1]:
+        end2 = par2.limits[1]-par2.limits[1]*1e-3
+    else:
+        end2 = par2.value + par2.error*nsigma_range
+
+    step2 = (end2 - start2) / nsteps
+
+    assert end1 > start1
+    assert end2 > start2
+
+    p1vals, p2vals = np.mgrid[start1:end1:step1,
+                              start2:end2:step2]
+
+
+    par_likes = np.array([chi2(sp, replace(replace(sp.specfit.parinfo.values, par1.n, val1), par2.n, val2))
+                          for val1,val2 in zip(p1vals.ravel(), p2vals.ravel())]).reshape(p1vals.shape)
+
+    pct68 = 1-scipy.stats.norm.sf(1)*2
+    pct95 = 1-scipy.stats.norm.sf(2)*2
+    pct997 = 1-scipy.stats.norm.sf(3)*2
+
+    # marginalize over only one parameter; we now have two free parameters
+    delta_chi2_68 = scipy.stats.chi2.ppf(pct68, 2)
+    delta_chi2_95 = scipy.stats.chi2.ppf(pct95, 2)
+    delta_chi2_997 = scipy.stats.chi2.ppf(pct997, 2)
+
+    ax = fig.add_subplot(5,5,plotinds[ii])
+    ax.contour(p1vals, p2vals, par_likes,
+               levels=[par_likes.min()+delta_chi2_68,
+                       par_likes.min()+delta_chi2_95,
+                       par_likes.min()+delta_chi2_997])
+    xmin, xmax = ax.get_xlim()
+    ymin, ymax = ax.get_ylim()
+    ax.plot(par1.value, par2.value, 'kx')
+    ax.hlines([par2.value - par2.error,
+               par2.value + par2.error,], xmin, xmax, 'k', '--')
+    ax.vlines([par1.value - par1.error,
+               par1.value + par1.error,], ymin, ymax, 'k', '--')
+    ax.set_xlabel("{0} Value".format(par1.parname))
+    ax.set_ylabel("{0} Value".format(par2.parname))
+    pl.setp(ax.get_xticklabels(), rotation=90)
+
+    ax.set_xlim(xmin, xmax,)
+    ax.set_ylim(ymin, ymax,)
+
+fig.tight_layout()
+
+fig.savefig("ammonia_nLTE_default_error_estimate_demonstration.pdf")
+
+
+# fit with restricted delta-T instead of restricted T
+
+sp.specfit.Registry.add_fitter('ammonia_dtex',
+                               ammonia.ammonia_model_restricted_tex(), 7,
+                               multisingle='multi')
+
+sp.specfit(fittype='ammonia_dtex',
+           guesses=[30, 25, 15.5, 3, 2, 0, 5],
+           fixed=[False,False,False,False,False,True,False])
+
+sp.plotter.savefig('oned_ammonia_nLTE_fit_example_deltaT.pdf')
+
+# do a deeper examination of the likelihood function
+
+def chi2(sp, pars):
+    """
+    Given a spectrum and some parameters, calculate the chi^2 value
+    """
+    return ((sp.specfit.get_model_frompars(sp.xarr, pars) -
+             sp.specfit.spectofit)**2 /
+            (sp.specfit.errspec**2)
+           ).sum()
+
+def replace(lst, eltid, value):
+    """
+    Helper function to make new parameter value lists below
+    """
+    lstcopy = list(lst)
+    lstcopy[eltid] = value
+    return lstcopy
+
+
+fig = pl.figure(2, figsize=(12,12))
+fig.clf()
+
+nsteps = 10
+dd = 0
+for ii,par in enumerate(sp.specfit.parinfo):
+    if par.fixed or par.tied:
+        dd = dd + 1
+        continue
+    par_vals = np.linspace(par.value - par.error * 2,
+                           par.value + par.error * 2,
+                           nsteps)
+
+    if par.parname == 'delta0':
+        start, step, end = 0, 5/nsteps, 25
+        par_vals = np.linspace(start, end, nsteps)
+
+    par_likes = np.array([chi2(sp, replace(sp.specfit.parinfo.values, ii, val))
+                          for val in par_vals])
+
+    pct68 = scipy.stats.chi2.cdf(1, 1)
+
+    # this is for the full 3-parameter case
+    delta_chi2 = scipy.stats.chi2.ppf(pct68, sp.specfit.fitter.npars - sum(sp.specfit.parinfo.fixed))
+
+    # this is the one we're actually using (which is just 1) because we're
+    # marginalizing over the other parameters
+    delta_chi2 = scipy.stats.chi2.ppf(pct68, 1)
+
+    ax = fig.add_subplot(5,5,1+(ii-dd)*6)
+    ax.plot(par_vals, par_likes)
+    xmin, xmax = ax.get_xlim()
+    ymin, ymax = ax.get_ylim()
+    ax.hlines(par_likes.min() + delta_chi2, xmin, xmax, 'k', '--')
+    ax.vlines([par.value - par.error,
+               par.value + par.error,], ymin, ymax, 'k', '--')
+    ax.set_ylabel("$\Delta \chi^2$")
+    ax.set_xlabel("{0} Value".format(par.parname))
+    pl.setp(ax.get_xticklabels(), rotation=90)
+
+    ax.set_xlim(xmin, xmax,)
+    ax.set_ylim(ymin, ymax,)
+
+fig.tight_layout()
+
+
+nsigma_range = 2
+nsteps = 15.
+
+
+plotinds = {0:6, 1:11, 2:12, 3:16, 4:17, 5:18, 6:21, 7:22, 8:23, 9:24}
+for ii,(par1,par2) in enumerate(itertools.combinations(itemgetter(0,2,3,4,6)(sp.specfit.parinfo),2)):
+
+    if par1.limited[0] and par1.value-par1.error*nsigma_range < par1.limits[0]:
+        start1 = par1.limits[0]+par1.limits[0]*1e-3
+    else:
+        start1 = par1.value - par1.error*nsigma_range
+    if par1.limited[1] and par1.value+par1.error*nsigma_range > par1.limits[1]:
+        end1 = par1.limits[1]-par1.limits[1]*1e-3
+    else:
+        end1 = par1.value + par1.error*nsigma_range
+
+    step1 = (end1 - start1) / nsteps
+
+    if par2.limited[0] and par2.value-par2.error*nsigma_range < par2.limits[0]:
+        start2 = par2.limits[0]+par2.limits[0]*1e-3
+    else:
+        start2 = par2.value - par2.error*nsigma_range
+    if par2.limited[1] and par2.value+par2.error*nsigma_range > par2.limits[1]:
+        end2 = par2.limits[1]-par2.limits[1]*1e-3
+    else:
+        end2 = par2.value + par2.error*nsigma_range
+
+    step2 = (end2 - start2) / nsteps
+
+    if par1.parname == 'delta0':
+        start1, step1, end1 = 0, 5/nsteps, 25
+    if par2.parname == 'delta0':
+        start2, step2, end2 = 0, 5/nsteps, 25
+
+    assert end1 > start1
+    assert end2 > start2
+
+    p1vals, p2vals = np.mgrid[start1:end1:step1,
+                              start2:end2:step2]
+
+
+    par_likes = np.array([chi2(sp, replace(replace(sp.specfit.parinfo.values, par1.n, val1), par2.n, val2))
+                          for val1,val2 in zip(p1vals.ravel(), p2vals.ravel())]).reshape(p1vals.shape)
+
+    pct68 = 1-scipy.stats.norm.sf(1)*2
+    pct95 = 1-scipy.stats.norm.sf(2)*2
+    pct997 = 1-scipy.stats.norm.sf(3)*2
+
+    # marginalize over only one parameter; we now have two free parameters
+    delta_chi2_68 = scipy.stats.chi2.ppf(pct68, 2)
+    delta_chi2_95 = scipy.stats.chi2.ppf(pct95, 2)
+    delta_chi2_997 = scipy.stats.chi2.ppf(pct997, 2)
+
+    ax = fig.add_subplot(5,5,plotinds[ii])
+    ax.contour(p1vals, p2vals, par_likes,
+               levels=[par_likes.min()+delta_chi2_68,
+                       par_likes.min()+delta_chi2_95,
+                       par_likes.min()+delta_chi2_997])
+    xmin, xmax = ax.get_xlim()
+    ymin, ymax = ax.get_ylim()
+    ax.plot(par1.value, par2.value, 'kx')
+    ax.hlines([par2.value - par2.error,
+               par2.value + par2.error,], xmin, xmax, 'k', '--')
+    ax.vlines([par1.value - par1.error,
+               par1.value + par1.error,], ymin, ymax, 'k', '--')
+    ax.set_xlabel("{0} Value".format(par1.parname))
+    ax.set_ylabel("{0} Value".format(par2.parname))
+    pl.setp(ax.get_xticklabels(), rotation=90)
+
+    ax.set_xlim(xmin, xmax,)
+    ax.set_ylim(ymin, ymax,)
+
+fig.tight_layout()
+
+fig.savefig("ammonia_nLTE_restricteddelta_error_estimate_demonstration.pdf")

--- a/examples/synthetic_nLTE_ammonia_spectrum_example_witherrorestimates.py
+++ b/examples/synthetic_nLTE_ammonia_spectrum_example_witherrorestimates.py
@@ -37,7 +37,7 @@ data = noise+synth_data
 # this will give a "blank header" warning, which is fine
 sp = pyspeckit.Spectrum(data=data, error=error, xarr=xaxis,
                         xarrkwargs={'unit':'km/s'},
-                        unit=u.erg/u.s/u.cm**2/u.AA)
+                        unit=u.K)
 
 sp.plotter(figure=pl.figure(1), errstyle='fill')
 

--- a/examples/synthetic_spectrum_example.py
+++ b/examples/synthetic_spectrum_example.py
@@ -1,0 +1,140 @@
+import numpy as np
+import itertools
+import pyspeckit
+import scipy.stats
+
+import pylab as pl
+pl.close('all')
+pl.figure(1).clf()
+
+xaxis = np.linspace(-50,150,100.)
+sigma = 10.
+center = 50.
+synth_data = np.exp(-(xaxis-center)**2/(sigma**2 * 2.))
+
+# Add noise
+stddev = 0.1
+noise = np.random.randn(xaxis.size)*stddev
+error = stddev*np.ones_like(synth_data)
+data = noise+synth_data
+
+# this will give a "blank header" warning, which is fine
+sp = pyspeckit.Spectrum(data=data, error=error, xarr=xaxis,
+                        xarrkwargs={'unit':'km/s'},
+                        unit='erg/s/cm^2/AA')
+
+sp.plotter(figure=pl.figure(1))
+
+# Fit with automatic guesses
+sp.specfit(fittype='gaussian')
+
+# Fit with input guesses
+# The guesses initialize the fitter
+# This approach uses the 0th, 1st, and 2nd moments
+amplitude_guess = data.max()
+center_guess = (data*xaxis).sum()/data.sum()
+width_guess = (data.sum() / amplitude_guess / (2*np.pi))**0.5
+guesses = [amplitude_guess, center_guess, width_guess]
+sp.specfit(fittype='gaussian', guesses=guesses)
+
+sp.plotter(errstyle='fill')
+sp.specfit.plot_fit()
+
+
+
+# do a deeper examination of the likelihood function
+
+def chi2(sp, pars):
+    """
+    Given a spectrum and some parameters, calculate the chi^2 value
+    """
+    return ((sp.specfit.get_model_frompars(sp.xarr, pars) -
+             sp.specfit.spectofit)**2 /
+            (sp.specfit.errspec**2)
+           ).sum()
+
+def replace(lst, eltid, value):
+    """
+    Helper function to make new parameter value lists below
+    """
+    lstcopy = list(lst)
+    lstcopy[eltid] = value
+    return lstcopy
+
+
+fig = pl.figure(2, figsize=(12,12))
+fig.clf()
+
+for ii,par in enumerate(sp.specfit.parinfo):
+    par_vals = np.linspace(par.value - par.error * 2,
+                           par.value + par.error * 2,
+                           50)
+
+    par_likes = np.array([chi2(sp, replace(sp.specfit.parinfo.values, ii, val))
+                          for val in par_vals])
+
+    pct68 = scipy.stats.chi2.cdf(1, 1)
+
+    # this is for the full 3-parameter case
+    delta_chi2 = scipy.stats.chi2.ppf(pct68, sp.specfit.fitter.npars)
+
+    # this is the one we're actually using (which is just 1) because we're
+    # marginalizing over the other parameters
+    delta_chi2 = scipy.stats.chi2.ppf(pct68, 1)
+
+    ax = fig.add_subplot(3,3,1+ii*4)
+    ax.plot(par_vals, par_likes)
+    xmin, xmax = ax.get_xlim()
+    ymin, ymax = ax.get_ylim()
+    ax.hlines(par_likes.min() + delta_chi2, xmin, xmax, 'k', '--')
+    ax.vlines([par.value - par.error,
+               par.value + par.error,], ymin, ymax, 'k', '--')
+    ax.set_ylabel("$\Delta \chi^2$")
+    ax.set_xlabel("{0} Value".format(par.parname))
+    pl.setp(ax.get_xticklabels(), rotation=90)
+
+    ax.set_xlim(xmin, xmax,)
+    ax.set_ylim(ymin, ymax,)
+
+fig.tight_layout()
+
+
+plotinds = {0:4, 1:7, 2:8}
+for ii,(par1,par2) in enumerate(itertools.combinations(sp.specfit.parinfo,2)):
+    p1vals, p2vals = np.mgrid[par1.value-par1.error*2:par1.value+par1.error*2:par1.error/25,
+                              par2.value-par2.error*2:par2.value+par2.error*2:par2.error/25,]
+
+
+    par_likes = np.array([chi2(sp, replace(replace(sp.specfit.parinfo.values, par1.n, val1), par2.n, val2))
+                          for val1,val2 in zip(p1vals.ravel(), p2vals.ravel())]).reshape(p1vals.shape)
+
+    pct68 = 1-scipy.stats.norm.sf(1)*2
+    pct95 = 1-scipy.stats.norm.sf(2)*2
+    pct997 = 1-scipy.stats.norm.sf(3)*2
+
+    # marginalize over only one parameter; we now have two free parameters
+    delta_chi2_68 = scipy.stats.chi2.ppf(pct68, 2)
+    delta_chi2_95 = scipy.stats.chi2.ppf(pct95, 2)
+    delta_chi2_997 = scipy.stats.chi2.ppf(pct997, 2)
+
+    ax = fig.add_subplot(3,3,plotinds[ii])
+    ax.contour(p1vals, p2vals, par_likes,
+               levels=[par_likes.min()+delta_chi2_68,
+                       par_likes.min()+delta_chi2_95,
+                       par_likes.min()+delta_chi2_997])
+    xmin, xmax = ax.get_xlim()
+    ymin, ymax = ax.get_ylim()
+    ax.hlines([par2.value - par2.error,
+               par2.value + par2.error,], xmin, xmax, 'k', '--')
+    ax.vlines([par1.value - par1.error,
+               par1.value + par1.error,], ymin, ymax, 'k', '--')
+    ax.set_xlabel("{0} Value".format(par1.parname))
+    ax.set_ylabel("{0} Value".format(par2.parname))
+    pl.setp(ax.get_xticklabels(), rotation=90)
+
+    ax.set_xlim(xmin, xmax,)
+    ax.set_ylim(ymin, ymax,)
+
+fig.tight_layout()
+
+fig.savefig("error_estimate_demonstration.pdf")

--- a/pyspeckit/spectrum/models/ammonia.py
+++ b/pyspeckit/spectrum/models/ammonia.py
@@ -350,6 +350,25 @@ def _ammonia_spectrum(xarr, tex, tau_dict, width, xoff_v, fortho, line_names,
 
 
 class ammonia_model(model.SpectralModel):
+    """
+    The basic Ammonia (NH3) model with 6 free parameters:
+        Trot, Tex, ntot, width, xoff_v, and fortho
+
+    Trot is the rotational temperature.  It governs the relative populations of
+    the rotational states, i.e., the relative strength of different transitions
+
+    Tex is the excitation temperature.  It is assumed constant across all
+    states, which is not always a good assumption - a radiative transfer and
+    excitation model is required to constrain this, though.
+
+    ntot is the total column density of p-NH3 integrated over all states.
+
+    width is the linewidth
+
+    xoff_v is the velocity offset / line of sight velocity
+
+    fortho is the ortho fraction  (northo / (northo+npara))
+    """
 
     def __init__(self,npeaks=1,npars=6,
                  parnames=['trot','tex','ntot','width','xoff_v','fortho'],

--- a/pyspeckit/spectrum/models/ammonia.py
+++ b/pyspeckit/spectrum/models/ammonia.py
@@ -998,10 +998,12 @@ class ammonia_model_restricted_tex(ammonia_model):
         super(ammonia_model_restricted_tex, self).__init__(npars=7,
                                                            parnames=parnames,
                                                            **kwargs)
-        def ammonia_dtex(*args, delta=None, **kwargs):
+        def ammonia_dtex(*args, **kwargs):
             """
             Strip out the 'delta' keyword
             """
+            # for py2 compatibility, must strip out manually
+            delta = kwargs.pop('delta') if 'delta' in kwargs else None
             np.testing.assert_allclose(kwargs['trot'] - kwargs['tex'],
                                        delta)
             return ammonia(*args, **kwargs)

--- a/pyspeckit/spectrum/models/ammonia.py
+++ b/pyspeckit/spectrum/models/ammonia.py
@@ -26,6 +26,7 @@ from astropy.extern.six import iteritems
 from . import mpfit_messages
 import operator
 import string
+import warnings
 
 from .ammonia_constants import (line_names, freq_dict, aval_dict, ortho_dict,
                                 voff_lines_dict, tau_wts_dict)
@@ -108,6 +109,11 @@ def ammonia(xarr, trot=20, tex=None, ntot=14, width=1, xoff_v=0.0,
         for k in tex:
             assert k in line_names,"{0} not in line list".format(k)
         line_names = tex.keys()
+    elif tex > trot:
+        warnings.warn("tex > trot in the ammonia model.  "
+                      "This is unphysical and "
+                      "suggests that you may need to constrain tex.  See "
+                      "ammonia_model_restricted_tex.")
 
     from .ammonia_constants import line_name_indices, line_names as original_line_names
 
@@ -632,7 +638,7 @@ class ammonia_model(model.SpectralModel):
         tex_key = {'trot':'T_R', 'tkin': 'T_K', 'tex':'T_{ex}', 'ntot':'N',
                    'fortho':'F_o', 'width':'\\sigma', 'xoff_v':'v',
                    'fillingfraction':'FF', 'tau':'\\tau_{1-1}',
-                   'background_tb':'T_{BG}'}
+                   'background_tb':'T_{BG}', 'delta':'T_R-T_{ex}'}
         # small hack below: don't quantize if error > value.  We want to see the values.
         label_list = []
         for pinfo in self.parinfo:
@@ -806,9 +812,6 @@ class ammonia_model_vtau(ammonia_model):
         # trot, TEX, ntot, width, center, ortho fraction
         return [20, 10, 10, 1.0, 0.0, 1.0]
 
-    def __call__(self,*args,**kwargs):
-        return self.multinh3fit(*args,**kwargs)
-
     def _validate_parinfo(self,
                           must_be_limited={'trot': [True,False],
                                            'tex': [False,False],
@@ -924,13 +927,6 @@ class ammonia_model_background(ammonia_model):
         # trot, TEX, ntot, width, center, ortho fraction
         return [20,10, 10, 1.0, 0.0, 1.0, TCMB]
 
-    def __call__(self,*args,**kwargs):
-        #if self.multisingle == 'single':
-        #    return self.onepeakammoniafit(*args,**kwargs)
-        #elif self.multisingle == 'multi':
-        #    # Why is tied 6 instead of 7?
-        return self.multinh3fit(*args,**kwargs)
-
     def make_parinfo(self, npeaks=1, err=None,
                      params=(20,20,14,1.0,0.0,0.5,TCMB), parnames=None,
                      fixed=(False,False,False,False,False,False,True),
@@ -993,6 +989,92 @@ class cold_ammonia_model(ammonia_model):
         supes = super(cold_ammonia_model, self)
         return supes._validate_parinfo(must_be_limited=must_be_limited,
                                        required_limits=required_limits)
+
+class ammonia_model_restricted_tex(ammonia_model):
+    def __init__(self,
+                 parnames=['trot', 'tex', 'ntot', 'width', 'xoff_v', 'fortho',
+                           'delta'],
+                 **kwargs):
+        super(ammonia_model_restricted_tex, self).__init__(npars=7,
+                                                           parnames=parnames,
+                                                           **kwargs)
+        def ammonia_dtex(*args, delta=None, **kwargs):
+            """
+            Strip out the 'delta' keyword
+            """
+            np.testing.assert_allclose(kwargs['trot'] - kwargs['tex'],
+                                       delta)
+            return ammonia(*args, **kwargs)
+        self.modelfunc = ammonia_dtex
+
+    def n_ammonia(self, pars=None, parnames=None, **kwargs):
+        if parnames is not None:
+            for ii,pn in enumerate(parnames):
+                if ii % 7 == 1 and 'tex' not in pn:
+                    raise ValueError('bad parameter names')
+                if ii % 7 == 6 and 'delta' not in pn:
+                    raise ValueError('bad parameter names')
+        if pars is not None:
+            assert len(pars) % 7 == 0
+            for ii in range(int(len(pars)/7)):
+                try:
+                    # Case A: they're param objects
+                    # (setting the param directly can result in recursion errors)
+                    pars[1+ii*7].value = pars[0+ii*7].value - pars[6+ii*7].value
+                except AttributeError:
+                    # Case B: they're just lists of values
+                    pars[1+ii*7] = pars[0+ii*7] - pars[6+ii*7]
+
+        supes = super(ammonia_model_restricted_tex, self)
+        return supes.n_ammonia(pars=pars, parnames=parnames, **kwargs)
+
+
+    def _validate_parinfo(self,
+                          must_be_limited={'trot': [True,False],
+                                           'tex': [False,False],
+                                           'ntot': [True, False],
+                                           'width': [True, False],
+                                           'xoff_v': [False, False],
+                                           'fortho': [True, True],
+                                           'delta': [True, False],
+                                          },
+                          required_limits={'trot': [0, None],
+                                           'tex': [None,None],
+                                           'width': [0, None],
+                                           'ntot': [0, None],
+                                           'xoff_v': [None,None],
+                                           'fortho': [0,1],
+                                           'delta': [0, None],
+                                          }):
+        supes = super(ammonia_model_restricted_tex, self)
+        return supes._validate_parinfo(must_be_limited=must_be_limited,
+                                       required_limits=required_limits)
+
+    def make_parinfo(self,
+                     params=(20,20,0.5,1.0,0.0,0.5,0),
+                     fixed=(False,False,False,False,False,False,False),
+                     limitedmin=(True,True,True,True,False,True,True),
+                     limitedmax=(False,False,False,False,False,True,False),
+                     minpars=(TCMB,TCMB,0,0,0,0,0),
+                     maxpars=(0,0,0,0,0,1,0),
+                     tied=('','p[0]-p[6]','','','','',''),
+                     **kwargs
+                     ):
+        """
+        parnames=['trot', 'tex', 'ntot', 'width', 'xoff_v', 'fortho', 'delta']
+        
+        'delta' is the difference between tex and trot
+        """
+        supes = super(ammonia_model_restricted_tex, self)
+        return supes.make_parinfo(params=params, fixed=fixed,
+                                  limitedmax=limitedmax, limitedmin=limitedmin,
+                                  minpars=minpars, maxpars=maxpars, tied=tied,
+                                  **kwargs)
+
+
+
+
+
 
 def _increment_string_number(st, count):
     """

--- a/pyspeckit/spectrum/models/model.py
+++ b/pyspeckit/spectrum/models/model.py
@@ -892,7 +892,7 @@ class SpectralModel(fitter.SimpleFitter):
         return sampler
 
     def get_pymc(self, xarr, data, error, use_fitted_values=False, inf=np.inf,
-            use_adaptive=False, return_dict=False, **kwargs):
+                 use_adaptive=False, return_dict=False, **kwargs):
         """
         Create a pymc MCMC sampler.  Defaults to 'uninformative' priors
 
@@ -903,6 +903,8 @@ class SpectralModel(fitter.SimpleFitter):
         use_fitted_values : bool
             Each parameter with a measured error will have a prior defined by
             the Normal distribution with sigma = par.error and mean = par.value
+        use_adaptive : bool
+            Use the Adaptive Metropolis-Hastings sampler?
 
         Examples
         --------
@@ -943,7 +945,7 @@ class SpectralModel(fitter.SimpleFitter):
         parcopy = copy.deepcopy(self.parinfo)
         for par in parcopy:
             lolim = par.limits[0] if par.limited[0] else -inf
-            uplim = par.limits[1] if par.limited[1] else  inf
+            uplim = par.limits[1] if par.limited[1] else inf
             if par.fixed:
                 funcdict[par.parname] = pymc.distributions.Uniform(par.parname, par.value, par.value, value=par.value)
             elif use_fitted_values:
@@ -963,7 +965,7 @@ class SpectralModel(fitter.SimpleFitter):
                         funcdict[par.parname] = pymc.distributions.Uninformative(par.parname, value=par.value)
             elif any(par.limited):
                 lolim = par.limits[0] if par.limited[0] else -1e10
-                uplim = par.limits[1] if par.limited[1] else  1e10
+                uplim = par.limits[1] if par.limited[1] else 1e10
                 funcdict[par.parname] = pymc.distributions.Uniform(par.parname, lower=lolim, upper=uplim, value=par.value)
             else:
                 funcdict[par.parname] = pymc.distributions.Uninformative(par.parname, value=par.value)


### PR DESCRIPTION
The new ammonia model is a more reasonable fitter to use in the LTE case
(T_rot=T_ex), since T_ex > T_rot is unphysical.

This comes with some examples that effectively test that case, but I'm not
running them as tests.  Instead, they're good for looking at how parameter
errors are affected.