### PR TITLE
Remove extra dimension from paralel_map's output

### DIFF
--- a/pyspeckit/parallel_map/parallel_map.py
+++ b/pyspeckit/parallel_map/parallel_map.py
@@ -92,12 +92,11 @@ def run_tasks(procs, err_q, out_q, num):
     idx, result = out_q.get()
     results[idx] = result
 
+  # Remove extra dimension added by array_split
   try:
-      # Remove extra dimension added by array_split
       return list(numpy.concatenate(results))
   except ValueError:
-      return list(results)
-
+      return [r for row in results for r in row]
 
 def parallel_map(function, sequence, numcores=None):
   """


### PR DESCRIPTION
Enable `paralel_map.run_tasks()` to remove extra dimensions from its output in the exception case. This should resolve issue https://github.com/pyspeckit/pyspeckit/issues/412.