### PR TITLE
Fix model-layer bugs: misaligned hyperfine background limits, multi-peak tied re-indexing, formaldehyde RADEX crashes

### DIFF
--- a/pyspeckit/mpfit/mpfit.py
+++ b/pyspeckit/mpfit/mpfit.py
@@ -1287,7 +1287,7 @@ class mpfit:
                 catch_msg = 'calling '+str(fcn)
                 [self.status, wa4] = self.call(fcn, self.params, functkw)
                 if self.status < 0:
-                    self.errmsg = 'WARNING: premature termination by "'+fcn+'"'
+                    self.errmsg = 'WARNING: premature termination by "'+str(fcn)+'"'
                     log.log(5, self.errmsg)
                     return
                 fnorm1 = self.enorm(wa4)

--- a/pyspeckit/spectrum/models/ammonia.py
+++ b/pyspeckit/spectrum/models/ammonia.py
@@ -784,7 +784,15 @@ class ammonia_model(model.SpectralModel):
                 # multiplied by npars to get to the right number of
                 # gaussians, it will just replicate
                 if len(parlist) == self.npars:
-                    partype_dict[partype] *= npeaks
+                    if partype == 'tied':
+                        # tied strings reference parameter indices (e.g.,
+                        # 'p[0]-p[6]'), so each peak's copy must have its
+                        # indices shifted by ii*npars
+                        partype_dict[partype] = [_increment_string_number(t, ii*self.npars)
+                                                 for ii in range(npeaks)
+                                                 for t in parlist]
+                    else:
+                        partype_dict[partype] *= npeaks
                 elif len(parlist) > self.npars:
                     # DANGER:  THIS SHOULD NOT HAPPEN!
                     log.warning("WARNING!  Input parameters were longer than allowed for variable {0}".format(parlist))
@@ -807,8 +815,8 @@ class ammonia_model(model.SpectralModel):
                     partype_dict[partype] = list(parnames) * self.npeaks
                 elif parlist==tied:
                     partype_dict[partype] = [_increment_string_number(t, ii*self.npars)
-                                             for t in tied
-                                             for ii in range(self.npeaks)]
+                                             for ii in range(self.npeaks)
+                                             for t in tied]
 
         if len(parnames) != len(partype_dict['params']):
             raise ValueError("Wrong array lengths AFTER fixing them")
@@ -1212,17 +1220,14 @@ class ammonia_model_restricted_tex(ammonia_model):
 
 def _increment_string_number(st, count):
     """
-    Increment a number in a string
+    Increment each parameter index in a 'tied' string by ``count``
 
-    Expects input of the form: p[6]
+    Expects input of the form: p[6] or p[0]-p[6]; each bracketed number is
+    incremented independently (e.g., 'p[0]-p[6]' + 7 -> 'p[7]-p[13]').
     """
 
     import re
-    dig = re.compile('[0-9]+')
 
-    if dig.search(st):
-        n = int(dig.search(st).group())
-        result = dig.sub(str(n+count), st)
-        return result
-    else:
-        return st
+    return re.sub(r'\[([0-9]+)\]',
+                  lambda m: '[{0}]'.format(int(m.group(1)) + count),
+                  st)

--- a/pyspeckit/spectrum/models/formaldehyde.py
+++ b/pyspeckit/spectrum/models/formaldehyde.py
@@ -216,7 +216,7 @@ def formaldehyde_radex(xarr, density=4, column=13, xoff_v=0.0, width=1.0,
         raise ValueError("Invalid column/density")
 
     if scipyOK:
-        slices = [temperature_gridnumber] + [slice(int(np.floor(gv)),int(np.floor(gv))+2) for gv in (gridval2,gridval1)]
+        slices = tuple([temperature_gridnumber] + [slice(int(np.floor(gv)),int(np.floor(gv))+2) for gv in (gridval2,gridval1)])
         tau = [scipy.ndimage.map_coordinates(tg[slices],np.array([[gridval2%1],[gridval1%1]]),order=1) for tg in taugrid]
         tex = [scipy.ndimage.map_coordinates(tg[slices],np.array([[gridval2%1],[gridval1%1]]),order=1) for tg in texgrid]
     else:
@@ -231,7 +231,7 @@ def formaldehyde_radex(xarr, density=4, column=13, xoff_v=0.0, width=1.0,
         import pdb; pdb.set_trace()
 
     spec = np.sum([(formaldehyde_vtau(xarr,Tex=float(tex[ii]),tau=float(tau[ii]),xoff_v=xoff_v,width=width, **kwargs)
-                * (xarr.as_unit('GHz')>minfreq[ii]) * (xarr.as_unit('GHz')<maxfreq[ii])) for ii in xrange(len(tex))],
+                * (xarr.as_unit('GHz').value>minfreq[ii]) * (xarr.as_unit('GHz').value<maxfreq[ii])) for ii in xrange(len(tex))],
                 axis=0)
 
     return spec
