### PR TITLE
Mask out bad values using np.ma instead of just changing them

### DIFF
--- a/pyspeckit/mpfit/mpfit.py
+++ b/pyspeckit/mpfit/mpfit.py
@@ -902,7 +902,7 @@ class mpfit:
         # In the case if the xall is not float or if is float but has less
         # than 64 bits we do convert it into double
         if xall.dtype.kind != 'f' or xall.dtype.itemsize<=4:
-            xall = xall.astype(numpy.float)
+            xall = xall.astype(float)
 
         npar = len(xall)
         self.fnorm  = -1.

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -587,10 +587,13 @@ class Specfit(interactive.Interactive):
             warnings.simplefilter("ignore")
             self.spectofit[~OKmask] = 0
 
+        self.spectofit.mask = ~OKmask
+
         self.seterrspec()
 
         # the "OK" mask is just checking that the values are finite
         self.errspec[~OKmask] = 1e10
+        self.errspec.mask = ~OKmask
 
         # if an includemask is set *and* there are some included values, "mask out" the rest
         # otherwise, if *all* data are excluded, we should assume that means the includemask

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -542,8 +542,8 @@ class Specfit(interactive.Interactive):
                     else:
                         self.errspec = np.ma.ones(self.spectofit.shape[0]) * residuals_std
                 elif type(self.Spectrum.error) is np.ma.masked_array:
-                    # force errspec to be a non-masked array of ones
-                    self.errspec = self.Spectrum.error.data + 1
+                    # force errspec to be a masked array of ones
+                    self.errspec = self.Spectrum.error + 1
                 else:
                     self.errspec = np.ma.copy(self.Spectrum.error) + 1
             else:
@@ -553,6 +553,8 @@ class Specfit(interactive.Interactive):
             self.errspec = np.ma.ones(self.spectofit.shape[0]) * self.residuals.std()
         else:
             self.errspec = np.ma.ones(self.spectofit.shape[0]) * self.spectofit.std()
+
+        assert hasattr(self.errspec, 'mask')
 
     def setfitspec(self):
         """

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -545,7 +545,7 @@ class Specfit(interactive.Interactive):
                     # force errspec to be a non-masked array of ones
                     self.errspec = self.Spectrum.error.data + 1
                 else:
-                    self.errspec = self.Spectrum.error + 1
+                    self.errspec = np.ma.copy(self.Spectrum.error) + 1
             else:
                 # this is the default behavior if spectrum.error is set
                 self.errspec = np.ma.copy(self.Spectrum.error)

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -536,11 +536,11 @@ class Specfit(interactive.Interactive):
                 if self.residuals is not None and useresiduals:
                     residuals_std = self.residuals.std()
                     if residuals_std == 0:
-                        self.errspec = np.ones(self.spectofit.shape[0])
+                        self.errspec = np.ma.ones(self.spectofit.shape[0])
                         warnings.warn("Residuals have 0 standard deviation.  "
                                       "That's probably too good to be true.")
                     else:
-                        self.errspec = np.ones(self.spectofit.shape[0]) * residuals_std
+                        self.errspec = np.ma.ones(self.spectofit.shape[0]) * residuals_std
                 elif type(self.Spectrum.error) is np.ma.masked_array:
                     # force errspec to be a non-masked array of ones
                     self.errspec = self.Spectrum.error.data + 1
@@ -548,11 +548,11 @@ class Specfit(interactive.Interactive):
                     self.errspec = self.Spectrum.error + 1
             else:
                 # this is the default behavior if spectrum.error is set
-                self.errspec = self.Spectrum.error.copy()
+                self.errspec = np.ma.copy(self.Spectrum.error)
         elif self.residuals is not None and useresiduals:
-            self.errspec = np.ones(self.spectofit.shape[0]) * self.residuals.std()
+            self.errspec = np.ma.ones(self.spectofit.shape[0]) * self.residuals.std()
         else:
-            self.errspec = np.ones(self.spectofit.shape[0]) * self.spectofit.std()
+            self.errspec = np.ma.ones(self.spectofit.shape[0]) * self.spectofit.std()
 
     def setfitspec(self):
         """

--- a/pyspeckit/spectrum/tests/test_units.py
+++ b/pyspeckit/spectrum/tests/test_units.py
@@ -186,7 +186,7 @@ class TestUnits(object):
 
         with pytest.raises(u.UnitConversionError) as ex:
             xarr.x_to_pix(120,u.GHz)
-        assert str(ex.value) == "'GHz' (frequency) and 'km / s' (speed) are not convertible"
+        assert str(ex.value) == "'GHz' (frequency) and 'km / s' (speed/velocity) are not convertible"
 
         xarr = pyspeckit.units.SpectroscopicAxis(np.linspace(-50,50)*u.km/u.s, refX=100*u.GHz,
                                                  velocity_convention='radio')

--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -39,35 +39,34 @@ class SmartCaseNoSpaceDict(dict):
         try:
             return dict.__getitem__(self,key)
         except KeyError:
-            return dict.__getitem__(self, key.lower().replace(" ",""))
+            return dict.__getitem__(self, str(key).lower().replace(" ",""))
 
     def __setitem__(self, key, value):
         dict.__setitem__(self,key,value)
         # only set lower-case version if there isn't one there already
         # prevents overwriting mm with Mm.lower()
-        if hasattr(key,'lower'):
-            if key.lower().replace(" ","") not in self:
-                self.__setitem__(key.lower().replace(" ",""), value)
+        if str(key).lower().replace(" ","") not in self:
+            self.__setitem__(str(key).lower().replace(" ",""), value)
 
     def __contains__(self, key):
         cased = dict.__contains__(self,key)
-        if hasattr(key,'lower') and cased is False:
-            return dict.__contains__(self, key.lower().replace(" ",""))
+        if cased is False:
+            return dict.__contains__(self, str(key).lower().replace(" ",""))
         else:
             return cased
 
     def has_key(self, key):
         """ This is deprecated, but we're keeping it around """
         cased = dict.has_key__(self,key)
-        if hasattr(key,'lower') and cased is False:
-            return dict.has_key__(self, key.lower().replace(" ",""))
+        if cased is False:
+            return dict.has_key__(self, str(key).lower().replace(" ",""))
         else:
             return cased
 
     def get(self, key, def_val=None):
         cased = dict.get(self,key)
-        if hasattr(key,'lower') and cased is None:
-            return dict.get(self, key.lower().replace(" ",""),def_val)
+        if cased is None:
+            return dict.get(self, str(key).lower().replace(" ",""),def_val)
         else:
             return cased
 
@@ -77,8 +76,8 @@ class SmartCaseNoSpaceDict(dict):
         a value of default and return default. default defaults to None.
         """
         cased = dict.setdefault(self,key)
-        if hasattr(key,'lower') and cased is None:
-            return dict.setdefault(self, key.lower().replace(" ",""),def_val)
+        if cased is None:
+            return dict.setdefault(self, str(key).lower().replace(" ",""),def_val)
         else:
             return cased
 
@@ -95,8 +94,8 @@ class SmartCaseNoSpaceDict(dict):
 
     def pop(self, key, def_val=None):
         cased = dict.pop(self,key)
-        if hasattr(key,'lower') and cased is None:
-            return dict.pop(self, key.lower().replace(" ",""),def_val)
+        if cased is None:
+            return dict.pop(self, str(key).lower().replace(" ",""),def_val)
         else:
             return cased
 


### PR DESCRIPTION
This is to solve an error where sometimes, rather inexplicably (I tracked this down super far), `lmfit` turns perfectly valid values into NaNs if the errors are huge.

example:
```python
> self.errspec
masked_array(data=[10000000000.0, 0.7184141874313354,  ....  0.7184141874313354, 10000000000.0] ...)
```
causes
```
ipdb> _minpack._lmdif(func, x0, args, full_output, ftol, xtol, gtol, maxfev, epsfcn, factor, [1,1,1,1,1,0.1,])
DEBUG: Pars, kwarg keys: Parameters([('AMPLITUDE0', <Parameter 'AMPLITUDE0', value=5.538497979872734, bounds=[-inf:inf]>), ('SHIFT0', <Parameter 'SHIFT0', value=1797.8843857954282, bounds=[-inf:inf]>), ('WIDTH0', <Parameter 'WIDTH0', value=14.387609803061617, bounds=[0:inf]>), ('AMPLITUDE1', <Parameter 'AMPLITUDE1', value=2.0771486130830774, bounds=[-inf:inf]>), ('SHIFT1', <Parameter 'SHIFT1', value=1955.3304475424397, bounds=[-inf:inf]>), ('WIDTH1', <Parameter 'WIDTH1', value=0.2996304729220922, bounds=[0:inf]>)]),[] [pyspeckit.spectrum.models.model]
DEBUG: pars to n_modelfunc: Param #0   AMPLITUDE0 =       5.5385  Range:[-inf,inf]
Param #1       SHIFT0 =      1797.88  Range:[-inf,inf]
Param #2       WIDTH0 =      14.3876  Range:   [0,inf]
Param #3   AMPLITUDE1 =      2.07715  Range:[-inf,inf]
Param #4       SHIFT1 =      1955.33  Range:[-inf,inf]
Param #5       WIDTH1 =      0.29963  Range:   [0,inf], parvals:[5.538497979872734, 1797.8843857954282, 14.387609803061617, 2.0771486130830774, 1955.3304475424397, 0.2996304729220922] [pyspeckit.spectrum.models.model]
DEBUG: Pars, kwarg keys: Parameters([('AMPLITUDE0', <Parameter 'AMPLITUDE0', value=5.538497979872734, bounds=[-inf:inf]>), ('SHIFT0', <Parameter 'SHIFT0', value=1797.8843857954282, bounds=[-inf:inf]>), ('WIDTH0', <Parameter 'WIDTH0', value=14.387609803061617, bounds=[0:inf]>), ('AMPLITUDE1', <Parameter 'AMPLITUDE1', value=2.0771486130830774, bounds=[-inf:inf]>), ('SHIFT1', <Parameter 'SHIFT1', value=1955.3304475424397, bounds=[-inf:inf]>), ('WIDTH1', <Parameter 'WIDTH1', value=0.2996304729220922, bounds=[0:inf]>)]),[] [pyspeckit.spectrum.models.model]
DEBUG: pars to n_modelfunc: Param #0   AMPLITUDE0 =       5.5385  Range:[-inf,inf]
Param #1       SHIFT0 =      1797.88  Range:[-inf,inf]
Param #2       WIDTH0 =      14.3876  Range:   [0,inf]
Param #3   AMPLITUDE1 =      2.07715  Range:[-inf,inf]
Param #4       SHIFT1 =      1955.33  Range:[-inf,inf]
Param #5       WIDTH1 =      0.29963  Range:   [0,inf], parvals:[5.538497979872734, 1797.8843857954282, 14.387609803061617, 2.0771486130830774, 1955.3304475424397, 0.2996304729220922] [pyspeckit.spectrum.models.model]
DEBUG: Pars, kwarg keys: Parameters([('AMPLITUDE0', <Parameter 'AMPLITUDE0', value=5.538498062402785, bounds=[-inf:inf]>), ('SHIFT0', <Parameter 'SHIFT0', value=1797.8843857954282, bounds=[-inf:inf]>), ('WIDTH0', <Parameter 'WIDTH0', value=14.387609803061617, bounds=[0:inf]>), ('AMPLITUDE1', <Parameter 'AMPLITUDE1', value=2.0771486130830774, bounds=[-inf:inf]>), ('SHIFT1', <Parameter 'SHIFT1', value=1955.3304475424397, bounds=[-inf:inf]>), ('WIDTH1', <Parameter 'WIDTH1', value=0.2996304729220922, bounds=[0:inf]>)]),[] [pyspeckit.spectrum.models.model]
DEBUG: pars to n_modelfunc: Param #0   AMPLITUDE0 =       5.5385  Range:[-inf,inf]
Param #1       SHIFT0 =      1797.88  Range:[-inf,inf]
Param #2       WIDTH0 =      14.3876  Range:   [0,inf]
Param #3   AMPLITUDE1 =      2.07715  Range:[-inf,inf]
Param #4       SHIFT1 =      1955.33  Range:[-inf,inf]
Param #5       WIDTH1 =      0.29963  Range:   [0,inf], parvals:[5.538498062402785, 1797.8843857954282, 14.387609803061617, 2.0771486130830774, 1955.3304475424397, 0.2996304729220922] [pyspeckit.spectrum.models.model]
DEBUG: Pars, kwarg keys: Parameters([('AMPLITUDE0', <Parameter 'AMPLITUDE0', value=5.538497979872734, bounds=[-inf:inf]>), ('SHIFT0', <Parameter 'SHIFT0', value=1797.8844125859932, bounds=[-inf:inf]>), ('WIDTH0', <Parameter 'WIDTH0', value=14.387609803061617, bounds=[0:inf]>), ('AMPLITUDE1', <Parameter 'AMPLITUDE1', value=2.0771486130830774, bounds=[-inf:inf]>), ('SHIFT1', <Parameter 'SHIFT1', value=1955.3304475424397, bounds=[-inf:inf]>), ('WIDTH1', <Parameter 'WIDTH1', value=0.2996304729220922, bounds=[0:inf]>)]),[] [pyspeckit.spectrum.models.model]
DEBUG: pars to n_modelfunc: Param #0   AMPLITUDE0 =       5.5385  Range:[-inf,inf]
Param #1       SHIFT0 =      1797.88  Range:[-inf,inf]
Param #2       WIDTH0 =      14.3876  Range:   [0,inf]
Param #3   AMPLITUDE1 =      2.07715  Range:[-inf,inf]
Param #4       SHIFT1 =      1955.33  Range:[-inf,inf]
Param #5       WIDTH1 =      0.29963  Range:   [0,inf], parvals:[5.538497979872734, 1797.8844125859932, 14.387609803061617, 2.0771486130830774, 1955.3304475424397, 0.2996304729220922] [pyspeckit.spectrum.models.model]
DEBUG: Pars, kwarg keys: Parameters([('AMPLITUDE0', <Parameter 'AMPLITUDE0', value=5.538497979872734, bounds=[-inf:inf]>), ('SHIFT0', <Parameter 'SHIFT0', value=1797.8843857954282, bounds=[-inf:inf]>), ('WIDTH0', <Parameter 'WIDTH0', value=14.387610031386483, bounds=[0:inf]>), ('AMPLITUDE1', <Parameter 'AMPLITUDE1', value=2.0771486130830774, bounds=[-inf:inf]>), ('SHIFT1', <Parameter 'SHIFT1', value=1955.3304475424397, bounds=[-inf:inf]>), ('WIDTH1', <Parameter 'WIDTH1', value=0.2996304729220922, bounds=[0:inf]>)]),[] [pyspeckit.spectrum.models.model]
DEBUG: pars to n_modelfunc: Param #0   AMPLITUDE0 =       5.5385  Range:[-inf,inf]
Param #1       SHIFT0 =      1797.88  Range:[-inf,inf]
Param #2       WIDTH0 =      14.3876  Range:   [0,inf]
Param #3   AMPLITUDE1 =      2.07715  Range:[-inf,inf]
Param #4       SHIFT1 =      1955.33  Range:[-inf,inf]
Param #5       WIDTH1 =      0.29963  Range:   [0,inf], parvals:[5.538497979872734, 1797.8843857954282, 14.387610031386483, 2.0771486130830774, 1955.3304475424397, 0.2996304729220922] [pyspeckit.spectrum.models.model]
DEBUG: Pars, kwarg keys: Parameters([('AMPLITUDE0', <Parameter 'AMPLITUDE0', value=5.538497979872734, bounds=[-inf:inf]>), ('SHIFT0', <Parameter 'SHIFT0', value=1797.8843857954282, bounds=[-inf:inf]>), ('WIDTH0', <Parameter 'WIDTH0', value=14.387609803061617, bounds=[0:inf]>), ('AMPLITUDE1', <Parameter 'AMPLITUDE1', value=2.0771486440350038, bounds=[-inf:inf]>), ('SHIFT1', <Parameter 'SHIFT1', value=1955.3304475424397, bounds=[-inf:inf]>), ('WIDTH1', <Parameter 'WIDTH1', value=0.2996304729220922, bounds=[0:inf]>)]),[] [pyspeckit.spectrum.models.model]
DEBUG: pars to n_modelfunc: Param #0   AMPLITUDE0 =       5.5385  Range:[-inf,inf]
Param #1       SHIFT0 =      1797.88  Range:[-inf,inf]
Param #2       WIDTH0 =      14.3876  Range:   [0,inf]
Param #3   AMPLITUDE1 =      2.07715  Range:[-inf,inf]
Param #4       SHIFT1 =      1955.33  Range:[-inf,inf]
Param #5       WIDTH1 =      0.29963  Range:   [0,inf], parvals:[5.538497979872734, 1797.8843857954282, 14.387609803061617, 2.0771486440350038, 1955.3304475424397, 0.2996304729220922] [pyspeckit.spectrum.models.model]
DEBUG: Pars, kwarg keys: Parameters([('AMPLITUDE0', <Parameter 'AMPLITUDE0', value=5.538497979872734, bounds=[-inf:inf]>), ('SHIFT0', <Parameter 'SHIFT0', value=1797.8843857954282, bounds=[-inf:inf]>), ('WIDTH0', <Parameter 'WIDTH0', value=14.387609803061617, bounds=[0:inf]>), ('AMPLITUDE1', <Parameter 'AMPLITUDE1', value=2.0771486130830774, bounds=[-inf:inf]>), ('SHIFT1', <Parameter 'SHIFT1', value=1955.3304766791339, bounds=[-inf:inf]>), ('WIDTH1', <Parameter 'WIDTH1', value=0.2996304729220922, bounds=[0:inf]>)]),[] [pyspeckit.spectrum.models.model]
DEBUG: pars to n_modelfunc: Param #0   AMPLITUDE0 =       5.5385  Range:[-inf,inf]
Param #1       SHIFT0 =      1797.88  Range:[-inf,inf]
Param #2       WIDTH0 =      14.3876  Range:   [0,inf]
Param #3   AMPLITUDE1 =      2.07715  Range:[-inf,inf]
Param #4       SHIFT1 =      1955.33  Range:[-inf,inf]
Param #5       WIDTH1 =      0.29963  Range:   [0,inf], parvals:[5.538497979872734, 1797.8843857954282, 14.387609803061617, 2.0771486130830774, 1955.3304766791339, 0.2996304729220922] [pyspeckit.spectrum.models.model]
DEBUG: Pars, kwarg keys: Parameters([('AMPLITUDE0', <Parameter 'AMPLITUDE0', value=5.538497979872734, bounds=[-inf:inf]>), ('SHIFT0', <Parameter 'SHIFT0', value=1797.8843857954282, bounds=[-inf:inf]>), ('WIDTH0', <Parameter 'WIDTH0', value=14.387609803061617, bounds=[0:inf]>), ('AMPLITUDE1', <Parameter 'AMPLITUDE1', value=2.0771486130830774, bounds=[-inf:inf]>), ('SHIFT1', <Parameter 'SHIFT1', value=1955.3304475424397, bounds=[-inf:inf]>), ('WIDTH1', <Parameter 'WIDTH1', value=0.2996304808224046, bounds=[0:inf]>)]),[] [pyspeckit.spectrum.models.model]
DEBUG: pars to n_modelfunc: Param #0   AMPLITUDE0 =       5.5385  Range:[-inf,inf]
Param #1       SHIFT0 =      1797.88  Range:[-inf,inf]
Param #2       WIDTH0 =      14.3876  Range:   [0,inf]
Param #3   AMPLITUDE1 =      2.07715  Range:[-inf,inf]
Param #4       SHIFT1 =      1955.33  Range:[-inf,inf]
Param #5       WIDTH1 =      0.29963  Range:   [0,inf], parvals:[5.538497979872734, 1797.8843857954282, 14.387609803061617, 2.0771486130830774, 1955.3304475424397, 0.2996304808224046] [pyspeckit.spectrum.models.model]
DEBUG: Pars, kwarg keys: Parameters([('AMPLITUDE0', <Parameter 'AMPLITUDE0', value=nan, bounds=[-inf:inf]>), ('SHIFT0', <Parameter 'SHIFT0', value=nan, bounds=[-inf:inf]>), ('WIDTH0', <Parameter 'WIDTH0', value=nan, bounds=[0:inf]>), ('AMPLITUDE1', <Parameter 'AMPLITUDE1', value=nan, bounds=[-inf:inf]>), ('SHIFT1', <Parameter 'SHIFT1', value=nan, bounds=[-inf:inf]>), ('WIDTH1', <Parameter 'WIDTH1', value=nan, bounds=[0:inf]>)]),[] [pyspeckit.spectrum.models.model]
*** ValueError: A parameter is NaN.  Unless you gave a NaN value directly, this is a bug and should be reported.  If you specified a NaN parameter, don't do that.
```