### PR TITLE
GBT reader + Spectrum division fixes for python 3 (supersedes #319)

### DIFF
--- a/pyspeckit/spectrum/classes.py
+++ b/pyspeckit/spectrum/classes.py
@@ -847,6 +847,8 @@ class BaseSpectrum(object):
     __sub__ = _operation_wrapper(np.subtract)
     __mul__ = _operation_wrapper(np.multiply)
     __div__ = _operation_wrapper(np.divide)
+    # python 3 uses __truediv__; without this, Spectrum / x raises TypeError
+    __truediv__ = _operation_wrapper(np.divide)
 
 class SingleSpectrum(BaseSpectrum):
     __class_name__ = 'SingleSpectrum'

--- a/pyspeckit/spectrum/correlate.py
+++ b/pyspeckit/spectrum/correlate.py
@@ -19,7 +19,12 @@ def correlate(spectrum1, spectrum2, range=None, unit=None, errorweight=False):
         spectrum1 = spectrum1.slice(*range, unit=unit)
         spectrum2 = spectrum2.slice(*range, unit=unit)
 
-    if not (spectrum1.xarr.shape == spectrum2.xarr.shape) or not all(spectrum1.xarr == spectrum2.xarr):
+    # `all(xarr1 == xarr2)` fails when the shapes differ, because the
+    # comparison then evaluates to a scalar False, which is not iterable
+    if (spectrum1.xarr.shape != spectrum2.xarr.shape or
+            spectrum1.xarr.unit != spectrum2.xarr.unit or
+            not np.array_equal(np.asarray(spectrum1.xarr),
+                               np.asarray(spectrum2.xarr))):
         spectrum2 = interpolation.interp(spectrum2, spectrum1)
 
     data1 = spectrum1.data

--- a/pyspeckit/spectrum/interpolation.py
+++ b/pyspeckit/spectrum/interpolation.py
@@ -89,13 +89,16 @@ def interp_on_axes(spec1, xarr, left=0, right=0):
     newdata = _interp(xarr, xarr1, spec1.data, left=left, right=right)
 
     if spec1.error is not None:
-        if xarr1.cdelt() and xarr.cdelt():
-            binsizeratio = xarr1.cdelt() / xarr.cdelt()
+        # cdelt() raises ValueError for non-linear axes, and the truthiness
+        # of the Quantity it returns is ambiguous on modern astropy
+        try:
+            binsizeratio = float((xarr1.cdelt() / xarr.cdelt()).decompose().value)
+        except ValueError:
+            newerror = _interp(xarr,xarr1,spec1.error)
+        else:
             # reduce errors by sqrt(binsize) if going from small to large bins
             # else increase errors by similar factor (WARNING!  THEY WILL BE CORRELATED!)
             newerror = _interp(xarr,xarr1,spec1.error) * binsizeratio**0.5
-        else:
-            newerror = _interp(xarr,xarr1,spec1.error)
     else:
         newerror = None
 

--- a/pyspeckit/spectrum/readers/gbt.py
+++ b/pyspeckit/spectrum/readers/gbt.py
@@ -8,11 +8,10 @@ supported, frequency switching is not.
 
 """
 from __future__ import print_function
+from functools import reduce
 from six import iteritems
-try:
-    import astropy.io.fits as pyfits
-except ImportError:
-    import pyfits
+import astropy.io.fits as pyfits
+from astropy import units as u
 import pyspeckit
 import numpy as np
 try:
@@ -50,7 +49,12 @@ def list_targets(sdfitsfile, doprint=True):
     strings = [ "\n%18s  %10s %10s %26s%8s %9s %9s %9s" % ("Object Name","RA","DEC","%12s%14s"%("RA","DEC"),"N(ptgs)","Exp.Time","requested","n(ints)") ]
     for objectname in uniq(bintable.data['OBJECT']):
         whobject = bintable.data['OBJECT'] == objectname
-        RA,DEC = bintable.data['TRGTLONG'][whobject],bintable.data['TRGTLAT'][whobject]
+        # some SDFITS dialects (e.g., the examples in the GBTIDL Users'
+        # Guide) lack TRGTLONG/TRGTLAT; fall back to the WCS columns
+        if 'TRGTLONG' in bintable.data.names and 'TRGTLAT' in bintable.data.names:
+            RA,DEC = bintable.data['TRGTLONG'][whobject],bintable.data['TRGTLAT'][whobject]
+        else:
+            RA,DEC = bintable.data['CRVAL2'][whobject],bintable.data['CRVAL3'][whobject]
         RADEC = zip(RA,DEC)
         midRA,midDEC = np.median(RA),np.median(DEC)
         npointings = len(set(RADEC))
@@ -61,7 +65,10 @@ def list_targets(sdfitsfile, doprint=True):
         firstsampler = bintable.data['SAMPLER'][whobject][0]
         whfirstsampler = bintable.data['SAMPLER'] == firstsampler
         exptime = bintable.data['EXPOSURE'][whobject*whfirstsampler].sum()
-        duration = bintable.data['DURATION'][whobject*whfirstsampler].sum()
+        if 'DURATION' in bintable.data.names:
+            duration = bintable.data['DURATION'][whobject*whfirstsampler].sum()
+        else:
+            duration = exptime
         n_ints = count_integrations(bintable, objectname)
         strings.append( "%18s  %10f %10f %26s%8i %9g %9g %9i" % (objectname,midRA,midDEC,sexagesimal, npointings, exptime, duration, n_ints) )
 
@@ -94,13 +101,14 @@ def read_gbt_scan(sdfitsfile, obsnumber=0):
     sp = pyspeckit.Spectrum(HDU,filetype='pyfits')
     #sp.xarr.frame = 'topo' # sp.header.get('VELDEF') #'topo'
 
-    # HACK - temporary!
-    # Convert xarr to LSR units
-    #sp.xarr.convert_to_unit('m/s')
+    # Shift the topocentric frequency axis into the reference frame of the
+    # observation: VFRAME is the frame velocity (m/s), converted to a
+    # frequency offset via the radio convention at the observed frequency
     obsfreq = header['OBSFREQ']
-    centerfreq = pyspeckit.spectrum.units.SpectroscopicAxis(float(obsfreq),'Hz',refX=obsfreq,refX_unit='Hz')
-    delta_freq = (centerfreq.as_unit('m/s') + header['VFRAME']).as_unit(centerfreq.units) - centerfreq
-    sp.xarr -= delta_freq
+    centerfreq = u.Quantity(obsfreq, u.Hz)
+    delta_freq = u.Quantity(header['VFRAME'], u.m/u.s).to(
+        u.Hz, u.doppler_radio(centerfreq)) - centerfreq
+    sp.xarr = sp.xarr - delta_freq
 
     return sp
 
@@ -129,7 +137,9 @@ def read_gbt_target(sdfitsfile, objectname, verbose=False):
         for nod in nods:
             whnod = bintable.data['PROCSEQN'] == nod
             for onoff in ('ON','OFF'):
-                calOK = (calON - (onoff=='OFF'))
+                # select rows with the cal diode on for 'ON', off for 'OFF'
+                # (python-2 numpy boolean subtraction was elementwise XOR)
+                calOK = (calON ^ (onoff=='OFF'))
                 whOK = (whobject*whsampler*calOK*whnod)
                 if whOK.sum() == 0:
                     continue
@@ -140,7 +150,12 @@ def read_gbt_target(sdfitsfile, objectname, verbose=False):
                     maxdiff = np.diff(crvals).max()
                 else:
                     maxdiff = 0
-                freqres = np.max(bintable.data[whOK]['FREQRES'])
+                if 'FREQRES' in bintable.data.names:
+                    freqres = np.max(bintable.data[whOK]['FREQRES'])
+                else:
+                    # some SDFITS dialects lack FREQRES; the channel width
+                    # is a reasonable stand-in
+                    freqres = np.max(np.abs(bintable.data[whOK]['CDELT1']))
                 if maxdiff < freqres:
                     splist = [read_gbt_scan(bintable,ii) for ii in np.where(whOK)[0]]
                     blocks[sampler+onoff+str(nod)] = pyspeckit.ObsBlock(splist,force=True)
@@ -281,19 +296,19 @@ def dcmeantsys(calon,caloff,tcal,debug=False):
 
     # Use the inner 80% of data to calculate mean Tsys
     nchans = calon.data.shape[0]
-    pct10 = nchans/10
+    pct10 = nchans//10
     pct90 = nchans - pct10
 
-    meanoff = np.mean(caloff.slice(pct10,pct90,units='pixels').data)
-    meandiff = np.mean(calon.slice(pct10,pct90,units='pixels').data - 
-                        caloff.slice(pct10,pct90,units='pixels').data)
+    meanoff = np.mean(caloff.slice(pct10,pct90,unit='pixel').data)
+    meandiff = np.mean(calon.slice(pct10,pct90,unit='pixel').data -
+                        caloff.slice(pct10,pct90,unit='pixel').data)
 
     meanTsys = ( meanoff / meandiff * tcal + tcal/2.0 )
     if debug:
         print(caloff)
-        print(caloff.slice(pct10,pct90,units='pixels'))
+        print(caloff.slice(pct10,pct90,unit='pixel'))
         print(calon)
-        print(calon.slice(pct10,pct90,units='pixels'))
+        print(calon.slice(pct10,pct90,unit='pixel'))
         print("pct10: %i  pct90: %i mean1: %f mean2: %f tcal: %f tsys: %f" % (pct10,pct90,meanoff,meandiff,tcal,meanTsys))
 
     return meanTsys
@@ -341,14 +356,15 @@ def find_matched_freqs(reduced_blocks, debug=False):
     # IF order 
     sampler_numbers = [int(name[1:]) for name in reduced_blocks.keys()]
     sorted_pairs = sorted(zip(sampler_numbers,reduced_blocks.keys()))
-    sorted_names = zip(*sorted_pairs)[1]
+    sorted_names = list(zip(*sorted_pairs))[1]
 
     # how many IFs?
     frequencies = dict((name,reduced_blocks[name].header.get('OBSFREQ')) for name in sorted_names)
     if debug: print(frequencies)
     round_frequencies = dict((name,
         round_to_resolution(reduced_blocks[name].header.get('OBSFREQ'),
-                            reduced_blocks[name].header.get('FREQRES')))
+                            reduced_blocks[name].header.get('FREQRES') or
+                            abs(reduced_blocks[name].header.get('CDELT1'))))
                  for name in sorted_names)
     if debug: print(round_frequencies)
     unique_frequencies = uniq(round_frequencies.values()) # uniq is an order-preserving function


### PR DESCRIPTION
Supersedes and closes #319.

## Summary

A distilled version of @teuben's GBT fixes with the review requests applied: all debug prints, `if False:` experiments, and the WIP `reduce_ps` work are dropped; the real fixes are kept (credited via Co-authored-by); and two of his workarounds are replaced by fixes to the root causes he was hacking around.

- **gbt.py**
  - The VFRAME doppler correction is now exactly the reviewer-suggested form: `u.Quantity(header['VFRAME'], u.m/u.s).to(u.Hz, u.doppler_radio(centerfreq)) - centerfreq`.
  - `calOK = calON ^ (onoff=='OFF')` — answering the review question about XOR vs AND-NOT: XOR is correct. The block names' ON/OFF refer to the **cal diode** state (`reduce_nod` feeds `...ON1`/`...OFF1` pairs to `dcmeantsys(calon, caloff, tcal)`), so the 'OFF' blocks must select cal-off rows; AND-NOT would make every OFF block empty and break Tsys calculation. XOR also exactly preserves the original py2 `calON - (onoff=='OFF')` semantics.
  - py3 fixes: `functools.reduce` import, `zip` subscripting, integer division and the stale `units=` kwarg in `dcmeantsys`.
  - Tolerate SDFITS dialects lacking `TRGTLONG`/`TRGTLAT`, `DURATION`, `FREQRES` (the GBTIDL Users' Guide example files) by falling back to `CRVAL2/3`, `EXPOSURE`, `CDELT1`.
- **classes.py**: add `__truediv__` to Spectrum arithmetic — on Python 3, `Spectrum / x` raised `TypeError` because only py2's `__div__` was defined. This is the root cause of the `totalpower`/`sigref` crashes that #319 worked around by mutating `.data` in place.
- **correlate.py**: the axis-equality check called `all()` on a scalar `False` whenever the shapes differ (the "why did this ever work?" commit); replaced with a shape/unit/`np.array_equal` test.
- **interpolation.py**: `interp_on_axes` tested the truthiness of `cdelt()` Quantities, which raises `ValueError: Quantity truthiness is ambiguous` on modern astropy — a live crash for interpolating any spectrum that has errors; now handled via the `ValueError` that `cdelt()` raises for non-linear axes.

Not included: `reduce_ps`/`reduce_fs` (author-labeled "horrific hacks", position-switched reduction) — that work needs its own PR with PS test data.

## Validation

Run end-to-end against real GBT SDFITS data (`3C286.fits` from pyspeckit-tests): session load and target listing (this file lacks TRGTLONG/DURATION, exercising the fallbacks), ObsBlock loading, a Gaussian fit whose χ²/n **matches the historical 1.61022** recorded in #319's own notes, `totalpower`/`sigref` arithmetic, `dcmeantsys`, and `correlate()` with and without errors.

Full suite: **2252 passed**, 3 xfailed, 30 xpassed on both Python 3.10 / numpy 1.26 and Python 3.12 / numpy 2.5 / astropy 7.2.

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv
