### PR TITLE
Fix cube fitting: transposed x/y in fiteach ordering, multicore has_fit/blanking, and several crash bugs

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -365,7 +365,7 @@ class Cube(spectrum.Spectrum):
 
         return Cube(xarr=self.xarr.__getitem__(indx[0]),
                     cube=self.cube[indx],
-                    errorcube=self.errorcube[indx] if self.errorcube else None,
+                    errorcube=self.errorcube[indx] if self.errorcube is not None else None,
                     maskmap=self.maskmap[indx[1:]] if self.maskmap is not None else None,
                     header=self.header
                    )
@@ -796,11 +796,11 @@ class Cube(spectrum.Spectrum):
         log.info("Fitting up to {0} spectra".format(OK.sum()))
 
         if start_from_point == 'center':
-            start_from_point = (xx.max()/2., yy.max()/2.)
+            start_from_point = (xx.max()//2, yy.max()//2)
         if hasattr(position_order,'shape') and position_order.shape == self.cube.shape[1:]:
             sort_distance = np.argsort(position_order.flat)
         else:
-            d_from_start = ((xx-start_from_point[1])**2 + (yy-start_from_point[0])**2)**0.5
+            d_from_start = ((xx-start_from_point[0])**2 + (yy-start_from_point[1])**2)**0.5
             sort_distance = np.argsort(d_from_start.flat)
 
         if use_neighbor_as_guess or use_nearest_as_guess:
@@ -930,7 +930,7 @@ class Cube(spectrum.Spectrum):
             if use_nearest_as_guess and self.has_fit.sum() > 0:
                 if verbose_level > 1 and ii == 0 or verbose_level > 4:
                     log.info("Using nearest fit as guess")
-                rolled_distance = np.roll(np.roll(distance, x, 0), y, 1)
+                rolled_distance = np.roll(np.roll(distance, y, 0), x, 1)
                 # If there's no fit, set its distance to be unreasonably large
                 # so it will be ignored by argmin
                 nearest_ind = np.argmin(rolled_distance+1e10*(~self.has_fit))
@@ -1013,6 +1013,7 @@ class Cube(spectrum.Spectrum):
             else:
                 log.exception("Fit number {0} at {1},{2} had non-finite guesses {3}"
                               .format(ii, x, y, guesses))
+                success = False
                 self.has_fit[int(y),int(x)] = False
                 self.parcube[:,int(y),int(x)] = blank_value
                 self.errcube[:,int(y),int(x)] = blank_value
@@ -1052,17 +1053,12 @@ class Cube(spectrum.Spectrum):
                     raise TypeError("The fit never completed; something has gone wrong.")
 
 
-            # blank out the errors (and possibly the values) wherever they are zero = assumed bad
-            # this is done after the above exception to make sure we can inspect these values
-            if blank_value != 0:
-                self.parcube[self.parcube == 0] = blank_value
-                self.errcube[self.parcube == 0] = blank_value
-
             if integral:
                 return ((x,y), sp.specfit.modelpars, sp.specfit.modelerrs,
-                        self.integralmap[:,int(y),int(x)])
+                        success, self.integralmap[:,int(y),int(x)])
             else:
-                return ((x,y), sp.specfit.modelpars, sp.specfit.modelerrs)
+                return ((x,y), sp.specfit.modelpars, sp.specfit.modelerrs,
+                        success)
         #### BEGIN TEST BLOCK ####
         # This test block is to make sure you don't run a 30 hour fitting
         # session that's just going to crash at the end.
@@ -1136,9 +1132,9 @@ class Cube(spectrum.Spectrum):
             # force it to maintain a sensible shape.
             try:
                 if integral:
-                    ((x,y), m1, m2, intgl) = merged_result[0]
+                    ((x,y), m1, m2, success, intgl) = merged_result[0]
                 else:
