### PR TITLE
Increase fiteach verbosity and work on ammonia fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: python
+language: c
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
@@ -17,11 +17,6 @@ cache:
     directories:
         - $HOME/.cache/matplotlib
 
-python:
-    - 2.7
-    - 3.5
-    - 3.6
-      # not yet - 3.7
 
 env:
     global:
@@ -34,6 +29,7 @@ env:
         - PIP_DEPENDENCIES='lineid-plot'
         - SETUP_XVFB=True
         - MPLBACKEND=TkAgg
+        - PYTHON_VERSION=3.6
 
     matrix:
         # Make sure that egg_info works without dependencies
@@ -44,46 +40,52 @@ env:
 matrix:
     include:
 
+        - env: PYTHON_VERSION=2.7
+
+        - env: PYTHON_VERSION=3.6
+
+        - env: PYTHON_VERSION=3.7
+
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
-        - python: 3.6
-          env: SETUP_CMD='build_sphinx' # don't crash for warnings
+        - env: SETUP_CMD='build_sphinx' # don't crash for warnings
+               PYTHON_VERSION=3.6
 
         # Try Astropy development version (which is no longer compatible with py2.7)
-        - python: 3.6
-          env: ASTROPY_VERSION=development SETUP_CMD='test'
-              PIP_DEPENDENCIES='pytest-astropy'
+        - env: ASTROPY_VERSION=development SETUP_CMD='test'
+               PIP_DEPENDENCIES='pytest-astropy'
+               PYTHON_VERSION=3.6
 
         # try with recent versions of mpl
-        - python: 3.5
-          env: ASTROPY_VERSION=development
+        - env: ASTROPY_VERSION=development
               SETUP_CMD='test'
               NUMPY_VERSION=1.14
               CONDA_DEPENDENCIES='matplotlib=2 scipy spectral-cube'
               PIP_DEPENDENCIES='pytest-astropy'
+              PYTHON_VERSION=3.7
 
-        - python: 3.6
-          env: ASTROPY_VERSION=development
+        - env: ASTROPY_VERSION=development
               SETUP_CMD='test'
               NUMPY_VERSION=1.14
               CONDA_DEPENDENCIES='matplotlib=2 scipy spectral-cube'
               PIP_DEPENDENCIES='pytest-astropy'
+              PYTHON_VERSION=3.6
 
-        - python: 3.6
-          env: ASTROPY_VERSION=development
+        - env: ASTROPY_VERSION=development
               SETUP_CMD='test'
               CONDA_DEPENDENCIES='matplotlib=3 scipy spectral-cube'
               PIP_DEPENDENCIES='matplotlib==3 pytest-astropy'
+              PYTHON_VERSION=3.6
 
         # Try with optional dependencies disabled
-        - python: 2.7
-          env: SETUP_CMD='test'
+        - env: SETUP_CMD='test'
                CONDA_DEPENDENCIES='matplotlib=1.5 scipy spectral-cube'
                PIP_DEPENDENCIES=''
-        - python: 3.6
-          env: SETUP_CMD='test'
+               PYTHON_VERSION=2.7
+        - env: SETUP_CMD='test'
                CONDA_DEPENDENCIES='matplotlib=1.5 scipy spectral-cube'
                PIP_DEPENDENCIES=''
+               PYTHON_VERSION=3.6
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,16 +45,17 @@ env:
 matrix:
     include:
 
+        # Check for sphinx doc build warnings - we do this first because it
+        # may run for a long time
+        # -wn is removed because I'm ignoring warnings
+        - env: SETUP_CMD='build_sphinx'
+               PYTHON_VERSION=3.6
+
         - env: PYTHON_VERSION=2.7
 
         - env: PYTHON_VERSION=3.6
 
         - env: PYTHON_VERSION=3.7
-
-        # Check for sphinx doc build warnings - we do this first because it
-        # may run for a long time
-        - env: SETUP_CMD='build_sphinx' # don't crash for warnings
-               PYTHON_VERSION=3.6
 
         # Try Astropy development version (which is no longer compatible with py2.7)
         - env: ASTROPY_VERSION=development SETUP_CMD='test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ env:
         - SETUP_XVFB=True
         - MPLBACKEND=TkAgg
         - PYTHON_VERSION=3.6
+        - SETUP_CMD='test'
 
     matrix:
         # Make sure that egg_info works without dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: c
 
+compiler: gcc
+
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
+
+os:
+    - linux
 
 # The apt packages below are needed for sphinx builds, which can no longer
 # be installed with sudo apt-get.
