### PR TITLE
Better defaults for Ammonia interactive guesser

### DIFF
--- a/pyspeckit/spectrum/models/ammonia.py
+++ b/pyspeckit/spectrum/models/ammonia.py
@@ -843,7 +843,7 @@ class ammonia_model(model.SpectralModel):
         guesses appropriate to the model.
 
         For NH3 models, we add in several extra parameters:
-            tex = peak
+            tex = 2.73 * peak
             trot = tex * 2
             fortho = 0.5
             ntot = 15
@@ -851,6 +851,11 @@ class ammonia_model(model.SpectralModel):
         ntot is set to a constant ~10^15 because this results in optical depths
         near 1, so it forces the emission to be approximately significant.
         trot > tex so that we're in a physical regime to begin with.
+
+        We assume tex = peak + 2.73 because most spectra are shown
+        background-subtracted (single dish are always that way, interferometric
+        data are intrinsically that way...) and otherwise the guessing will
+        crash if you guess a number < 2.73.
         """
         gauss_npars = 3
         if len(guesses) % gauss_npars != 0:
@@ -865,8 +870,8 @@ class ammonia_model(model.SpectralModel):
             peak = guesses[ii * gauss_npars + 0]
             center = guesses[ii * gauss_npars + 1]
             width = guesses[ii * gauss_npars + 2]
-            new_guesses[ii*npars + 0] = peak * 2
-            new_guesses[ii*npars + 1] = peak
+            new_guesses[ii*npars + 0] = (2.73+peak) * 2
+            new_guesses[ii*npars + 1] = (2.73+peak)
             new_guesses[ii*npars + 3] = width
             new_guesses[ii*npars + 4] = center
 

--- a/pyspeckit/spectrum/models/tests/test_ammonia.py
+++ b/pyspeckit/spectrum/models/tests/test_ammonia.py
@@ -205,14 +205,14 @@ def test_ammonia_guessing():
 
     mod = ammonia.ammonia_model()
 
-    rslt = mod.parse_3par_guesses(['amp', 'cen', 'wid'])
+    rslt = mod.parse_3par_guesses([1.0, 'cen', 'wid'])
 
-    assert rslt == ['ampamp', 'amp', 15, 'wid', 'cen', 0.5]
+    assert rslt == [3.73*2, 3.73, 15, 'wid', 'cen', 0.5]
 
-    rslt = mod.parse_3par_guesses(['amp1', 'cen1', 'wid1',
-                                   'amp2', 'cen2', 'wid2',
+    rslt = mod.parse_3par_guesses([1.0, 'cen1', 'wid1',
+                                   2.0, 'cen2', 'wid2',
                                   ])
 
-    assert rslt == ['amp1amp1', 'amp1', 15, 'wid1', 'cen1', 0.5,
-                    'amp2amp2', 'amp2', 15, 'wid2', 'cen2', 0.5,
+    assert rslt == [3.73*2, 3.73, 15, 'wid1', 'cen1', 0.5,
+                    4.73*2, 4.73, 15, 'wid2', 'cen2', 0.5,
                    ]


### PR DESCRIPTION
Default to Tex > 2.73 to avoid <2.73-> crash errors.