@@ -291,8 +291,8 @@ def formaldehyde_radex_orthopara_temp(xarr, density=4, column=13,
         raise ValueError("Invalid column/density")
 
     if scipyOK:
-        slices = [slice(int(np.floor(gv)),int(np.floor(gv)+2))
-                  for gv in (gridval4,gridval3,gridval2,gridval1)]
+        slices = tuple(slice(int(np.floor(gv)),int(np.floor(gv)+2))
+                       for gv in (gridval4,gridval3,gridval2,gridval1))
         tau = [scipy.ndimage.map_coordinates(tg[slices],
                                              np.array([[gridval4 % 1],
                                                        [gridval3 % 1],
@@ -331,8 +331,8 @@ def formaldehyde_radex_orthopara_temp(xarr, density=4, column=13,
                                       Tex=float(tex[ii]), tau=float(tau[ii]),
                                       Tbackground=tbg[ii], xoff_v=xoff_v,
                                       width=width, **kwargs)
-                    * (xarr.as_unit('GHz')>minfreq[ii])
-                    * (xarr.as_unit('GHz')<maxfreq[ii]))
+                    * (xarr.as_unit('GHz').value>minfreq[ii])
+                    * (xarr.as_unit('GHz').value<maxfreq[ii]))
                    for ii in xrange(len(tex))],
                   axis=0)
 
@@ -394,7 +394,7 @@ def formaldehyde_pyradex(xarr, density=4, column=13, temperature=20,
                       tbackground=tbackground,)
 
     spec = np.sum([(formaldehyde_vtau(xarr,Tex=float(tex[ii]),tau=float(tau[ii]),xoff_v=xoff_v,width=width, **kwargs)
-                * (xarr.as_unit('GHz')>minfreq[ii]) * (xarr.as_unit('GHz')<maxfreq[ii])) for ii in xrange(len(tex))],
+                * (xarr.as_unit('GHz').value>minfreq[ii]) * (xarr.as_unit('GHz').value<maxfreq[ii])) for ii in xrange(len(tex))],
                 axis=0)
 
     return spec
@@ -498,7 +498,7 @@ def formaldehyde_radex_tau(xarr, density=4, column=13, xoff_v=0.0, width=1.0,
         raise ValueError("Invalid column/density")
 
     if scipyOK:
-        slices = [temperature_gridnumber] + [slice(np.floor(gv),np.floor(gv)+2) for gv in (gridval2,gridval1)]
+        slices = tuple([temperature_gridnumber] + [slice(int(np.floor(gv)),int(np.floor(gv))+2) for gv in (gridval2,gridval1)])
         tau = [scipy.ndimage.map_coordinates(tg[slices],np.array([[gridval2%1],[gridval1%1]]),order=1) for tg in taugrid]
     else:
         raise ImportError("Couldn't import scipy, therefore cannot interpolate")
@@ -507,8 +507,8 @@ def formaldehyde_radex_tau(xarr, density=4, column=13, xoff_v=0.0, width=1.0,
     spec_components = [(formaldehyde_vtau(xarr.as_unit('Hz', quiet=True),
         tau=float(tau[ii]), xoff_v=xoff_v, width=width,
         return_tau=True, return_hyperfine_components=True, **kwargs) *
-            (xarr.as_unit('GHz')>minfreq[ii]) *
-            (xarr.as_unit('GHz')<maxfreq[ii]))
+            (xarr.as_unit('GHz').value>minfreq[ii]) *
+            (xarr.as_unit('GHz').value<maxfreq[ii]))
                 for ii in  xrange(len(tau))]
 
     # get an array of [n_lines, n_hyperfine, len(xarr)]

--- a/pyspeckit/spectrum/models/hyperfine.py
+++ b/pyspeckit/spectrum/models/hyperfine.py
@@ -102,16 +102,16 @@ class hyperfinemodel(object):
 
         self.background_fitter = model.SpectralModel(self.hyperfine_addbackground,5,
             parnames=['Tbackground','Tex','tau','center','width'],
-            parlimited=[(True,False), (True,False), (False,False), (True,False), (False,False), (True,False)],
-            parlimits=[(0,0), (1e-5,0), (0,0), (0,0), (0,0), (0,0)],
+            parlimited=[(True,False), (True,False), (True,False), (False,False), (True,False)],
+            parlimits=[(0,0), (1e-5,0), (0,0), (0,0), (0,0)],
             shortvarnames=('T_{BG}',"T_{ex}","\\tau","v","\\sigma"), # specify the parameter names (TeX is OK)
             guess_types=[2.73, 'amplitude+2.73', 1.0, 'center', 'width'],
             fitunit='Hz')
 
         self.background_contsub_fitter = model.SpectralModel(self.hyperfine_background,5,
             parnames=['Tbackground','Tex','tau','center','width'],
-            parlimited=[(True,False), (True,False), (False,False), (True,False), (False,False), (True,False)],
-            parlimits=[(0,0), (1e-5,0), (0,0), (0,0), (0,0), (0,0)],
+            parlimited=[(True,False), (True,False), (True,False), (False,False), (True,False)],
+            parlimits=[(0,0), (1e-5,0), (0,0), (0,0), (0,0)],
             shortvarnames=('T_{BG}',"T_{ex}","\\tau","v","\\sigma"), # specify the parameter names (TeX is OK)
             guess_types=[0.0, 'amplitude+2.73', 1.0, 'center', 'width'],
             fitunit='Hz')

--- a/pyspeckit/spectrum/models/inherited_gaussfitter.py
+++ b/pyspeckit/spectrum/models/inherited_gaussfitter.py
@@ -57,7 +57,7 @@ def gaussian(xarr, amplitude, dx, width, return_components=False, normalized=Fal
     xarr = np.array(xarr) # make sure xarr is no longer a spectroscopic axis
     model = amplitude*np.exp(-(xarr-dx)**2/(2.0*width**2))
     if normalized:
-        return model / (np.sqrt(2*np.pi) * width**2)
+        return model / (np.sqrt(2*np.pi) * width)
     else:
         return model
 

--- a/pyspeckit/spectrum/models/lte_molecule.py
+++ b/pyspeckit/spectrum/models/lte_molecule.py
@@ -266,12 +266,24 @@ def get_molecular_parameters(molecule_name, tex=50, fmin=1*u.GHz, fmax=1*u.THz,
     if use_get_molecule:
         if molecule_tag is not None:
             jpltbl = QueryTool.get_molecule(molecule=molecule_tag, catalog=catalog)
+            tagcol = 'tag' if 'tag' in speciestab.colnames else 'TAG'
+            match = speciestab[tagcol] == molecule_tag
         else:
             jpltbl = QueryTool.get_molecule(molecule=molecule_name,
                                             catalog=catalog,
                                             parse_name_locally=parse_name_locally,
                                             flags=flags)
+            match = speciestab[molcol] == molecule_name
+            if match.sum() == 0:
+                # retry using partial string matching
+                match = np.core.defchararray.find(speciestab[molcol], molecule_name) != -1
         molecule_name = jpltbl['name']
+
+        if match.sum() != 1:
+            raise ValueError(f"Too many or too few matches ({match.sum()}) to {molecule_name}")
+        # jpltable (the species table row) holds the partition function
+        # metadata used by partfunc below
+        jpltable = speciestab[match]
 
     else:
         if molecule_tag is not None:

--- a/pyspeckit/spectrum/models/tests/test_regressions.py
+++ b/pyspeckit/spectrum/models/tests/test_regressions.py
@@ -1,0 +1,111 @@
+"""
+Regression tests for assorted model-layer bugs:
+
+ - hyperfine background fitter parlimited/parlimits misalignment
+ - ammonia multi-peak 'tied' strings not being re-indexed
+ - _increment_string_number replacing all indices with the first one
+ - normalized Gaussian dividing by width**2 instead of width
+ - ParinfoList.__setitem__ infinite recursion on existing keys
+"""
+import numpy as np
+
+from .. import ammonia
+from .. import n2hp
+from .. import inherited_gaussfitter
+from ...parinfo import Parinfo, ParinfoList
+
+
+def test_hyperfine_background_fitter_parinfo_alignment():
+    """
+    The background fitters declared 5 parnames but 6-element
+    parlimited/parlimits, shifting every limit after 'Tex': tau became
+    unbounded, center silently became limited >=0 (forbidding blueshifted
+    fits), and width became unbounded.
+    """
+    for fitter in (n2hp.n2hp_vtau_tbg_fitter,
+                   n2hp.n2hp_vtau.background_contsub_fitter):
+        parinfo = fitter.make_parinfo()
+        limits = {p['parname'].strip('0123456789'): (p['limited'], p['limits'])
+                  for p in parinfo}
+        assert set(limits.keys()) == {'TBACKGROUND', 'TEX', 'TAU', 'CENTER',
+                                      'WIDTH'}
+        # Tbackground >= 0
+        assert limits['TBACKGROUND'] == ((True, False), (0, 0))
+        # Tex >= 1e-5 (Tex=0 is a singularity)
+        assert limits['TEX'] == ((True, False), (1e-5, 0))
+        # tau >= 0
+        assert limits['TAU'] == ((True, False), (0, 0))
+        # center must be UNlimited (velocity can be negative)
+        assert limits['CENTER'] == ((False, False), (0, 0))
+        # width >= 0
+        assert limits['WIDTH'] == ((True, False), (0, 0))
+
+
+def test_increment_string_number():
+    """
+    _increment_string_number used to replace ALL numbers in the string with
+    the (first number + increment): 'p[0]-p[6]' + 7 -> 'p[7]-p[7]'.
+    Each index must be incremented independently.
+    """
+    assert ammonia._increment_string_number('p[0]-p[6]', 7) == 'p[7]-p[13]'
+    assert ammonia._increment_string_number('p[6]', 7) == 'p[13]'
+    # empty / index-free strings pass through unchanged
+    assert ammonia._increment_string_number('', 7) == ''
+    assert ammonia._increment_string_number('notied', 7) == 'notied'
+
+
+def test_ammonia_restricted_tex_multipeak_tied():
+    """
+    With npeaks=2, the per-peak 'tied' strings used to be replicated
+    verbatim, so peak 2's tex was tied to PEAK 1's parameters.
+    """
+    mod = ammonia.ammonia_model_restricted_tex()
+    parinfo = mod.make_parinfo(npeaks=2, params=(20, 20, 0.5, 1.0, 0.0, 0.5, 0)*2)
+    assert parinfo.tied == ['', 'p[0]-p[6]', '', '', '', '', '',
+                            '', 'p[7]-p[13]', '', '', '', '', '']
+
+    # single-peak behavior must be unchanged
+    mod1 = ammonia.ammonia_model_restricted_tex()
+    parinfo1 = mod1.make_parinfo()
+    assert parinfo1.tied == ['', 'p[0]-p[6]', '', '', '', '', '']
+
+
+def test_normalized_gaussian_integral():
+    """
+    The normalized Gaussian used to divide by width**2 instead of width,
+    making it wrong by a factor of width.
+    """
+    # np.trapz was removed in numpy 2.0 in favor of np.trapezoid
+    trapezoid = getattr(np, 'trapezoid', getattr(np, 'trapz', None))
+    x = np.linspace(-100, 100, 200001)
+    for amp, width in [(1.0, 1.0), (3.0, 2.5), (2.0, 0.3)]:
+        y = inherited_gaussfitter.gaussian(x, amp, 0.0, width,
+                                           normalized=True)
+        assert np.isclose(trapezoid(y, x), amp, rtol=1e-6)
+
+
+def test_parinfolist_setitem():
+    """
+    ParinfoList.__setitem__ used to recurse infinitely (self[key] = val)
+    when replacing an existing item by int or string key.
+    """
+    pl = ParinfoList([Parinfo({'n': 0, 'value': 1.0, 'parname': 'AMPLITUDE'}),
+                      Parinfo({'n': 1, 'value': 2.0, 'parname': 'SHIFT'})])
+
+    # replace by integer index
+    pl[0] = Parinfo({'n': 0, 'value': 5.0, 'parname': 'AMPLITUDE0'})
+    assert pl.values == [5.0, 2.0]
+    assert pl[0]['value'] == 5.0
+    assert pl['AMPLITUDE0']['value'] == 5.0
+
+    # replace by string (parameter name) key
+    pl['AMPLITUDE0'] = Parinfo({'n': 0, 'value': 7.0,
+                                'parname': 'AMPLITUDE0'})
+    assert pl.values == [7.0, 2.0]
+    assert pl[0]['value'] == 7.0
+    assert pl['AMPLITUDE0']['value'] == 7.0
+
+    # out-of-range int assignment still raises
+    import pytest
+    with pytest.raises(IndexError):
+        pl[5] = Parinfo({'n': 5, 'value': 1.0, 'parname': 'NOPE'})

--- a/pyspeckit/spectrum/parinfo.py
+++ b/pyspeckit/spectrum/parinfo.py
@@ -112,15 +112,33 @@ class ParinfoList(list):
 
     def __setitem__(self, key, val):
         """
-        DO NOT allow items to be replaced/overwritten,
-        instead use their own setters
+        Replace an existing item (by index or parameter name) with a new
+        Parinfo, keeping the name lookup dictionary in sync.
         """
-        # if key already exists, use its setter
-        if key in self._dict or (type(key) is int and key < len(self)):
-            self[key] = val
-        elif type(key) is int:
-            # can't set a new list element this way
-            raise IndexError("Index %i out of range" % key)
+        if type(key) is int:
+            if not (-len(self) <= key < len(self)):
+                # can't set a new list element this way
+                raise IndexError("Index %i out of range" % key)
+            if not isinstance(val, Parinfo):
+                raise TypeError("Can only add Parinfo items to ParinfoLists")
+            olditem = super(ParinfoList, self).__getitem__(key)
+            super(ParinfoList, self).__setitem__(key, val)
+            oldname = olditem['parname']
+            if self._dict.get(oldname) is olditem:
+                self._dict.pop(oldname)
+            if self.__dict__.get(oldname) is olditem:
+                self.__dict__.pop(oldname)
+            self._dict[val['parname']] = val
+            self.__dict__[val['parname']] = val
+        elif key in self._dict:
+            # replace the corresponding list element (by identity)
+            olditem = self._dict[key]
+            for index in xrange(len(self)):
+                if super(ParinfoList, self).__getitem__(index) is olditem:
+                    self.__setitem__(index, val)
+                    return
+            raise KeyError("Parameter {0} found in the name dictionary but "
+                           "not in the list".format(key))
         elif isinstance(val,Parinfo):
             # otherwise, add the item
             self.__dict__[key] = val


### PR DESCRIPTION
## Summary

A code-audit pass over the model layer found bugs that produce **silently wrong fit results** plus a few crashes. All verified before fixing; regression tests added in `pyspeckit/spectrum/models/tests/test_regressions.py`.

### Silently wrong results

- **Hyperfine `background_fitter`/`background_contsub_fitter` limits were misaligned**: both passed 6-element `parlimited`/`parlimits` for 5 parameters. The stray extra entry shifted everything after `tau`: `tau` became unbounded, the **velocity centroid was constrained ≥ 0** (silently forbidding blueshifted fits), and `width` could go negative. Affects `n2hp_vtau_tbg_fitter`, `formaldehyde_vtau_tbg_fitter`, and every hyperfine background fitter.
- **Multi-peak `tied` expressions in ammonia models were never re-indexed**: `make_parinfo(npeaks=2, ...)` replicated peak 1's tie verbatim, so peak 2's `tex` was tied to *peak 1's* parameters (e.g. `ammonia_model_restricted_tex` gave `tex1 = p[0]-p[6]` instead of `p[7]-p[13]`) — silently wrong multi-component fits. Additionally `_increment_string_number` replaced *all* numbers in the string with the first incremented one (`'p[0]-p[6]' + 7 → 'p[7]-p[7]'`); it now increments each `p[N]` index independently.
- **`inherited_gaussfitter.gaussian(..., normalized=True)` divided by `width**2`** instead of `width`, making normalized-Gaussian results wrong by a factor of the width.

### Crashes

- **`lte_molecule.get_molecular_parameters` raised `NameError` on its default path**: `partfunc` closes over `jpltable`, which was only defined in the non-default `use_get_molecule=False` branch.
- **`formaldehyde_radex*` grid interpolators** indexed numpy arrays with a Python *list* of slices (`IndexError` on numpy ≥ 1.24), used float slice bounds (`TypeError`), and compared GHz `Quantity`s against bare floats (`UnitConversionError`). Verified end-to-end with a synthetic grid: both `formaldehyde_radex` and `formaldehyde_radex_tau` now return finite spectra.
- **`ParinfoList.__setitem__` recursed infinitely** for any existing key (`pl[0] = parinfo` → `RecursionError`) and silently corrupted the container for new named keys. Item replacement by index or name now works and keeps the name lookup in sync.
- **mpfit**: the premature-termination error path concatenated a function object into a string (`TypeError` masking the real diagnostic); now `str(fcn)`, matching the existing idiom elsewhere in the file.

## Testing

- 5 new regression tests: hyperfine background parinfo alignment, `_increment_string_number`, `restricted_tex` npeaks=2 tied indices, normalized-Gaussian integral, ParinfoList item assignment.
- Full suite, Python 3.10 / numpy 1.26.4 / astropy 6.1.7: **2236 passed** (2231 baseline + 5 new), 3 xfailed, 30 xpassed.
- Python 3.12 / numpy 2.5.0 / astropy 7.2.0: same, apart from the two known numpy-2.5 failures fixed in #422.
- No existing test depended on the buggy limits or tied replication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv
