### PR TITLE
If errors can't be computed, set them to None

### DIFF
--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -995,7 +995,8 @@ class Specfit(interactive.Interactive):
         for par in self.parinfo:
             if par.scaleable:
                 par.value = par.value * scalefactor
-                par.error = par.error * scalefactor
+                if par.error is not None:
+                    par.error = par.error * scalefactor
 
         if self.Spectrum.plotter.axis is not None and plot:
             if color is not None:

--- a/pyspeckit/spectrum/models/model.py
+++ b/pyspeckit/spectrum/models/model.py
@@ -501,7 +501,8 @@ class SpectralModel(fitter.SimpleFitter):
         # Force consistency w/earlier versions of lmfit: if error == 0 exactly,
         # change it to None
         for par in self.LMParams:
-            if par.stderr == 0:
+            if hasattr(par, 'stderr') and par.stderr == 0:
+                #assert minimizer.ier == 4
                 par.stderr = None
 
         self.parinfo._from_Parameters(self.LMParams)
@@ -612,6 +613,12 @@ class SpectralModel(fitter.SimpleFitter):
             # for consistency w/lmfit, and because it makes more sense, errors
             # of 0 will instead be None
             self.parinfo[i]['error'] = e if e != 0 else None
+
+        # sanity check: if status==4, errors could not be computed
+        # Apparently some parameters can have errors estimated even if all can't?
+        #if mp.status == 4:
+        #    assert all([self.parinfo[ii]['error'] is None
+        #                for ii in range(len(mpp))])
 
         if veryverbose:
             log.info("Fit status: {0}".format(mp.status))

--- a/pyspeckit/spectrum/models/model.py
+++ b/pyspeckit/spectrum/models/model.py
@@ -612,7 +612,7 @@ class SpectralModel(fitter.SimpleFitter):
             self.parinfo[i]['value'] = p
             # for consistency w/lmfit, and because it makes more sense, errors
             # of 0 will instead be None
-            self.parinfo[i]['error'] = e if e != 0 else None
+            self.parinfo[i]['error'] = e if (e != 0 or mp.status != 4) else None
 
         # sanity check: if status==4, errors could not be computed
         # Apparently some parameters can have errors estimated even if all can't?

--- a/pyspeckit/spectrum/models/model.py
+++ b/pyspeckit/spectrum/models/model.py
@@ -153,6 +153,7 @@ class SpectralModel(fitter.SimpleFitter):
 
     def __call__(self, *args, **kwargs):
 
+        log.debug("Fitter called with args={0} and kwargs={1}".format(args, kwargs))
         use_lmfit = kwargs.pop('use_lmfit') if 'use_lmfit' in kwargs else self.use_lmfit
         if use_lmfit:
             return self.lmfitter(*args,**kwargs)
@@ -187,6 +188,7 @@ class SpectralModel(fitter.SimpleFitter):
         therefore must have values within parameter ranges)
 
         """
+        log.debug("BEGIN _make_parinfo")
 
         # for backwards compatibility - partied = tied, etc.
         locals_dict = locals()
@@ -451,7 +453,9 @@ class SpectralModel(fitter.SimpleFitter):
         try:
             import lmfit
         except ImportError as e:
-            raise ImportError( "Could not import lmfit, try using mpfit instead." )
+            raise ImportError("Could not import lmfit, try using mpfit instead.")
+
+        log.debug("lmfit called with parinfo=\n{0}".format(parinfo))
 
         self.xax = xax # the 'stored' xax is just a link to the original
         if hasattr(xax,'convert_to_unit') and self.fitunit is not None:
@@ -485,16 +489,25 @@ class SpectralModel(fitter.SimpleFitter):
         LMParams = parinfo.as_Parameters()
         log.debug("LMParams: "+"\n".join([repr(p) for p in list(LMParams.values())]))
         log.debug("parinfo:  {0}".format(parinfo))
+        log.debug("BEGIN MINIMIZER")
         minimizer = lmfit.minimize(self.lmfitfun(xax,np.array(data),err,debug=debug),LMParams,**kwargs)
+        log.debug("END MINIMIZER")
         if not quiet:
             log.info("There were %i function evaluations" % (minimizer.nfev))
         #modelpars = [p.value for p in parinfo.values()]
         #modelerrs = [p.stderr for p in parinfo.values() if p.stderr is not None else 0]
 
         self.LMParams = minimizer.params
+        # Force consistency w/earlier versions of lmfit: if error == 0 exactly,
+        # change it to None
+        for par in self.LMParams:
+            if par.stderr == 0:
+                par.stderr = None
+
         self.parinfo._from_Parameters(self.LMParams)
         log.debug("LMParams: {0}".format(self.LMParams))
         log.debug("parinfo: {0}".format(parinfo))
+
 
         self.mp = minimizer
         self.mpp = self.parinfo.values
@@ -511,7 +524,7 @@ class SpectralModel(fitter.SimpleFitter):
             except TypeError:
                 chi2 = ((data-self.model)**2).sum()
         if np.isnan(chi2):
-            warn( "Warning: chi^2 is nan" )
+            warn("Warning: chi^2 is nan")
 
         if hasattr(self.mp,'ier') and self.mp.ier not in [1,2,3,4]:
             log.warning("Fitter failed: %s, %s" % (self.mp.message, self.mp.lmdif_message))
@@ -583,18 +596,22 @@ class SpectralModel(fitter.SimpleFitter):
 
         mp = mpfit(self.mpfitfun(xax,data,err),parinfo=parinfo,quiet=quiet,debug=debug,**kwargs)
         mpp = mp.params
-        if mp.perror is not None: mpperr = mp.perror
-        else: mpperr = mpp*0
+        if mp.perror is not None:
+            mpperr = mp.perror
+        else:
+            mpperr = mpp*0
         chi2 = mp.fnorm
 
         if mp.status == 0:
             if "parameters are not within PARINFO limits" in mp.errmsg:
-                log.warning( parinfo )
+                log.warning(parinfo)
             raise mpfitException(mp.errmsg)
 
         for i,(p,e) in enumerate(zip(mpp,mpperr)):
             self.parinfo[i]['value'] = p
-            self.parinfo[i]['error'] = e
+            # for consistency w/lmfit, and because it makes more sense, errors
+            # of 0 will instead be None
+            self.parinfo[i]['error'] = e if e != 0 else None
 
         if veryverbose:
             log.info("Fit status: {0}".format(mp.status))

--- a/pyspeckit/spectrum/parinfo.py
+++ b/pyspeckit/spectrum/parinfo.py
@@ -143,7 +143,7 @@ class ParinfoList(list):
         """
         if hasattr(value,'n') and value.n in self.n and renumber is not False:
             # indexed from 0, so len(self) = max(self.n)+1
-            value.n = len(self) 
+            value.n = len(self)
         super(ParinfoList, self).append(value)
         self._check_names()
         self._set_attributes()
@@ -156,11 +156,11 @@ class ParinfoList(list):
             P = Parameters()
             for par in self:
                 P.add(name=par.parname,
-                        value=par.value,
-                        vary=not(par.fixed),
-                        expr=par.tied if par.tied is not '' else None,
-                        min=par.limits[0] if par.limited[0] else None,
-                        max=par.limits[1] if par.limited[1] else None)
+                      value=par.value,
+                      vary=not(par.fixed),
+                      expr=par.tied if par.tied is not '' else None,
+                      min=par.limits[0] if par.limited[0] else None,
+                      max=par.limits[1] if par.limited[1] else None)
 
             return P
 
@@ -231,7 +231,7 @@ class Parinfo(dict):
         if limited
     limited: (bool, bool)
         Is the parameter value limited?
-    step: number 
+    step: number
         from MPFIT: the step size to be used in calculating the numerical
         derivatives.  If set to zero, then the step size is computed
         automatically.  Ignored when AUTODERIVATIVE=0.
@@ -247,8 +247,8 @@ class Parinfo(dict):
             parameter array P are permitted.  Example: if parameter 2 is always
             to be twice parameter 1 then use the following: parinfo(2).tied =
             '2 * p(1)'.  Since they are totally constrained, tied parameters
-            are considered to be fixed; no errors are computed for them.  
-            NOTE: the PARNAME can't be used in expressions. 
+            are considered to be fixed; no errors are computed for them.
+            NOTE: the PARNAME can't be used in expressions.
     parname: string
         The parameter name
     shortparname: string (tex)
@@ -270,7 +270,7 @@ class Parinfo(dict):
 
         if values is not None:
             self.update(values)
-        
+
         self.__dict__ = self
 
     def __repr__(self):
@@ -404,7 +404,7 @@ class Parinfo(dict):
         Perform an operation (addition, subtraction, mutiplication, division, etc.)
         """
 
-        def ofunc(self, other): 
+        def ofunc(self, other):
             """ Operation Function """
             intypes = type(other),type(self.value)
             try:
@@ -439,7 +439,7 @@ class Parinfo(dict):
     __pow__ = _operation_wrapper('pow')
     __rpow__ = _operation_wrapper('rpow')
 
-    try: 
+    try:
         def __array__(self):
             import numpy as np
             return np.array(self.value)
@@ -468,26 +468,26 @@ if __name__=="__main__":
         P.limits = value
 
     def check_index(key):
-        PL = ParinfoList([Parinfo({'parname':'HEIGHT'}), 
+        PL = ParinfoList([Parinfo({'parname':'HEIGHT'}),
                         Parinfo({'value':15,'parname':'AMPLITUDE'}),
                         Parinfo({'value':3,'parname':'WIDTH'}),
                         Parinfo({'value':4,'parname':'WIDTH'})])
         return PL[key]
 
     def check_set_list(values):
-        PL = ParinfoList([Parinfo({'parname':'HEIGHT'}), 
+        PL = ParinfoList([Parinfo({'parname':'HEIGHT'}),
                         Parinfo({'value':15,'parname':'AMPLITUDE'}),
                         Parinfo({'value':3,'parname':'WIDTH','limits':(0,5),'limited':(True,True)}),
                         Parinfo({'value':4,'parname':'WIDTH'})])
         PL.shortparnames = ['a','b','c','d']
         PL.values = values
         return PL.values
-    
+
     class MyTestCase(unittest.TestCase):
         def __init__(self, methodName='runTest', param=None):
             super(MyTestCase, self).__init__(methodName)
             self.param = param
-        
+
         def test_checks_value_fail(self):
             check_failure(0.5)
             self.assertRaises(ValueError, check_failure, 5)


### PR DESCRIPTION
This will prevent erroneous reporting of "zero" error when really it is "None".  At the moment, though, it will also result in somehwat useless annotations in plots...