### PR TITLE
Modernize mm-formaldehyde grid indexing (supersedes #336)

### DIFF
--- a/pyspeckit/spectrum/models/formaldehyde_mm.py
+++ b/pyspeckit/spectrum/models/formaldehyde_mm.py
@@ -389,9 +389,9 @@ def formaldehyde_mm_radex(xarr,
         # this is mostly a trick for speed: slice so you only have two thin layers to interpolate
         # between
         #slices = [density_gridnumber] + [slice(np.floor(gv),np.floor(gv)+2) for gv in (gridval2,gridval1)]
-        slices = [slice(np.floor(gridval3),np.floor(gridval3)+2),
-                  slice(np.floor(gridval2),np.floor(gridval2)+2),
-                  slice(np.floor(gridval1),np.floor(gridval1)+2)
+        slices = [slice(int(np.floor(gridval3)), int(np.floor(gridval3))+2),
+                  slice(int(np.floor(gridval2)), int(np.floor(gridval2))+2),
+                  slice(int(np.floor(gridval1)), int(np.floor(gridval1))+2)
                   ]
         tau = [scipy.ndimage.map_coordinates(tg[slices],
             np.array([[gridval3%1],[gridval2%1],[gridval1%1]]),order=1) for tg in taugrid]
@@ -404,6 +404,7 @@ def formaldehyde_mm_radex(xarr,
 
     if verbose:
         for ta,tk in zip(tau,tex):
+            print((density, temperature, column, ta, tk))
             print("density %20.12g temperature %20.12g column %20.12g: tau %20.12g tex %20.12g" % (density, temperature, column, ta, tk))
 
     if debug:

--- a/pyspeckit/spectrum/models/formaldehyde_mm.py
+++ b/pyspeckit/spectrum/models/formaldehyde_mm.py
@@ -295,7 +295,8 @@ def formaldehyde_mm_despotic(xarr,
     minfreq = [218.15, 218.40, 218.7]
     maxfreq = [218.25, 218.55, 218.8]
     spec = np.sum([
-        (formaldehyde_mm_vtau(xarr, Tex=float(tex[ii]), tau=float(tau[ii]),
+        (formaldehyde_mm_vtau(xarr, Tex=float(np.squeeze(tex[ii])),
+                              tau=float(np.squeeze(tau[ii])),
                               xoff_v=xoff_v, width=width, **kwargs)
          * (xarr.as_unit('GHz').value>minfreq[ii]) *
          (xarr.as_unit('GHz').value<maxfreq[ii])) for ii in xrange(len(tex))],
@@ -389,10 +390,8 @@ def formaldehyde_mm_radex(xarr,
         # this is mostly a trick for speed: slice so you only have two thin layers to interpolate
         # between
         #slices = [density_gridnumber] + [slice(np.floor(gv),np.floor(gv)+2) for gv in (gridval2,gridval1)]
-        slices = [slice(int(np.floor(gridval3)), int(np.floor(gridval3))+2),
-                  slice(int(np.floor(gridval2)), int(np.floor(gridval2))+2),
-                  slice(int(np.floor(gridval1)), int(np.floor(gridval1))+2)
-                  ]
+        slices = tuple(slice(int(np.floor(gv)), int(np.floor(gv))+2)
+                       for gv in (gridval3, gridval2, gridval1))
         tau = [scipy.ndimage.map_coordinates(tg[slices],
             np.array([[gridval3%1],[gridval2%1],[gridval1%1]]),order=1) for tg in taugrid]
         tex = [scipy.ndimage.map_coordinates(tg[slices],
@@ -404,14 +403,14 @@ def formaldehyde_mm_radex(xarr,
 
     if verbose:
         for ta,tk in zip(tau,tex):
-            print((density, temperature, column, ta, tk))
             print("density %20.12g temperature %20.12g column %20.12g: tau %20.12g tex %20.12g" % (density, temperature, column, ta, tk))
 
     if debug:
         import pdb; pdb.set_trace()
 
     spec = np.sum([
-        (formaldehyde_mm_vtau(xarr, Tex=float(tex[ii]), tau=float(tau[ii]),
+        (formaldehyde_mm_vtau(xarr, Tex=float(np.squeeze(tex[ii])),
+            tau=float(np.squeeze(tau[ii])),
             xoff_v=xoff_v, width=width, **kwargs)
         * (xarr.as_unit('GHz').value>minfreq[ii]) *
          (xarr.as_unit('GHz').value<maxfreq[ii])) for ii in xrange(len(tex))],

--- a/pyspeckit/spectrum/models/h2co_mm.py
+++ b/pyspeckit/spectrum/models/h2co_mm.py
@@ -150,9 +150,10 @@ def h2co_mm_radex(xarr,
 #        spec2 = spec2 + (1-np.exp(-taunu))*tex[ii] + Tbg*(np.exp(-taunu)-1)  #second term assumes an ON-OFF
 
     spec = np.sum([
-            (formaldehyde_mm_vtau(xarr, Tex=float(tex[ii]), tau=float(tau[ii]),
+            (formaldehyde_mm_vtau(xarr, Tex=float(np.squeeze(tex[ii])),
+                                  tau=float(np.squeeze(tau[ii])),
                                   xoff_v=xoff_v, width=width, **kwargs)
-             * (xarr.as_unit('GHz')>minfreq[ii]) * (xarr.as_unit('GHz')<maxfreq[ii])) for ii in xrange(len(tex))],
+             * (xarr.as_unit('GHz').value>minfreq[ii]) * (xarr.as_unit('GHz').value<maxfreq[ii])) for ii in xrange(len(tex))],
                   axis=0)
 #    import pdb
 #    pdb.set_trace()

--- a/pyspeckit/spectrum/models/tests/test_regressions.py
+++ b/pyspeckit/spectrum/models/tests/test_regressions.py
@@ -109,3 +109,78 @@ def test_parinfolist_setitem():
     import pytest
     with pytest.raises(IndexError):
         pl[5] = Parinfo({'n': 5, 'value': 1.0, 'parname': 'NOPE'})
+
+
+def test_formaldehyde_mm_radex_synthetic_grid():
+    """
+    formaldehyde_mm_radex indexed its (temperature, column, density) RADEX
+    grids with a *list* of slices whose bounds were np.float64; modern numpy
+    raises for both (list-of-slices fancy indexing and float slice bounds).
+    Feed it a small synthetic grid that is linear in the grid indices, so
+    the trilinear interpolation is exact, and compare against the
+    directly-evaluated vtau model.
+    """
+    import astropy.io.fits as pyfits
+    from astropy import units as u
+    from .. import formaldehyde_mm
+    from ...units import SpectroscopicAxis
+
+    ntemp, ncol, ndens = 5, 6, 7
+    hdr = pyfits.Header()
+    hdr['CRPIX1'], hdr['CRVAL1'], hdr['CDELT1'] = 1, 2.0, 0.5    # log density: 2-5
+    hdr['CRPIX2'], hdr['CRVAL2'], hdr['CDELT2'] = 1, 11.0, 0.5   # log column: 11-13.5
+    hdr['CRPIX3'], hdr['CRVAL3'], hdr['CDELT3'] = 1, 10.0, 10.0  # temperature: 10-50
+
+    zz, yy, xx = np.indices((ntemp, ncol, ndens), dtype=float)
+    taug = 0.01 * (1 + zz + 2 * yy + 3 * xx)
+    texg = 5.0 + zz + yy + xx
+
+    xarr = SpectroscopicAxis(np.linspace(218.1, 218.35, 200) * u.GHz)
+
+    # temperature=25 -> gridval3=1.5; column=13.25 -> gridval2=4.5;
+    # density=4.25 -> gridval1=4.5 -- all deliberately off-grid so the
+    # slice bounds are non-integer floats before conversion.
+    spec = formaldehyde_mm.formaldehyde_mm_radex(xarr,
+                                                 temperature=25,
+                                                 column=13.25,
+                                                 density=4.25,
+                                                 xoff_v=0.0, width=1.0,
+                                                 texgrid=((218., 219., texg),),
+                                                 taugrid=((218., 219., taug),),
+                                                 hdr=hdr)
+
+    # linear grids => exact trilinear interpolation values
+    expected_tau = 0.01 * (1 + 1.5 + 2 * 4.5 + 3 * 4.5)  # 0.25
+    expected_tex = 5.0 + 1.5 + 4.5 + 4.5                 # 15.5
+    direct = formaldehyde_mm.formaldehyde_mm_vtau(xarr, Tex=expected_tex,
+                                                  tau=expected_tau,
+                                                  xoff_v=0.0, width=1.0)
+    assert np.all(np.isfinite(spec))
+    assert spec.max() > 0
+    np.testing.assert_allclose(np.asarray(spec), np.asarray(direct),
+                               rtol=1e-10, atol=1e-12)
+
+
+def test_h2co_mm_radex_quantity_comparison():
+    """
+    h2co_mm_radex compared xarr.as_unit('GHz') (a Quantity) against plain
+    floats when masking each line's frequency range, which raises
+    UnitConversionError with modern astropy; the comparison must use .value.
+    """
+    from astropy import units as u
+    from .. import h2co_mm
+    from ...units import SpectroscopicAxis
+
+    xarr = SpectroscopicAxis(np.linspace(218.1, 218.9, 300) * u.GHz)
+    gridbundle = (lambda c, d, t: 12.0,   # Tex303
+                  lambda c, d, t: 10.0,   # Tex322
+                  lambda c, d, t: 9.0,    # Tex321
+                  lambda c, d, t: 0.5,    # tau303
+                  lambda c, d, t: 0.2,    # tau322
+                  lambda c, d, t: 0.1)    # tau321
+
+    spec = h2co_mm.h2co_mm_radex(xarr, Temperature=25, logColumn=13,
+                                 logDensity=4, xoff_v=0.0, width=1.0,
+                                 gridbundle=gridbundle)
+    assert np.all(np.isfinite(spec))
+    assert spec.max() > 0


### PR DESCRIPTION
Supersedes and closes #336.

## Summary

The original 2020 commit wrapped the `formaldehyde_mm_radex` grid slice bounds in `int(np.floor(...))` to fix float-index deprecations. On its own that no longer suffices — numpy ≥ 1.24 hard-errors on the list-of-slices indexing too. This PR cherry-picks the original commit and finishes the job, matching the idiom merged for `formaldehyde.py` in #425:

- `formaldehyde_mm.py`: index grids with a `tuple` of int-bounded slices; remove a stray debug `print`.
- `h2co_mm.py`: compare `xarr.as_unit('GHz').value` against the float grid edges (Quantity-vs-float raises `UnitConversionError` on modern astropy).
- numpy 2.5 fix caught during validation: `float(arr)` on the shape-(1,) outputs of `map_coordinates` is a hard `TypeError` under numpy 2 — now `float(np.squeeze(...))` in `formaldehyde_mm_radex`, `formaldehyde_mm_despotic`, and `h2co_mm_radex`.

## Validation

- New tests in `test_regressions.py`: a synthetic-grid test for `formaldehyde_mm_radex` (grids linear in grid coordinates, off-grid query point, so trilinear interpolation is analytically exact; asserts the spectrum equals directly-evaluated `formaldehyde_mm_vtau` to rtol 1e-10) — fails with IndexError/TypeError on the pre-fix code — plus an `h2co_mm_radex` smoke test with stub interpolators covering the Quantity comparison.
- Full suite: **2254 passed**, 3 xfailed, 30 xpassed on both Python 3.10 / numpy 1.26 and Python 3.12 / numpy 2.5.

Note for a follow-up: merged `formaldehyde.py` still has bare `float(tex[ii])` calls that are a latent numpy-2 `TypeError` on the same pattern (its #425 synthetic-grid test doesn't hit that line).

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv
