### PR TITLE
Make the WIP LTE molecule a fully-functional tool

### DIFF
--- a/pyspeckit/spectrum/models/lte_molecule.py
+++ b/pyspeckit/spectrum/models/lte_molecule.py
@@ -206,6 +206,8 @@ def generate_model(xarr, vcen, width, tex, column,
     Q = partfunc(tex)
 
     for A, g, nu, eu in zip(aij, deg, freqs_, EU):
+        if nu == 0:
+            continue
         tau_per_dnu = line_tau_cgs(tex,
                                    column,
                                    Q,

--- a/pyspeckit/spectrum/models/lte_molecule.py
+++ b/pyspeckit/spectrum/models/lte_molecule.py
@@ -196,18 +196,24 @@ def generate_model(xarr, vcen, width, tex, column,
     # assume equal-width channels
     #kwargs = dict(rest=ref_freq)
     #equiv = u.doppler_radio(**kwargs)
-    channelwidth = np.abs(xarr[1].to(u.Hz, ) - xarr[0].to(u.Hz, )).value
+
+    # channelwidth array, with last element approximated
+    channelwidth = np.empty_like(xarr.value)
+    channelwidth[:-1] = np.abs(np.diff(xarr.to(u.Hz))).value
+    channelwidth[-1] = channelwidth[-2]
+
     #velo = xarr.to(u.km/u.s, equiv).value
     freq = xarr.to(u.Hz).value # same unit as nu below
     model = np.zeros_like(xarr).value
+
+    # splatalogue can report bad frequencies as zero
+    OK = freqs.value != 0
 
     freqs_ = freqs.to(u.Hz).value
 
     Q = partfunc(tex)
 
-    for A, g, nu, eu in zip(aij, deg, freqs_, EU):
-        if nu == 0:
-            continue
+    for A, g, nu, eu in zip(aij[OK], deg[OK], freqs_[OK], EU[OK]):
         tau_per_dnu = line_tau_cgs(tex,
                                    column,
                                    Q,

--- a/pyspeckit/spectrum/models/lte_molecule.py
+++ b/pyspeckit/spectrum/models/lte_molecule.py
@@ -108,6 +108,7 @@ class lte_line_model_generator(object):
 def get_molecular_parameters(molecule_name,
                              molecule_name_vamdc=None,
                              tex=50, fmin=1*u.GHz, fmax=1*u.THz,
+                             line_lists=['SLAIM'],
                              chem_re_flags=0, **kwargs):
     """
     Get the molecular parameters for a molecule from the CDMS database using
@@ -144,9 +145,9 @@ def get_molecular_parameters(molecule_name,
 
     # do this here, before trying to compute the partition function, because
     # this query could fail
-    slaim = Splatalogue.query_lines(fmin, fmax, chemical_name=molecule_name,
-                                    line_lists=['SLAIM'],
-                                    show_upper_degeneracy=True, **kwargs)
+    tbl = Splatalogue.query_lines(fmin, fmax, chemical_name=molecule_name,
+                                  line_lists=line_lists,
+                                  show_upper_degeneracy=True, **kwargs)
      
     nl = nodes.Nodelist()
     nl.findnode('cdms')
@@ -165,10 +166,10 @@ def get_molecular_parameters(molecule_name,
         return Q
 
 
-    freqs = np.array(slaim['Freq-GHz'])*u.GHz
-    aij = slaim['Log<sub>10</sub> (A<sub>ij</sub>)']
-    deg = slaim['Upper State Degeneracy']
-    EU = (np.array(slaim['E_U (K)'])*u.K*constants.k_B).to(u.erg).value
+    freqs = np.array(tbl['Freq-GHz'])*u.GHz
+    aij = tbl['Log<sub>10</sub> (A<sub>ij</sub>)']
+    deg = tbl['Upper State Degeneracy']
+    EU = (np.array(tbl['E_U (K)'])*u.K*constants.k_B).to(u.erg).value
 
     return freqs, aij, deg, EU, partfunc
 


### PR DESCRIPTION
It depends on vamdclib for the partition function, which is a bit annoying, but it works!

An example that is not very cheap to run:

```
fmin, fmax = (90,100)*u.GHz
freqs, aij, deg, EU, partfunc = get_molecular_parameters('CH3OH', fmin=fmin, fmax=fmax)

def modfunc(xarr, vcen, width, tex, column):
    return generate_model(xarr, vcen, width, tex, column, freqs=freqs, aij=aij,
                          deg=deg, EU=EU, partfunc=partfunc)

fitter = generate_fitter(modfunc, name="CH3OH")

xarr = np.linspace(fmin, fmax, 1e6)
yarr = modfunc(xarr, 0, 5, 500, 1e15)
pl.plot(xarr, yarr)
```
![image](https://user-images.githubusercontent.com/143715/36811346-a8ce3432-1c8a-11e8-9c3c-9cf99f13def1.png)