@@ -58,24 +63,24 @@ matrix:
 
         # try with recent versions of mpl
         - env: ASTROPY_VERSION=development
-              SETUP_CMD='test'
-              NUMPY_VERSION=1.14
-              CONDA_DEPENDENCIES='matplotlib=2 scipy spectral-cube'
-              PIP_DEPENDENCIES='pytest-astropy'
-              PYTHON_VERSION=3.7
+               SETUP_CMD='test'
+               NUMPY_VERSION=1.14
+               CONDA_DEPENDENCIES='matplotlib=2 scipy spectral-cube'
+               PIP_DEPENDENCIES='pytest-astropy'
+               PYTHON_VERSION=3.7
 
         - env: ASTROPY_VERSION=development
-              SETUP_CMD='test'
-              NUMPY_VERSION=1.14
-              CONDA_DEPENDENCIES='matplotlib=2 scipy spectral-cube'
-              PIP_DEPENDENCIES='pytest-astropy'
-              PYTHON_VERSION=3.6
+               SETUP_CMD='test'
+               NUMPY_VERSION=1.14
+               CONDA_DEPENDENCIES='matplotlib=2 scipy spectral-cube'
+               PIP_DEPENDENCIES='pytest-astropy'
+               PYTHON_VERSION=3.6
 
         - env: ASTROPY_VERSION=development
-              SETUP_CMD='test'
-              CONDA_DEPENDENCIES='matplotlib=3 scipy spectral-cube'
-              PIP_DEPENDENCIES='matplotlib==3 pytest-astropy'
-              PYTHON_VERSION=3.6
+               SETUP_CMD='test'
+               CONDA_DEPENDENCIES='matplotlib=3 scipy spectral-cube'
+               PIP_DEPENDENCIES='matplotlib==3 pytest-astropy'
+               PYTHON_VERSION=3.6
 
         # Try with optional dependencies disabled
         - env: SETUP_CMD='test'

--- a/docs/ammonia_model.rst
+++ b/docs/ammonia_model.rst
@@ -14,6 +14,17 @@ fitting module meant to fit a single metastable (or non-metastable) transition.
 If you run into a problem, have a look at the `ammonia-tagged issues on github
 <https://github.com/pyspeckit/pyspeckit/issues?q=label%3Aammonia+>`__
 
+Note that the default ammonia spectrum, with only the CMB as a background, is
+intentionally restricted to be positive to avoid nonphysical (absorption
+against the CMB) parameters.  If you find your spectral fits sometimes
+returning errors about a negative spectrum, you may need the 'restricted
+excitation temperature' model.  In this model, the excitation temperature
+is no longer a free parameter, but instead is set to trot + deltat, where
+deltat is a positive value.  The only difference from the main ammonia model
+is this restriction, which can result in more numerically stable results.
+An example can be found `in the examples directory
+<https://github.com/pyspeckit/pyspeckit/blob/master/examples/synthetic_nLTE_ammonia_spectrum_example_witherrorestimates.py>`__
+
 .. automodule:: pyspeckit.spectrum.models.ammonia
     :members:
 

--- a/docs/ammonia_model.rst
+++ b/docs/ammonia_model.rst
@@ -11,6 +11,8 @@ Note that there are two modules described here: the multi-rotational-transition
 fitter, which has its own set of custom functions, and a generic hyperfine-line
 fitting module meant to fit a single metastable (or non-metastable) transition.
 
+If you run into a problem, have a look at the `ammonia-tagged issues on github
+<https://github.com/pyspeckit/pyspeckit/issues?q=label%3Aammonia+>`__
 
 .. automodule:: pyspeckit.spectrum.models.ammonia
     :members:

--- a/examples/fit_nh3_cube.py
+++ b/examples/fit_nh3_cube.py
@@ -11,7 +11,7 @@ able to modify this example and get something useful out.
 .. WARNING:: Cube fitting, particularly with a complicated line profile
 ammonia, can take a long time.  Test this on a small cube first!
 
-.. TODO:: Turn this example script into a function.  But customizing 
+.. TODO:: Turn this example script into a function.  But customizing
     the fit parameters will still require digging into the data manually
     (e.g., excluding bad velocities, or excluding the hyperfine lines from
     the initial guess)
@@ -30,7 +30,7 @@ from astropy.convolution import convolve_fft,Gaussian2DKernel
 F=False; T=True
 
 # Some optional parameters for the script
