### PR TITLE
Updated N2H+ example, verified end-to-end (supersedes #374)

### DIFF
--- a/examples/n2hp_example.py
+++ b/examples/n2hp_example.py
@@ -1,4 +1,5 @@
 import pyspeckit
+from pyspeckit.spectrum.models import n2hp
 
 # Load the spectrum
 sp = pyspeckit.Spectrum('n2hp_opha_example.fits')
@@ -10,14 +11,16 @@ sp = pyspeckit.Spectrum('n2hp_opha_example.fits')
 # background will not automatically be fit 4 is the number of parameters in the
 # model (excitation temperature, optical depth, line center, and line width)
 sp.Registry.add_fitter('n2hp_vtau',pyspeckit.models.n2hp.n2hp_vtau_fitter,4)
+sp.xarr.refX = sp.header['REFFREQ'] 
 sp.xarr.velocity_convention = 'radio'
+sp.xarr.convert_to_unit('km/s')
 # Run the fitter
-sp.specfit(fittype='n2hp_vtau',multifit=None,guesses=[15,2,4,0.2])
+sp.specfit(fittype='n2hp_vtau', guesses=[5, 2, 4, 0.2])
 
 # Plot the results
 sp.plotter()
 # Re-run the fitter (to get proper error bars) and show the individual fit components
-sp.specfit(fittype='n2hp_vtau', multifit=None, guesses=[15, 2, 4, 0.2],
+sp.specfit(fittype='n2hp_vtau', guesses=[5, 2, 4, 0.2], 
            show_hyperfine_components=True)
 
 # Save the figure (this step is just so that an image can be included on the web page)


### PR DESCRIPTION
Supersedes and closes #374.

## Summary

@ashleythomasbarnes's approved update to `examples/n2hp_example.py` (convert the axis to km/s, more sensible guesses `[5, 2, 4, 0.2]`, drop the obsolete `multifit=None`), cherry-picked onto current master with authorship preserved. The only outstanding request on the original PR was "I'd like to run the test before I press Merge" — so we ran it.

## Verification run

The example was run end-to-end on current master (MPLBACKEND=Agg, data: `n2hp_opha_example.fits`). It completes with no modifications and produces a clean fit:

- Tex = 6.16 ± 0.62 K
- tau = 2.18 ± 0.53
- v_center = 3.4127 ± 0.0059 km/s
- sigma = 0.2636 ± 0.0059 km/s
- chi²/dof = 501.05/497 ≈ 1.008

The composite fit and 15 hyperfine components overlay the data cleanly across all three hyperfine groups.

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv
