### PR TITLE
Fix for issue 351

### DIFF
--- a/pyspeckit/spectrum/models/ammonia_constants.py
+++ b/pyspeckit/spectrum/models/ammonia_constants.py
@@ -25,9 +25,10 @@ line_name_indices = {'oneone': 0,
                      'eighteight': 5,
                      'tenten': 6,
                      'eleveneleven': 7,
-                     'threethree': 0,
-                     'sixsix': 1,
-                     'ninenine': 2,
+                     'zerozero': 0,
+                     'threethree': 1,
+                     'sixsix': 2,
+                     'ninenine': 3,
                     }
 
               #'ninenine']


### PR DESCRIPTION
This is a fix for #351.  It may also (help) solve issue #330.  

There is an accounting error in the Ortho transitions of NH3; the J-values were indexed from 0,0, but were being treated as if they started at 3,3