-                    ((x,y), m1, m2) = merged_result[0]
+                    ((x,y), m1, m2, success) = merged_result[0]
             except ValueError:
                 if verbose > 1:
                     log.exception("ERROR: merged_result[0] is {0} which has the"
@@ -1153,9 +1149,9 @@ class Cube(spectrum.Spectrum):
                     continue
                 try:
                     if integral:
-                        ((x,y), modelpars, modelerrs, intgl) = TEMP
+                        ((x,y), modelpars, modelerrs, success, intgl) = TEMP
                     else:
-                        ((x,y), modelpars, modelerrs) = TEMP
+                        ((x,y), modelpars, modelerrs, success) = TEMP
                 except TypeError:
                     # implies that TEMP does not have the shape ((a,b),c,d)
                     # as above, shouldn't be possible, but it happens...
@@ -1176,7 +1172,7 @@ class Cube(spectrum.Spectrum):
                 else:
                     self.parcube[:,int(y),int(x)] = modelpars
                     self.errcube[:,int(y),int(x)] = modelerrs
-                    self.has_fit[int(y),int(x)] = max(modelpars) > 0
+                    self.has_fit[int(y),int(x)] = success
                 if integral:
                     self.integralmap[:,int(y),int(x)] = intgl
         else:
@@ -1195,6 +1191,16 @@ class Cube(spectrum.Spectrum):
         if verbose:
             log.info("Finished final fit %i.  "
                      "Elapsed time was %0.1f seconds" % (len(valid_pixels), time.time()-t0))
+
+        # blank out the errors (and possibly the values) wherever they are
+        # zero = assumed bad.  This is done after the fitting loop completes
+        # (rather than per-pixel) so that it also applies when multicore > 1
+        # and so that the errcube mask is computed before parcube is
+        # overwritten.
+        if blank_value != 0:
+            bad = self.parcube == 0
+            self.parcube[bad] = blank_value
+            self.errcube[bad] = blank_value
 
         pars_are_finite = np.all(np.isfinite(self.parcube), axis=0)
 

--- a/pyspeckit/cubes/cubes.py
+++ b/pyspeckit/cubes/cubes.py
@@ -77,7 +77,7 @@ def blfunc_generator(x=None, polyorder=None, splineorder=None,
                 endpoint = ngood - (ngood % sampling)
                 y = np.mean([yfit[mask][ii:endpoint:sampling]
                              for ii in range(sampling)], axis=0)
-                polypars = np.polyfit(x[mask][sampling/2:endpoint:sampling],
+                polypars = np.polyfit(x[mask][sampling//2:endpoint:sampling],
                                       y, polyorder)
                 return yreal-np.polyval(polypars, x).astype(yreal.dtype)
 
@@ -95,7 +95,7 @@ def blfunc_generator(x=None, polyorder=None, splineorder=None,
                 if len(y) <= splineorder:
                     raise ValueError("Sampling is too sparse.  Use finer sampling or "
                                      "decrease the spline order.")
-                spl = UnivariateSpline(x[mask][sampling/2:endpoint:sampling],
+                spl = UnivariateSpline(x[mask][sampling//2:endpoint:sampling],
                                        y,
                                        k=splineorder,
                                        s=0)
@@ -148,7 +148,7 @@ def baseline_cube(cube, polyorder=None, cubemask=None, splineorder=None,
         fit_cube = masked_cube.reshape(cube.shape[0], cube.shape[1]*cube.shape[2]).T
 
 
-    baselined = np.array(parallel_map(blfunc, zip(fit_cube,reshaped_cube), numcores=numcores))
+    baselined = np.array(parallel_map(blfunc, list(zip(fit_cube,reshaped_cube)), numcores=numcores))
     blcube = baselined.T.reshape(cube.shape)
     return blcube
 

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -8,6 +8,7 @@ import astropy
 import multiprocessing
 
 from .. import cubes, Cube, CubeStack
+from ...parallel_map import parallel_map
 from ...spectrum.models import n2hp, ammonia_constants
 from ...spectrum.models.ammonia import cold_ammonia_model
 
@@ -348,6 +349,78 @@ def test_copy_ids(cubefile='test.fits'):
     naxis_old = spc1.header['NAXIS1']
     spc2.header['NAXIS1'] += 1
     assert spc1.header['NAXIS1'] == naxis_old
+
+def test_getitem_with_errorcube(cubefile='test.fits'):
+    """
+    Regression test: slicing a Cube whose errorcube is set used to crash
+    because ``if self.errorcube`` evaluated the truth value of an array.
+    """
+    if not os.path.exists(cubefile):
+        make_test_cube((100,9,9), cubefile)
+
+    spc = Cube(cubefile)
+    spc.errorcube = np.ones_like(spc.cube)
+
+    subcube = spc[:, 1:3, 2:4]
+
+    assert subcube.cube.shape == (spc.cube.shape[0], 2, 2)
+    assert subcube.errorcube is not None
+    assert subcube.errorcube.shape == subcube.cube.shape
+
+def test_fiteach_start_from_center_even_dims():
+    """
+    Regression test: start_from_point='center' used to produce float
+    coordinates on even-dimension maps, which failed the valid-pixel
+    membership check.  Also exercises the (x, y) ordering of the
+    distance-from-start computation on a non-square map.
+    """
+    cubefile = 'test_even.fits'
+    make_test_cube((100,4,6), cubefile)
+    spc = Cube(cubefile)
+    map_rms = np.zeros_like(spc.cube[0]) + spc.header['RMSLVL']
+    spc.fiteach(fittype='gaussian',
+                guesses=[0.5,0.2,0.8],
+                start_from_point='center',
+                errmap=map_rms,
+                signal_cut=0)
+    assert np.all(spc.has_fit)
+
+def test_parallel_map_serial_returns_list():
+    """
+    Regression test: parallel_map with numcores=1 used to return a lazy
+    ``map`` object on python3; callers assume a list.
+    """
+    result = parallel_map(lambda x: x**2, [1, 2, 3], numcores=1)
+    assert isinstance(result, list)
+    assert result == [1, 4, 9]
+
+def test_fiteach_blank_value_nan():
+    """
+    Regression test: blank_value used to be applied per-pixel inside the
+    fitting function with a stale mask, so errcube was never blanked and
+    (under multicore) parcube blanking was lost in the forked children.
+    """
+    cubefile = 'test_blank.fits'
+    make_test_cube((100,9,9), cubefile)
+    spc = Cube(cubefile)
+    map_rms = np.zeros_like(spc.cube[0]) + spc.header['RMSLVL']
+    maskmap = np.ones(spc.cube.shape[1:], dtype='bool')
+    maskmap[:, :2] = False  # exclude the first two columns from fitting
+    spc.fiteach(fittype='gaussian',
+                guesses=[0.5,0.2,0.8],
+                start_from_point=(4,4),
+                errmap=map_rms,
+                signal_cut=0,
+                blank_value=np.nan,
+                maskmap=maskmap)
+    # excluded pixels must be NaN (not zero) in both parcube and errcube
+    assert np.all(np.isnan(spc.parcube[:, :, :2]))
+    assert np.all(np.isnan(spc.errcube[:, :, :2]))
+    assert not np.any(spc.has_fit[:, :2])
+    # pixels inside the mask were fit and should be finite
+    assert np.all(np.isfinite(spc.parcube[:, :, 2:]))
+    assert np.all(np.isfinite(spc.errcube[:, :, 2:]))
+    assert np.all(spc.has_fit[:, 2:])
 
 def make_nh3_cube(shape, pars, errs11, errs22, seed=42):
     """

--- a/pyspeckit/parallel_map/parallel_map.py
+++ b/pyspeckit/parallel_map/parallel_map.py
@@ -121,7 +121,7 @@ def parallel_map(function, sequence, numcores=None):
   size = len(sequence)
 
   if not _multi or size == 1 or numcores == 1:
-    return map(function, sequence)
+    return list(map(function, sequence))
 
   if numcores is not None and numcores > _ncpus:
       warnings.warn("Number of requested cores is greated than the "

--- a/pyspeckit/wrappers/cube_fit.py
+++ b/pyspeckit/wrappers/cube_fit.py
@@ -59,7 +59,7 @@ def cube_fit(cubefilename, outfilename, errfilename=None, scale_keyword=None,
 
     # Load the spectrum
     sp = pyspeckit.Cube(cubefilename,scale_keyword=scale_keyword)
-    if os.path.exists(errfilename):
+    if errfilename is not None and os.path.exists(errfilename):
         errmap = fits.getdata(errfilename)
     else:
         # very simple error calculation... biased and bad, needs improvement
@@ -80,15 +80,20 @@ def cube_fit(cubefilename, outfilename, errfilename=None, scale_keyword=None,
     # steal the header from the error map
     f = fits.open(cubefilename)
     # start replacing components of the fits object
-    f[0].data = np.concatenate([sp.parcube,sp.errcube,sp.integralmap])
+    # sp.integralmap exists only if fiteach was run with integral=True
+    if hasattr(sp, 'integralmap'):
+        f[0].data = np.concatenate([sp.parcube,sp.errcube,sp.integralmap])
+    else:
+        f[0].data = np.concatenate([sp.parcube,sp.errcube])
     f[0].header['PLANE1'] = 'amplitude'
     f[0].header['PLANE2'] = 'velocity'
     f[0].header['PLANE3'] = 'sigma'
     f[0].header['PLANE4'] = 'err_amplitude'
     f[0].header['PLANE5'] = 'err_velocity'
     f[0].header['PLANE6'] = 'err_sigma'
-    f[0].header['PLANE7'] = 'integral'
-    f[0].header['PLANE8'] = 'integral_error'
+    if hasattr(sp, 'integralmap'):
+        f[0].header['PLANE7'] = 'integral'
+        f[0].header['PLANE8'] = 'integral_error'
     f[0].header['CDELT3'] = 1
     f[0].header['CTYPE3'] = 'FITPAR'
     f[0].header['CRVAL3'] = 0

--- a/pyspeckit/wrappers/fit_gaussians_to_simple_spectra.py
+++ b/pyspeckit/wrappers/fit_gaussians_to_simple_spectra.py
@@ -32,9 +32,9 @@ def fit_gaussians_to_simple_spectra(filename, unit='km/s', doplot=True,
 
     # load a FITS-compliant spectrum
     spec = Spectrum(filename)
-    if spec.xarr.unit != units:
+    if spec.xarr.unit != unit:
         spec.xarr.frequency_to_velocity()
-        spec.xarr.convert_to_unit(units)
+        spec.xarr.convert_to_unit(unit)
 
     if croprange is not None and len(croprange) == 2:
         spec.crop(*croprange)


### PR DESCRIPTION
## Summary

A code-audit pass over the cube-fitting layer found a set of crash bugs and — more importantly — two silent x/y transposition bugs that change fit results. All were verified before fixing; regression tests added in `test_cubetools.py`.

### Wrong-result bugs (silent)

- **`fiteach` fit ordering was transposed**: `d_from_start` subtracted the y-coordinate from `xx` and vice versa (the file uses `yy,xx = np.indices(...)` and `start_from_point` is `(x, y)`). Fitting did not start from the requested pixel, and `use_nearest_as_guess`/`use_neighbor_as_guess` propagated guesses outward from the wrong seed.
- **`use_nearest_as_guess` roll axes transposed**: `np.roll(np.roll(distance, x, 0), y, 1)` rolled x along the y axis, so "nearest successful fit" was computed relative to the transposed pixel.
- **`has_fit` diverged between serial and multicore runs**: the multicore merge recomputed success as `max(modelpars) > 0`, so successful fits with all-nonpositive parameters (absorption lines, negative velocities) were marked unfit when `multicore>1`. The real per-pixel success flag is now threaded through the returned tuple.
- **`blank_value` was applied per-pixel inside the forked workers and with an order bug** (`errcube` masked after `parcube` was already overwritten), so with `multicore>1` blanking was lost entirely and `errcube` was never blanked. Blanking now happens once after the fitting loop.

### Crash bugs

- `Cube.__getitem__` used `if self.errorcube` (ambiguous-truth `ValueError` whenever an errorcube is set).
- `start_from_point='center'` computed float coordinates that fail the valid-pixel membership test on any even-dimension map.
- `parallel_map(..., numcores=1)` (or 1-CPU machines) returned a lazy `map` object; `np.array(...)` of it is a 0-d object array, breaking `Cube.smooth`, `spectral_smooth`, and `plane_smooth`.
- `cubes.baseline_cube` passed a `zip` to `parallel_map` (which calls `len()`) and used py2 `sampling/2` float slice indices — dead on arrival on Python 3.
- `cube_fit(...)` crashed on the default `errfilename=None`, and — worse — after completing a potentially hours-long fit it crashed on `sp.integralmap`, which only exists when `fiteach(integral=True)` was requested.
- `fit_gaussians_to_simple_spectra` referenced an undefined name (`units` vs the `unit` parameter) on every call.

## Testing

- New tests: `test_getitem_with_errorcube`, `test_fiteach_start_from_center_even_dims` (100×4×6 cube), `test_parallel_map_serial_returns_list`, `test_fiteach_blank_value_nan` (asserts masked-out pixels end up NaN in both parcube **and** errcube).
- Full suite, Python 3.10 / numpy 1.26.4 / astropy 6.1.7: **2235 passed**, 3 xfailed, 30 xpassed.
- Python 3.12 / numpy 2.5.0 / astropy 7.2.0: same, apart from the two known numpy-2.5 failures fixed in #422.
- Transposition fixes verified numerically (zero of `d_from_start` lands on the requested `(x, y)` pixel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv
