### PR TITLE
Fix for Issue 419: calculate DOF for optimal chi2

### DIFF
--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -1905,7 +1905,8 @@ class Specfit(interactive.Interactive):
 
         if reduced:
             # vheight included here or not?  assuming it should be...
-            return chi2/self.dof
+            dof = modelmask.sum() - self.fitter.npars
+            return chi2 / dof
         else:
             return chi2
 


### PR DESCRIPTION
the number of degrees of freedom is substantially smaller for optimal_chi2

Closes #419