-# (if False, it will try to load an already-stored version 
+# (if False, it will try to load an already-stored version
 # of the file)
 fitcube = True
 
@@ -72,7 +72,7 @@ errmap11[errmap11 != errmap11] = convolve_fft(errmap11,
                                               interpolate_nan=True)[errmap11 != errmap11]
 
 # Stack the cubes into one big cube.  The X-axis is no longer linear: there
-# will be jumps from 1-1 to 2-2 to 4-4.  
+# will be jumps from 1-1 to 2-2 to 4-4.
 cubes = pyspeckit.CubeStack([cube11,cube22,cube44], maskmap=mask)
 cubes.unit = "K"
 
@@ -102,11 +102,11 @@ if os.path.exists(guessfn):
     guesses = guesscube[0].data
 else:
     guesses = np.zeros((6,)+cubes.cube.shape[1:])
-    guesses[0,:,:] = 20                    # Kinetic temperature 
+    guesses[0,:,:] = 20                    # Kinetic temperature
     guesses[1,:,:] = 5                     # Excitation  Temp
     guesses[2,:,:] = 14.5                  # log(column)
-    guesses[3,:,:] = momentcube[3,:,:] / 5 # Line width / 5 (the NH3 moment overestimates linewidth)                  
-    guesses[4,:,:] = momentcube[2,:,:]     # Line centroid              
+    guesses[3,:,:] = momentcube[3,:,:] / 5 # Line width / 5 (the NH3 moment overestimates linewidth)
+    guesses[4,:,:] = momentcube[2,:,:]     # Line centroid
     guesses[5,:,:] = 0.5                   # F(ortho) - ortho NH3 fraction (fixed)
 
     guesscube = pyfits.PrimaryHDU(data=guesses, header=cube11.header)
@@ -129,7 +129,7 @@ if fitcube:
     # set by the fitted parameters from the nearest pixel with a good fit
     # HOWEVER, because this fitting is done in parallel (multicore=12 means
     # 12 parallel fitting processes will run), this actually means that EACH
-    # core will have its own sub-set of the cube that it will search for good 
+    # core will have its own sub-set of the cube that it will search for good
     # fits. So if you REALLY want consistency, you need to do the fit in serial.
     cubes.fiteach(fittype='ammonia', multifit=None, guesses=guesses,
             integral=False, verbose_level=3, fixed=[F,F,F,F,F,T], signal_cut=3,
@@ -143,22 +143,22 @@ if fitcube:
 
     # Save the fitted parameters in a data cube
     fitcubefile = pyfits.PrimaryHDU(data=np.concatenate([cubes.parcube,cubes.errcube]), header=cubes.header)
-    fitcubefile.header.update('PLANE1','TKIN')
-    fitcubefile.header.update('PLANE2','TEX')
-    fitcubefile.header.update('PLANE3','COLUMN')
-    fitcubefile.header.update('PLANE4','SIGMA')
-    fitcubefile.header.update('PLANE5','VELOCITY')
-    fitcubefile.header.update('PLANE6','FORTHO')
-    fitcubefile.header.update('PLANE7','eTKIN')
-    fitcubefile.header.update('PLANE8','eTEX')
-    fitcubefile.header.update('PLANE9','eCOLUMN')
-    fitcubefile.header.update('PLANE10','eSIGMA')
-    fitcubefile.header.update('PLANE11','eVELOCITY')
-    fitcubefile.header.update('PLANE12','eFORTHO')
-    fitcubefile.header.update('CDELT3',1)
-    fitcubefile.header.update('CTYPE3','FITPAR')
-    fitcubefile.header.update('CRVAL3',0)
-    fitcubefile.header.update('CRPIX3',1)
+    fitcubefile.header['PLANE1'] = 'TKIN'
+    fitcubefile.header['PLANE2'] = 'TEX'
+    fitcubefile.header['PLANE3'] = 'COLUMN'
+    fitcubefile.header['PLANE4'] = 'SIGMA'
+    fitcubefile.header['PLANE5'] = 'VELOCITY'
+    fitcubefile.header['PLANE6'] = 'FORTHO'
+    fitcubefile.header['PLANE7'] = 'eTKIN'
+    fitcubefile.header['PLANE8'] = 'eTEX'
+    fitcubefile.header['PLANE9'] = 'eCOLUMN'
+    fitcubefile.header['PLANE10'] = 'eSIGMA'
+    fitcubefile.header['PLANE11'] = 'eVELOCITY'
+    fitcubefile.header['PLANE12'] = 'eFORTHO'
+    fitcubefile.header['CDELT3'] = 1
+    fitcubefile.header['CTYPE3'] = 'FITPAR'
+    fitcubefile.header['CRVAL3'] = 0
+    fitcubefile.header['CRPIX3'] = 1
     fitcubefile.writeto("hot_fitcube_try6.fits")
 else: # you can read in a fit you've already done!
     cubes.load_model_fit('hot_fitcube_try6.fits', 6, 'ammonia', _temp_fit_loc=(94,250))

--- a/examples/hcn_cube_test.py
+++ b/examples/hcn_cube_test.py
@@ -45,18 +45,18 @@ sp.fiteach(fittype='hcn_amp', errmap=errmap,
 f = pyfits.open('region5.hcn.errmap.fits')
 # start replacing components of the pyfits object
 f[0].data = np.concatenate([sp.parcube,sp.errcube,sp.integralmap])
-f[0].header.update('PLANE1','amplitude')
-f[0].header.update('PLANE2','velocity')
-f[0].header.update('PLANE3','sigma')
-f[0].header.update('PLANE4','err_amplitude')
-f[0].header.update('PLANE5','err_velocity')
-f[0].header.update('PLANE6','err_sigma')
-f[0].header.update('PLANE7','integral')
-f[0].header.update('PLANE8','integral_error')
-f[0].header.update('CDELT3',1)
-f[0].header.update('CTYPE3','FITPAR')
-f[0].header.update('CRVAL3',0)
-f[0].header.update('CRPIX3',1)
+f[0].header['PLANE1'] = 'amplitude'
+f[0].header['PLANE2'] = 'velocity'
+f[0].header['PLANE3'] = 'sigma'
+f[0].header['PLANE4'] = 'err_amplitude'
+f[0].header['PLANE5'] = 'err_velocity'
+f[0].header['PLANE6'] = 'err_sigma'
+f[0].header['PLANE7'] = 'integral'
+f[0].header['PLANE8'] = 'integral_error'
+f[0].header['CDELT3'] = 1
+f[0].header['CTYPE3'] = 'FITPAR'
+f[0].header['CRVAL3'] = 0
+f[0].header['CRPIX3'] = 1
 # save your work
 if astropy.version.major >= 2 or (astropy.version.major==1 and astropy.version.minor>=3):
     f.writeto('region5.hcn.nosmooth.fit.fits', overwrite=True)

--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -1042,10 +1042,10 @@ class Cube(spectrum.Spectrum):
                 log.exception("cube modelerrs are: {0}".format(str(self.errcube[:,int(y),int(x)])))
                 log.exception("Guesses were: {0}".format(str(gg)))
                 log.exception("Fitkwargs were: {0}".format(str(fitkwargs)))
+
                 if skip_failed_fits:
                     # turn the flag into a count
                     log.exception("The fit never completed; something has gone wrong.  Failed fits = {0}".format(int(skip_failed_fits)))
-                    skip_failed_fits = int(skip_failed_fits) + 1
                 else:
                     raise TypeError("The fit never completed; something has gone wrong.")
 

--- a/pyspeckit/spectrum/models/ammonia.py
+++ b/pyspeckit/spectrum/models/ammonia.py
@@ -1106,9 +1106,15 @@ class cold_ammonia_model(ammonia_model):
                                        required_limits=required_limits)
 
 class ammonia_model_restricted_tex(ammonia_model):
+    """
+    Ammonia model with an explicitly restricted excitation temperature
+    such that tex >= trot, set by the "delta" parameter (tex = trot + delta)
+    with delta > 0
+    """
     def __init__(self,
                  parnames=['trot', 'tex', 'ntot', 'width', 'xoff_v', 'fortho',
                            'delta'],
+                 ammonia_func=ammonia,
                  **kwargs):
         super(ammonia_model_restricted_tex, self).__init__(npars=7,
                                                            parnames=parnames,
@@ -1121,7 +1127,7 @@ class ammonia_model_restricted_tex(ammonia_model):
             delta = kwargs.pop('delta') if 'delta' in kwargs else None
             np.testing.assert_allclose(kwargs['trot'] - kwargs['tex'],
                                        delta)
-            return ammonia(*args, **kwargs)
+            return ammonia_func(*args, **kwargs)
         self.modelfunc = ammonia_dtex
 
     def n_ammonia(self, pars=None, parnames=None, **kwargs):

--- a/pyspeckit/spectrum/models/ammonia.py
+++ b/pyspeckit/spectrum/models/ammonia.py
@@ -36,7 +36,8 @@ TCMB = 2.7315 # K
 def ammonia(xarr, trot=20, tex=None, ntot=14, width=1, xoff_v=0.0, fortho=0.0,
             tau=None, fillingfraction=None, return_tau=False,
             return_tau_profile=False, background_tb=TCMB, verbose=False,
-            return_components=False, debug=False, line_names=line_names):
+            return_components=False, debug=False, line_names=line_names,
+            ignore_neg_models=False):
     """
     Generate a model Ammonia spectrum based on input temperatures, column, and
     gaussian parameters.  The returned model will be in Kelvin (brightness
@@ -88,6 +89,13 @@ def ammonia(xarr, trot=20, tex=None, ntot=14, width=1, xoff_v=0.0, fortho=0.0,
         just one array
     background_tb : float
         The background brightness temperature.  Defaults to TCMB.
+    ignore_neg_models: bool
+        Normally if background=TCMB and the model is negative, an exception
+        will be raised.  This parameter will simply skip that exception.  Use
+        with extreme caution: negative models (absorption spectra against the
+        CMB) are not physical!  You may want to allow this in some cases
+        because there can be numerical issues where the model goes negative
+        when it shouldn't.
     verbose: bool
         More messages
     debug: bool
@@ -222,7 +230,7 @@ def ammonia(xarr, trot=20, tex=None, ntot=14, width=1, xoff_v=0.0, fortho=0.0,
                                        return_tau_profile=return_tau_profile
                                       )
 
-    if not return_tau_profile and model_spectrum.min() < 0 and background_tb == TCMB:
+    if not return_tau_profile and model_spectrum.min() < 0 and background_tb == TCMB and not ignore_neg_models:
         raise ValueError("Model dropped below zero.  That is not possible "
                          " normally.  Here are the input values: "+
                          ("tex: {0} ".format(tex)) +

--- a/pyspeckit/spectrum/models/ammonia.py
+++ b/pyspeckit/spectrum/models/ammonia.py
@@ -1109,7 +1109,9 @@ class ammonia_model_restricted_tex(ammonia_model):
     """
     Ammonia model with an explicitly restricted excitation temperature
     such that tex >= trot, set by the "delta" parameter (tex = trot + delta)
-    with delta > 0
+    with delta > 0.  You can choose the ammonia funciton when you initialize
+    it (e.g., ``ammonia_model_restricted_tex(ammonia_func=ammonia)`` or
+    ``ammonia_model_restricted_tex(ammonia_func=cold_ammonia)``)
     """
     def __init__(self,
                  parnames=['trot', 'tex', 'ntot', 'width', 'xoff_v', 'fortho',

--- a/pyspeckit/spectrum/models/ammonia.py
+++ b/pyspeckit/spectrum/models/ammonia.py
@@ -1112,7 +1112,7 @@ class cold_ammonia_model(ammonia_model):
 class ammonia_model_restricted_tex(ammonia_model):
     """
     Ammonia model with an explicitly restricted excitation temperature
-    such that tex >= trot, set by the "delta" parameter (tex = trot + delta)
+    such that tex <= trot, set by the "delta" parameter (tex = trot - delta)
     with delta > 0.  You can choose the ammonia funciton when you initialize
     it (e.g., ``ammonia_model_restricted_tex(ammonia_func=ammonia)`` or
     ``ammonia_model_restricted_tex(ammonia_func=cold_ammonia)``)

--- a/pyspeckit/spectrum/models/ammonia.py
+++ b/pyspeckit/spectrum/models/ammonia.py
@@ -39,7 +39,13 @@ def ammonia(xarr, trot=20, tex=None, ntot=14, width=1, xoff_v=0.0, fortho=0.0,
             return_components=False, debug=False, line_names=line_names):
     """
     Generate a model Ammonia spectrum based on input temperatures, column, and
-    gaussian parameters
+    gaussian parameters.  The returned model will be in Kelvin (brightness
+    temperature) units.
+
+    Note that astropy units are not used internally for performance reasons.  A
+    wrapped version of this module including those units would be a good idea,
+    as it is definitely possible to implement this with unit support and good
+    performance.
 
     Parameters
     ----------
@@ -296,7 +302,15 @@ def _ammonia_spectrum(xarr, tex, tau_dict, width, xoff_v, fortho, line_names,
                       return_components=False, return_tau_profile=False):
     """
     Helper function: given a dictionary of ammonia optical depths,
-    an excitation tmeperature... etc, produce the spectrum
+    an excitation tmeperature etc, produce the spectrum.
+
+    The default return units are brightness temperature in Kelvin.  If
+    ``return_tau_profile`` is specified, the returned "spectrum" will be
+    a spectrum of optical depths, not an intensity spectrum.
+
+    If ``return_components`` is specified, a list of spectra will be returned,
+    where each spectrum represents one of the hyperfine components of the
+    particular ammonia line being modeled.
     """
     from .ammonia_constants import (ckms, h, kb)
 
@@ -1157,7 +1171,7 @@ class ammonia_model_restricted_tex(ammonia_model):
                      ):
         """
         parnames=['trot', 'tex', 'ntot', 'width', 'xoff_v', 'fortho', 'delta']
-        
+
         'delta' is the difference between tex and trot
         """
         supes = super(ammonia_model_restricted_tex, self)

--- a/pyspeckit/spectrum/models/ammonia.py
+++ b/pyspeckit/spectrum/models/ammonia.py
@@ -131,6 +131,10 @@ def ammonia(xarr, trot=20, tex=None, ntot=14, width=1, xoff_v=0.0, fortho=0.0,
                       "This is unphysical and "
                       "suggests that you may need to constrain tex.  See "
                       "ammonia_model_restricted_tex.")
+    if width < 0:
+        return np.zeros(xarr.size)*np.nan
+    elif width == 0:
+        return np.zeros(xarr.size)
 
     from .ammonia_constants import line_name_indices, line_names as original_line_names
 

--- a/pyspeckit/wrappers/fitnh3.py
+++ b/pyspeckit/wrappers/fitnh3.py
@@ -51,6 +51,7 @@ def fitnh3tkin(input_dict, dobaseline=True, baselinekwargs={}, crop=False,
                fortho=0.66, tau=None, thin=False, quiet=False, doplot=True,
                fignum=1, guessfignum=2, smooth=False, scale_keyword=None,
                rebase=False, tkin=None, npeaks=1, guesses=None,
+               fittype='ammonia',
                guess_error=True, plotter_wrapper_kwargs={}, **kwargs):
     """
     Given a dictionary of filenames and lines, fit them together
@@ -78,6 +79,9 @@ def fitnh3tkin(input_dict, dobaseline=True, baselinekwargs={}, crop=False,
         Use the guess line to estimate the error in all spectra?
     plotter_wrapper_kwargs : dict
         Keyword arguments to pass to the plotter
+    fittype: 'ammonia' or 'cold_ammonia'
+        The fitter model to use.  This is overridden if `tau` is specified,
+        in which case one of the `ammonia_tau` models is used (see source code)
     """
     if tkin is not None:
         if trot == 20 or trot is None:
@@ -154,7 +158,7 @@ def fitnh3tkin(input_dict, dobaseline=True, baselinekwargs={}, crop=False,
                         fortho)]
         if thin:
             raise ValueError("'thin' keyword not supported for the generic ammonia model")
-        spectra.specfit(fittype='ammonia', quiet=quiet, guesses=guesses,
+        spectra.specfit(fittype=fittype, quiet=quiet, guesses=guesses,
                         **kwargs)
 
     if doplot:
@@ -259,7 +263,9 @@ def make_axdict(splist, spdict):
 
 
 def fitnh3(spectrum, vrange=[-100, 100], vrangeunit='km/s', quiet=False, Tex=20,
-           trot=15, column=1e15, fortho=1.0, tau=None, Tkin=None, spec_convert_kwargs={}):
+           trot=15, column=1e15, fortho=1.0, tau=None, Tkin=None,
+           fittype='ammonia',
+           spec_convert_kwargs={}):
 
     if Tkin is not None:
         if trot == 20 or trot is None:
@@ -276,7 +282,7 @@ def fitnh3(spectrum, vrange=[-100, 100], vrangeunit='km/s', quiet=False, Tex=20,
     ampguess, vguess, widthguess = spectrum.specfit.modelpars
 
     if tau is None:
-        spectrum.specfit(fittype='ammonia', quiet=quiet,
+        spectrum.specfit(fittype=fittype, quiet=quiet,
                          guesses=[Tex, trot, column, widthguess, vguess,
                                   fortho])
     else:


### PR DESCRIPTION
There are some persistent issues using fiteach w/ammonia, e.g. #307 and some others.
This PR enables a `skip_failed_fits` keyword in `fiteach` that will just.... hopefully...
skip over the failed fits.  It's a BAD idea to enable this in general, but I can't think of
what else to do right now.