### PR TITLE
Changed install command in docs for installing via GitHub

### DIFF
--- a/docs/install_via_GitHub.rst
+++ b/docs/install_via_GitHub.rst
@@ -56,7 +56,7 @@ and enter your username and password if it asks.
 
 Still in the ``pyspeckit/`` directory, type::
 
-  python setup.py develop
+  pip install -e .
 
 You're good to go!
 


### PR DESCRIPTION
In order to correctly install `pyspeckit` via GitHub, `pip install -e .` should be used instead of `python setup.py develop`.