### PR TITLE
Replace Legend.draggable with Legend.set_draggable

### DIFF
--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -1372,7 +1372,7 @@ class Specfit(interactive.Interactive):
             except TypeError as ex:
                 print("Error {0} was raised, which may indicate an outdated mpl version".format(ex))
             try:
-                self.fitleg.draggable(True)
+                self.fitleg.set_draggable(True)
             except AttributeError:
                 # wrong version and/or non-interactive backend
                 pass


### PR DESCRIPTION
legend.Legend.draggable was deprecated and it has been removed in recent
matplotlib relases:

https://matplotlib.org/3.1.1/api/api_changes.html#removals
https://github.com/matplotlib/matplotlib/pull/10050