### PR TITLE
Bugfixes: revert 389, etc.

### DIFF
--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -1447,7 +1447,13 @@ class Specfit(interactive.Interactive):
             # don't remove fitleg unless it's in the current axis
             # self.fitleg.set_visible(False)
             if self.fitleg in axis.artists:
-                axis.artists.remove(self.fitleg)
+                try:
+                    axis.artists.remove(self.fitleg)
+                except AttributeError:
+                    try:
+                        self.fitleg.remove()
+                    except Exception as ex:
+                        pass
         if self.Spectrum.plotter.autorefresh:
             self.Spectrum.plotter.refresh()
 

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -754,14 +754,6 @@ class Specfit(interactive.Interactive):
         spectofit = self.spectofit[self.xmin:self.xmax][~self.mask_sliced].astype('float64')
         err = self.errspec[self.xmin:self.xmax][~self.mask_sliced].astype('float64')
 
-        # strip quantity properties before passing to fitter (fitters are not quantity-aware)
-        if hasattr(xtofit, 'value'):
-            xtofit = xtofit.value
-        if hasattr(spectofit, 'value'):
-            spectofit = spectofit.value
-        if hasattr(err, 'value'):
-            err = err.value
-
         if np.all(err == 0):
             raise ValueError("Errors are all zero.  This should not occur and "
                              "is a bug. (if you set the errors to all zero, "

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -19,6 +19,8 @@ from . import interactive
 from . import history
 from . import widgets
 
+from pyspeckit.spectrum.units import SpectroscopicAxis
+
 class Registry(object):
     """
     This class is a simple wrapper to prevent fitter properties from being globals
@@ -753,6 +755,9 @@ class Specfit(interactive.Interactive):
         xtofit = self.Spectrum.xarr[self.xmin:self.xmax][~self.mask_sliced].astype('float64')
         spectofit = self.spectofit[self.xmin:self.xmax][~self.mask_sliced].astype('float64')
         err = self.errspec[self.xmin:self.xmax][~self.mask_sliced].astype('float64')
+
+        if hasattr(xtofit, 'value') and not hasattr(xtofit, 'x_to_coord'):
+            xtofit = SpectroscopicAxis(xtofit)
 
         if np.all(err == 0):
             raise ValueError("Errors are all zero.  This should not occur and "

--- a/pyspeckit/spectrum/models/polynomial_continuum.py
+++ b/pyspeckit/spectrum/models/polynomial_continuum.py
@@ -21,7 +21,11 @@ def polymodel(x, *pars, **kwargs):
     *args = polynomial parameters
     **kwargs = just to catch extra junk; not passed
     """
-    return numpy.polyval(pars,x)
+    # polyval and astropy quantity are incompatible
+    if hasattr(x, 'value'):
+        x = x.value
+
+    return numpy.polyval(pars, x)
 
 polymodel.__doc__ += numpy.polyval.__doc__
 

--- a/pyspeckit/spectrum/models/template.py
+++ b/pyspeckit/spectrum/models/template.py
@@ -45,7 +45,7 @@ def spectral_template_generator(template_spectrum, xshift_units='km/s', left=0,
                                 left=left,
                                 right=right,
                                )
-        
+
         return model
 
     return spectral_template
@@ -83,5 +83,5 @@ def template_fitter(template_spectrum, xshift_units='km/s'):
                                    shortvarnames=('A',r'\Delta x'),
                                    centroid_par='shift',)
     myclass.__name__ = "spectral_template"
-    
+
     return myclass

--- a/pyspeckit/spectrum/models/tests/test_template.py
+++ b/pyspeckit/spectrum/models/tests/test_template.py
@@ -2,9 +2,8 @@
 Tests for template fitter
 """
 
-from .... import spectrum
-from ...classes import Spectrum
-from ... import models
+from pyspeckit import spectrum, models
+from pyspeckit.spectrum.classes import Spectrum
 import numpy as np
 
 def test_template():

--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -172,9 +172,14 @@ class Plotter(object):
             self.figure.canvas.callbacks.callbacks['key_press_event'].update(self._mpl_key_callbacks)
         elif self.figure is not None:
             mpl_keypress_handler = self.figure.canvas.manager.key_press_handler_id
-            bmp = BoundMethodProxy(self.figure.canvas.manager.key_press)
-            self.figure.canvas.callbacks.callbacks['key_press_event'].update({mpl_keypress_handler:
-                                                                              bmp})
+            try:
+                bmp = BoundMethodProxy(self.figure.canvas.manager.key_press)
+                self.figure.canvas.callbacks.callbacks['key_press_event'].update({mpl_keypress_handler:
+                                                                                  bmp})
+            except AttributeError as ex:
+                print(f"Error {ex} was raised when trying to connect the key_press handler.  "
+                      "Please file an issue on github.  You may try a different matplotlib backend "
+                      "as a temporary workaround")
 
     def __call__(self, figure=None, axis=None, clear=True, autorefresh=None,
                  plotscale=1.0, override_plotkwargs=False, **kwargs):

--- a/pyspeckit/spectrum/tests/test_eqw.py
+++ b/pyspeckit/spectrum/tests/test_eqw.py
@@ -1,7 +1,7 @@
 import numpy as np
 import warnings
 
-from .. import Spectrum
+from pyspeckit.spectrum import Spectrum
 
 
 def test_eqw():


### PR DESCRIPTION
#389 dropped properties in a way that didn't make sense.  Instead, we just need to enforce that all xarrs are SpectroscopicAxis's