### PR TITLE
handle xarrs with quantities in places they were raising issues

### DIFF
--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -754,6 +754,14 @@ class Specfit(interactive.Interactive):
         spectofit = self.spectofit[self.xmin:self.xmax][~self.mask_sliced].astype('float64')
         err = self.errspec[self.xmin:self.xmax][~self.mask_sliced].astype('float64')
 
+        # strip quantity properties before passing to fitter (fitters are not quantity-aware)
+        if hasattr(xtofit, 'value'):
+            xtofit = xtofit.value
+        if hasattr(spectofit, 'value'):
+            spectofit = spectofit.value
+        if hasattr(err, 'value'):
+            err = err.value
+
         if np.all(err == 0):
             raise ValueError("Errors are all zero.  This should not occur and "
                              "is a bug. (if you set the errors to all zero, "

--- a/pyspeckit/spectrum/models/model.py
+++ b/pyspeckit/spectrum/models/model.py
@@ -399,7 +399,16 @@ class SpectralModel(fitter.SimpleFitter):
             for jj in range(int((len(parvals)-self.vheight)/self.npars)):
                 lower_parind = jj*self.npars+self.vheight
                 upper_parind = (jj+1)*self.npars+self.vheight
-                v += self.modelfunc(x, *parvals[lower_parind:upper_parind], **kwargs)
+                try:
+                    v += self.modelfunc(x, *parvals[lower_parind:upper_parind], **kwargs)
+                except TypeError as ex:
+                    # not all model functions are quantity-aware, so we strip quantities here
+                    if hasattr(x, 'value'):
+                        x = x.value
+                        v += self.modelfunc(x, *parvals[lower_parind:upper_parind], **kwargs)
+                    else:
+                        raise ex
+
             return v
         return L
 


### PR DESCRIPTION
Glen Langston reported that this example:
https://pyspeckit.readthedocs.io/en/latest/example_continuum_fromscratch.html
was failing with the following traceback:

```
Traceback (most recent call last):
  File "<ipython-input-1-dca5499ff34c>", line 29, in <module>
    sp.specfit(fittype='polycontinuum', guesses=(0,0), exclude=[30, 70])
  File "/home/adam/repos/pyspeckit/pyspeckit/config.py", line 145, in decorator
    f(self, *args, **new_kwargs)
  File "/home/adam/repos/pyspeckit/pyspeckit/spectrum/fitters.py", line 344, in __call__
    self.multifit(show_components=show_components, verbose=verbose,
  File "/home/adam/repos/pyspeckit/pyspeckit/spectrum/fitters.py", line 822, in multifit
    self.plot_fit(annotate=annotate,
  File "/home/adam/repos/pyspeckit/pyspeckit/spectrum/fitters.py", line 1145, in plot_fit
    self._full_model()
  File "/home/adam/repos/pyspeckit/pyspeckit/spectrum/fitters.py", line 1035, in _full_model
    self.fullmodel = self.get_full_model(debug=debug,**kwargs)
  File "/home/adam/repos/pyspeckit/pyspeckit/spectrum/fitters.py", line 1040, in get_full_model
    return self.get_model(self.Spectrum.xarr, debug=debug,**kwargs)
  File "/home/adam/repos/pyspeckit/pyspeckit/spectrum/fitters.py", line 1045, in get_model
    return self.get_model_frompars(xarr=xarr, pars=self.parinfo,
  File "/home/adam/repos/pyspeckit/pyspeckit/spectrum/fitters.py", line 1057, in get_model_frompars
    return (self.fitter.n_modelfunc(pars,
  File "/home/adam/repos/pyspeckit/pyspeckit/spectrum/models/model.py", line 402, in L
    v += self.modelfunc(x, *parvals[lower_parind:upper_parind], **kwargs)
  File "/home/adam/repos/pyspeckit/pyspeckit/spectrum/models/polynomial_continuum.py", line 24, in polymodel
    return numpy.polyval(pars,x)
  File "<__array_function__ internals>", line 180, in polyval
TypeError: no implementation found for 'numpy.polyval' on types that implement __array_function__: [<class 'pyspeckit.spectrum.units.SpectroscopicAxis'>]
```

This is caused by some change in how Quantities behave wrt numpy functions.  This PR implements some workarounds that strip quantity properties where they might cause problems.