### PR TITLE
Migrate conf.py to python 3 syntax

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,7 @@ setup_cfg = dict(conf.items('metadata'))
 try:
     import numpy
 except ImportError:
-    print "Failed to import numpy"
+    print("Failed to import numpy")
 
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -72,7 +72,7 @@ sys.path.insert(0, rootpath)
 sys.path.insert(0, rootpath+"/docs/sphinxext/")
 sys.path.append(os.path.abspath('sphinxext'))
 sys.path.append(os.path.abspath('.'))
-print "rootpath: ",rootpath
+print("rootpath: ",rootpath)
 
 # -- General configuration -----------------------------------------------------
 
@@ -100,8 +100,8 @@ html_sidebars = {'**':['globaltoc.html', 'localtoc.html', 'relations.html',
                       'sourcelink.html', 'searchbox.html']}
 
 # General information about the project.
-project = u'pyspeckit'
-copyright = u'2011, Adam Ginsburg and coauthors'
+project = 'pyspeckit'
+copyright = '2011, Adam Ginsburg and coauthors'
 # This does not *have* to match the package name, but typically does
 project = setup_cfg['package_name']
 author = setup_cfg['author']
@@ -299,10 +299,10 @@ htmlhelp_basename = project + 'doc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'pyspeckit.tex', u'pyspeckit Documentation',
-   u'Adam Ginsburg and coauthors', 'manual'),
+  ('index', 'pyspeckit.tex', 'pyspeckit Documentation',
+   'Adam Ginsburg and coauthors', 'manual'),
 ]
-latex_documents = [('index', project + '.tex', project + u' Documentation',
+latex_documents = [('index', project + '.tex', project + ' Documentation',
                     author, 'manual')]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -335,7 +335,7 @@ autoclass_content = 'both'
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [('index', project.lower(), project + u' Documentation',
+man_pages = [('index', project.lower(), project + ' Documentation',
               [author], 1)]
 
 


### PR DESCRIPTION
This fixes the sphinx warning when building the docs:

```
	WARNING: Support for evaluating Python 2 syntax is deprecated
	and will be removed in Sphinx 4.0. Convert conf.py to Python 3
	syntax
```