### PR TITLE
RADEX-grid NH3 fitting with fortho robustness fix (supersedes #332)

### DIFF
--- a/pyspeckit/spectrum/models/__init__.py
+++ b/pyspeckit/spectrum/models/__init__.py
@@ -25,7 +25,7 @@ for ii in xrange(-15,0):
        for the user functions and will not clash with MPFIT."""
 
 from . import ammonia_hf
-from .ammonia import ammonia_model,ammonia_model_vtau
+from .ammonia import ammonia_model,ammonia_model_vtau,ammonia_model_radex
 from . import ammonia15n
 from .ammonia15n import ammonia15n_model
 # old way from gaussfitter import gaussian_fitter

--- a/pyspeckit/spectrum/models/ammonia.py
+++ b/pyspeckit/spectrum/models/ammonia.py
@@ -27,10 +27,12 @@ from . import mpfit_messages
 import operator
 import string
 import warnings
+from functools import partial
 
 from .ammonia_constants import (line_names, freq_dict, aval_dict, ortho_dict,
                                 TCMB,
                                 voff_lines_dict, tau_wts_dict)
+from .ammonia_grids import ammonia_grids, parbounds
 
 
 def ammonia(xarr, trot=20, tex=None, ntot=14, width=1, xoff_v=0.0, fortho=0.0,
@@ -71,10 +73,11 @@ def ammonia(xarr, trot=20, tex=None, ntot=14, width=1, xoff_v=0.0, fortho=0.0,
     fortho: float
         Fraction of NH3 molecules in ortho state.  Default assumes all para
         (fortho=0).
-    tau: None or float
+    tau: None or float or dict
         If tau (optical depth in the 1-1 line) is specified, ntot is NOT fit
         but is set to a fixed value.  The optical depths of the other lines are
-        fixed relative to tau_oneone
+        fixed relative to tau_oneone.  If a dict is given, it specifies the
+        optical depth of each line directly (keys must be line names).
     fillingfraction: None or float
         fillingfraction is an arbitrary scaling factor to apply to the model
     return_tau: bool
@@ -152,6 +155,11 @@ def ammonia(xarr, trot=20, tex=None, ntot=14, width=1, xoff_v=0.0, fortho=0.0,
                       "This is unphysical and "
                       "suggests that you may need to constrain tex.  See "
                       "ammonia_model_restricted_tex.")
+
+    if isinstance(tau, dict):
+        for k in tau:
+            assert k in line_names,"{0} not in line list".format(k)
+
     if width < 0:
         return np.zeros(xarr.size)*np.nan
     elif width == 0:
@@ -173,8 +181,6 @@ def ammonia(xarr, trot=20, tex=None, ntot=14, width=1, xoff_v=0.0, fortho=0.0,
         raise ValueError("ntot, the logarithmic total column density,"
                          " must be in the range 5 - 25")
 
-    tau_dict = {}
-
     """
     Column density is the free parameter.  It is used in conjunction with
     the full partition function to compute the optical depth in each band
@@ -188,62 +194,67 @@ def ammonia(xarr, trot=20, tex=None, ntot=14, width=1, xoff_v=0.0, fortho=0.0,
 
     log.debug("Partition Function: Q_ortho={0}, Q_para={1}".format(Qortho, Qpara))
 
-    for linename in line_names:
-        if ortho_dict[linename]:
-            # define variable "ortho_or_para_frac" that will be the ortho
-            # fraction in the case of an ortho transition or the para
-            # fraction for a para transition
-            ortho_or_parafrac = fortho
-            Z = Zortho
-            Qtot = Qortho
-        else:
-            ortho_or_parafrac = 1.0-fortho
-            Z = Zpara
-            Qtot = Qpara
+    if tau is None or not isinstance(tau, dict):
+        tau_dict = {}
+        for linename in line_names:
+            if ortho_dict[linename]:
+                # define variable "ortho_or_para_frac" that will be the ortho
+                # fraction in the case of an ortho transition or the para
+                # fraction for a para transition
+                ortho_or_parafrac = fortho
+                Z = Zortho
+                Qtot = Qortho
+            else:
+                ortho_or_parafrac = 1.0-fortho
+                Z = Zpara
+                Qtot = Qpara
 
-        # for a complete discussion of these equations, please see
-        # https://github.com/keflavich/pyspeckit/blob/ammonia_equations/examples/AmmoniaLevelPopulation.ipynb
-        # https://github.com/pyspeckit/pyspeckit/blob/master/examples/AmmoniaLevelPopulation.ipynb
-        # and
-        # http://low-sky.github.io/ammoniacolumn/
-        # and
-        # https://github.com/pyspeckit/pyspeckit/pull/136
+            # for a complete discussion of these equations, please see
+            # https://github.com/keflavich/pyspeckit/blob/ammonia_equations/examples/AmmoniaLevelPopulation.ipynb
+            # https://github.com/pyspeckit/pyspeckit/blob/master/examples/AmmoniaLevelPopulation.ipynb
+            # and
+            # http://low-sky.github.io/ammoniacolumn/
+            # and
+            # https://github.com/pyspeckit/pyspeckit/pull/136
 
-        # short variable names for readability
-        frq = freq_dict[linename]
-        partition = Z[line_name_indices[linename]]
-        aval = aval_dict[linename]
+            # short variable names for readability
+            frq = freq_dict[linename]
+            partition = Z[line_name_indices[linename]]
+            aval = aval_dict[linename]
 
-        # Total population of the higher energy inversion transition
-        population_rotstate = lin_ntot * ortho_or_parafrac * partition/Qtot
+            # Total population of the higher energy inversion transition
+            population_rotstate = lin_ntot * ortho_or_parafrac * partition/Qtot
 
-        if isinstance(tex, dict):
-            expterm = ((1-np.exp(-h*frq/(kb*tex[linename]))) /
-                       (1+np.exp(-h*frq/(kb*tex[linename]))))
-        else:
-            expterm = ((1-np.exp(-h*frq/(kb*tex))) /
-                       (1+np.exp(-h*frq/(kb*tex))))
-        fracterm = (ccms**2 * aval / (8*np.pi*frq**2))
-        widthterm = (ckms/(width*frq*(2*np.pi)**0.5))
+            if isinstance(tex, dict):
+                expterm = ((1-np.exp(-h*frq/(kb*tex[linename]))) /
+                           (1+np.exp(-h*frq/(kb*tex[linename]))))
+            else:
+                expterm = ((1-np.exp(-h*frq/(kb*tex))) /
+                           (1+np.exp(-h*frq/(kb*tex))))
+            fracterm = (ccms**2 * aval / (8*np.pi*frq**2))
+            widthterm = (ckms/(width*frq*(2*np.pi)**0.5))
 
-        tau_i = population_rotstate * fracterm * expterm * widthterm
-        tau_dict[linename] = tau_i
+            tau_i = population_rotstate * fracterm * expterm * widthterm
+            tau_dict[linename] = tau_i
 
-        log.debug("Line {0}: tau={1}, expterm={2}, pop={3},"
-                  " partition={4}"
-                  .format(linename, tau_i, expterm, population_rotstate,
-                          partition))
+            log.debug("Line {0}: tau={1}, expterm={2}, pop={3},"
+                      " partition={4}"
+                      .format(linename, tau_i, expterm, population_rotstate,
+                              partition))
 
-    # allow tau(11) to be specified instead of ntot
-    # in the thin case, this is not needed: ntot plays no role
-    # this process allows you to specify tau without using the approximate equations specified
-    # above.  It should remove ntot from the calculations anyway...
-    if tau is not None:
-        tau11_temp = tau_dict['oneone']
-        # re-scale all optical depths so that tau is as specified, but the relative taus
-        # are sest by the kinetic temperature and partition functions
-        for linename,t in iteritems(tau_dict):
-            tau_dict[linename] = t * tau/tau11_temp
+        # allow tau(11) to be specified instead of ntot
+        # in the thin case, this is not needed: ntot plays no role
+        # this process allows you to specify tau without using the approximate equations specified
+        # above.  It should remove ntot from the calculations anyway...
+        if tau is not None:
+            tau11_temp = tau_dict['oneone']
+            # re-scale all optical depths so that tau is as specified, but the relative taus
+            # are sest by the kinetic temperature and partition functions
+            for linename,t in iteritems(tau_dict):
+                tau_dict[linename] = t * tau/tau11_temp
+    else:
+        # tau is a dict specifying the optical depth of each line directly
+        tau_dict = tau
 
     if return_tau:
         return tau_dict
@@ -301,6 +312,80 @@ def cold_ammonia(xarr, tkin, **kwargs):
     log.debug("Cold ammonia turned T_K = {0} into T_rot = {1}".format(tkin,trot))
 
     return ammonia(xarr, trot=trot, **kwargs)
+
+
+def ammonia_radex(xarr, tkin=20,
+                  ntot=14, logdens=4, width=1.0, xoff_v=0.0, fortho=0.0,
+                  interpolator=None, scaling_method='loglogfit',
+                  line_names=line_names,
+                  **kwargs):
+    """
+    Generate a model Ammonia spectrum based on input temperatures,
+    column, and gaussian parameters.  Samples a user-provided grid of
+    radiation temperatures and opacities derived from RADEX.
+
+    Parameters
+    ----------
+    xarr: `pyspeckit.spectrum.units.SpectroscopicAxis`
+        Array of wavelength/frequency values
+    tkin: float
+        Kinetic temperature in K
+    ntot: float
+        Total log10 column density of NH3 (ortho + para)
+    logdens: float
+        log10 of the H2 volume density in cm^-3
+    width: float
+        Line width (Gaussian sigma) in km/s
+    xoff_v: float
+        Line offset in km/s
+    fortho: float
+        Fraction of NH3 molecules in ortho state
+    interpolator: callable
+        A grid sampler as returned by
+        `~pyspeckit.spectrum.models.ammonia_grids.ammonia_grids`
+    scaling_method: str
+        Line width scaling method passed to the interpolator
+    """
+
+    dix = interpolator(logdens=logdens,
+                       tkin=tkin,
+                       ntot=ntot,
+                       fortho=fortho,
+                       sigma=width,
+                       scaling_method=scaling_method)
+
+    tau_dict = {}
+    tex_dict = {}
+    if 'oneone' in line_names:
+        tau_dict['oneone'] = dix['tau_11']
+        tex_dict['oneone'] = dix['Tex_11']
+
+    if 'twotwo' in line_names:
+        tau_dict['twotwo'] = dix['tau_22']
+        tex_dict['twotwo'] = dix['Tex_22']
+
+    if ('threethree' in line_names) and (fortho > 0):
+        tau_dict['threethree'] = dix['tau_33']
+        tex_dict['threethree'] = dix['Tex_33']
+
+    if 'fourfour' in line_names:
+        tau_dict['fourfour'] = dix['tau_44']
+        tex_dict['fourfour'] = dix['Tex_44']
+
+    if 'fivefive' in line_names:
+        tau_dict['fivefive'] = dix['tau_55']
+        tex_dict['fivefive'] = dix['Tex_55']
+
+    if ('sixsix' in line_names) and (fortho > 0):
+        tau_dict['sixsix'] = dix['tau_66']
+        tex_dict['sixsix'] = dix['Tex_66']
+
+    spec = ammonia(xarr, tex=tex_dict, tau=tau_dict,
+                   width=width, xoff_v=xoff_v, fortho=fortho,
+                   line_names=line_names, **kwargs)
+
+    return spec
+
 
 def ammonia_thin(xarr, tkin=20, tex=None, ntot=14, width=1, xoff_v=0.0,
                  fortho=0.0, tau=None, return_tau=False, **kwargs):
@@ -746,6 +831,7 @@ class ammonia_model(model.SpectralModel):
         from decimal import Decimal # for formatting
         tex_key = {'trot':'T_R', 'tkin': 'T_K', 'tex':'T_{ex}', 'ntot':'N',
                    'fortho':'F_o', 'width':'\\sigma', 'xoff_v':'v',
+                   'logdens':'\\log_{10} n',
                    'fillingfraction':'FF', 'tau':'\\tau_{1-1}',
                    'background_tb':'T_{BG}', 'delta':'T_R-T_{ex}'}
         # small hack below: don't quantize if error > value.  We want to see the values.
@@ -1244,6 +1330,110 @@ class ammonia_model_restricted_tex(ammonia_model):
                                   **kwargs)
 
 
+class ammonia_model_radex(ammonia_model):
+    """
+    Ammonia model computed by sampling a grid of RADEX models.
+
+    The free parameters are the kinetic temperature ``tkin``, the total
+    (ortho+para) log column density ``ntot``, the log volume density
+    ``logdens``, plus the usual ``width``, ``xoff_v``, and ``fortho``.  The
+    excitation temperature and opacity of each line are interpolated from
+    the model grid stored in ``gridfile`` (see
+    `~pyspeckit.spectrum.models.ammonia_grids.ammonia_grids`).
+    """
+
+    def __init__(self,
+                 gridfile=None,
+                 scaling_method='loglogfit',
+                 parnames=['tkin', 'ntot', 'logdens', 'width',
+                           'xoff_v', 'fortho'],
+                 **kwargs):
+
+        self.gridfile = gridfile
+        self.grid_interpolator = ammonia_grids(gridfile=self.gridfile)
+        self.grid_bounds = parbounds(gridfile=self.gridfile)
+
+        # gridfile & scaling_method are deliberately *not* forwarded to
+        # super().__init__: leftover kwargs there become modelfunc_kwargs,
+        # which would then be passed to the model function on every call.
+        super(ammonia_model_radex, self).__init__(parnames=parnames, **kwargs)
+
+        self.modelfunc = partial(ammonia_radex,
+                                 interpolator=self.grid_interpolator,
+                                 scaling_method=scaling_method)
+
+    def _validate_parinfo(self,
+                          must_be_limited={'tkin': [True,False],
+                                           'ntot': [True, False],
+                                           'logdens':[True, True],
+                                           'width': [True, False],
+                                           'xoff_v': [False, False],
+                                           'fortho': [True, True],
+                          },
+                          required_limits={'tkin': [0, None],
+                                           'ntot': [0, None],
+                                           'logdens':[0, 10],
+                                           'width': [0, None],
+                                           'xoff_v': [None,None],
+                                           'fortho': [0,1],
+                          }):
+
+        if (required_limits is None
+            and must_be_limited is None
+            and self.grid_bounds is not None):
+            must_be_limited = {'tkin': [True, True],
+                               'ntot': [True, True],
+                               'logdens': [True, True],
+                               'width': [True, True],
+                               'xoff_v': [False, False],
+                               'fortho': [True, True]}
+            required_limits={'tkin': self.grid_bounds['tkin'],
+                             'ntot': self.grid_bounds['ntot'],
+                             'logdens':self.grid_bounds['logdens'],
+                             'width': self.grid_bounds['sigmav'],
+                             'xoff_v': [None,None],
+                             'fortho': [0,1]}
+
+        supes = super(ammonia_model_radex, self)
+        return supes._validate_parinfo(must_be_limited=must_be_limited,
+                                       required_limits=required_limits)
+
+    def make_parinfo(self, npeaks=1, err=None,
+                     params=(20, 14, 4, 0.5, 0.0, 0.0), parnames=None,
+                     fixed=(False,False,False,False,False,True),
+                     limitedmin=(True,True,True,True,False,True),
+                     limitedmax=(False,False,True,False,False,True),
+                     minpars=(TCMB,0,0,0,0,0), parinfo=None,
+                     maxpars=(0,0,10,0,0,1),
+                     tied=('',)*6,
+                     quiet=True, shh=True,
+                     veryverbose=False, **kwargs):
+
+        if self.grid_bounds is not None:
+            minpars = (self.grid_bounds['tkin'][0],
+                       self.grid_bounds['ntot'][0],
+                       self.grid_bounds['logdens'][0],
+                       self.grid_bounds['sigmav'][0],
+                       0, 0)
+            maxpars = (self.grid_bounds['tkin'][1],
+                       self.grid_bounds['ntot'][1],
+                       self.grid_bounds['logdens'][1],
+                       self.grid_bounds['sigmav'][1],
+                       0, 1)
+            limitedmin = (True, True, True, True, False, True)
+            limitedmax = (True, True, True, True, False, True)
+
+        return super(ammonia_model_radex,
+                     self).make_parinfo(npeaks=npeaks, err=err, params=params,
+                                        parnames=parnames, fixed=fixed,
+                                        limitedmin=limitedmin,
+                                        limitedmax=limitedmax, minpars=minpars,
+                                        parinfo=parinfo, maxpars=maxpars,
+                                        tied=tied, quiet=quiet, shh=shh,
+                                        veryverbose=veryverbose, **kwargs)
+
+    def __call__(self,*args,**kwargs):
+        return self.multinh3fit(*args, **kwargs)
 
 
 

--- a/pyspeckit/spectrum/models/ammonia_grids.py
+++ b/pyspeckit/spectrum/models/ammonia_grids.py
@@ -1,0 +1,198 @@
+"""
+===========================
+Ammonia RADEX grid sampling
+===========================
+
+Interpolation onto grids of RADEX models for the ammonia inversion
+transitions, translated from Erik Rosolowsky's implementation.
+
+The grid file is a table with one row per model.  The first ``N-4`` columns
+are the model outputs (e.g., ``tau_11`` ... ``tau_66``, ``Tex_11`` ...
+``Tex_66``) and the final four columns are the model parameters ``nH2``,
+``Temperature``, ``Column``, and ``sigmav``.
+
+Module API
+^^^^^^^^^^
+
+"""
+from astropy.table import Table
+from astropy import log
+import scipy.ndimage as ndinterp
+import scipy.interpolate as interp
+import numpy as np
+
+default_filename = None
+sig2fwhm = np.sqrt(8 * np.log(2))
+
+# Excitation temperature (CMB) assigned to lines that have no opacity
+# (tau=0); with tau=0 the emission is zero independent of Tex, but Tex must
+# be finite and nonzero to avoid division-by-zero in the radiative transfer.
+TCMB = 2.7315
+
+loglogdict = {'oneone': [-1.81326302e-01,  3.34381710e-01],
+              'twotwo': [-2.69968439e-02,  1.11981158e-01],
+              'threethree': [-2.68340072e-02,  6.72730044e-02],
+              'fourfour': [-7.89713752e-05,  2.91441632e-02],
+              'fivefive': [-3.25164539e-05,  1.93889654e-02],
+              'sixsix': [-1.76846051e-05,  1.38318044e-02],
+              'sevenseven': [-1.18320819e-05,  1.03632255e-02],
+              'eighteight': [-9.33491439e-06,  8.05543087e-03],
+              'ninenine': [ 0.00000000e+00,  0.00000000e+00]}
+
+
+def line_scaling_function(sigmav, linename, method='loglogfit'):
+
+    # Scaling of intrinsic line width to Gaussian equivalent line
+    # width for use in RADEX
+
+    if method == 'none':
+        return(sigmav)
+
+    if method == 'sig2fwhm':
+        return(sigmav * sig2fwhm)
+
+    if method == 'loglogfit':
+        coeffs = loglogdict[linename]
+        return(sigmav *  1e1**(np.log10(sigmav)
+                               * coeffs[0] + coeffs[1]))
+
+
+def parbounds(gridfile=None):
+    # Return boundaries of grid to bound fit parameters
+
+    if gridfile is None:
+        return(None)
+
+    t = Table.read(gridfile)
+    density_values = np.unique(t['nH2'].data)
+    temperature_values = np.unique(t['Temperature'].data)
+    column_values = np.unique(t['Column'].data)
+    sigmav_values = np.unique(t['sigmav'].data)
+    bound_dict = {'logdens': [np.nanmin(np.log10(density_values)),
+                              np.nanmax(np.log10(density_values))],
+                  'tkin':[np.nanmin(temperature_values),
+                          np.nanmax(temperature_values)],
+                  'ntot':[np.nanmin(np.log10(column_values)),
+                          np.nanmax(np.log10(column_values))],
+                  'sigmav':[np.nanmin(sigmav_values),
+                            np.nanmax(sigmav_values)]}
+    return(bound_dict)
+
+
+def ammonia_grids(gridfile=None):
+    if gridfile is None:
+        gridfile = default_filename
+    try:
+        t = Table.read(gridfile)
+    except Exception:
+        log.warning("Could not read RADEX grid file {0}; "
+                    "no grid interpolator will be available.".format(gridfile))
+        return None
+
+    # Given inputs, fold table into a grid.  Assume uniform spacing in
+    # log space.
+
+    nOutputs = len(t.keys())-4 # this is the number of outputs from the grid.
+    modelkeys = (t.keys())[0:nOutputs]
+    density_values = np.unique(t['nH2'].data)
+    temperature_values = np.unique(t['Temperature'].data)
+    column_values = np.unique(t['Column'].data)
+    sigmav_values = np.unique(t['sigmav'].data)
+
+    # Should this be initialized to NaNs instead?  Could be risky.
+    grid = np.zeros((nOutputs,density_values.size,temperature_values.size,
+                     column_values.size,sigmav_values.size))
+    idx1 = np.digitize(t['nH2'].data,density_values)-1
+    idx2 = np.digitize(t['Temperature'].data,temperature_values)-1
+    idx3 = np.digitize(t['Column'].data,column_values)-1
+    idx4 = np.digitize(t['sigmav'].data,sigmav_values)-1
+
+    f1 = interp.interp1d(np.log10(density_values),
+                         np.arange(density_values.size),
+                         bounds_error=False)
+    f2 = interp.interp1d(np.log10(temperature_values),
+                         np.arange(temperature_values.size),
+                         bounds_error=False)
+    f3 = interp.interp1d(np.log10(column_values),
+                         np.arange(column_values.size),
+                         bounds_error=False)
+    f4 = interp.interp1d(np.log10(sigmav_values),
+                         np.arange(sigmav_values.size),
+                         bounds_error = False)
+
+    # Pack that grid
+    for idx,key in enumerate(modelkeys):
+                         grid[idx,idx1,idx2,idx3,idx4] = t[key].data
+
+    def ammonia_sampler(logdens=4,
+                        tkin=15,
+                        ntot=14,
+                        fortho=0.0,
+                        sigma=0.3,
+                        order=1,
+                        scaling_method='loglogfit'):
+        outputdict = {}
+
+        param_interps = np.zeros((nOutputs, 5))
+        # Track which rows have actually been assigned coordinates: for
+        # fortho == 0 (or 1), the ortho (or para) lines are skipped and must
+        # not be fed to map_coordinates with stale zero coordinates.
+        valid = np.zeros(nOutputs, dtype=bool)
+        if fortho != 1:
+            for linename, idx in zip(['oneone','twotwo',
+                                      'fourfour','fivefive'],
+                                     [0, 1, 3, 4]):
+                dV = line_scaling_function(sigma, linename,
+                                           method=scaling_method)
+                thisarray = np.array(np.c_[0,f1(logdens),
+                                           f2(np.log10(tkin)),
+                                           f3(ntot + np.log10(1-fortho)),
+                                           f4(np.log10(dV))])
+                param_interps[idx, :] = thisarray
+                param_interps[idx + 6, :] = thisarray
+                valid[idx] = True
+                valid[idx + 6] = True
+
+        if fortho != 0:
+            for linename, idx in zip(['threethree', 'sixsix'],
+                                     [2, 5]):
+                dV = line_scaling_function(sigma, linename,
+                                           method=scaling_method)
+
+                thisarray = np.array(np.c_[0,f1(logdens),
+                                           f2(np.log10(tkin)),
+                                           f3(ntot + np.log10(fortho)),
+                                           f4(np.log10(dV))])
+                param_interps[idx, :] = thisarray
+                param_interps[idx + 6, :] = thisarray
+                valid[idx] = True
+                valid[idx + 6] = True
+        param_interps[:,0] = np.arange(nOutputs)
+
+        # The interp1d calls above use bounds_error=False, so parameters
+        # outside the grid produce NaN coordinates (e.g., the ortho column
+        # ntot + log10(fortho) for very small fortho).  NaN coordinates are
+        # undefined behavior for map_coordinates, so such rows are treated
+        # as "outside the grid" and given no-emission defaults below.
+        valid &= np.all(np.isfinite(param_interps), axis=1)
+
+        interp_params = np.full(nOutputs, np.nan)
+        if np.any(valid):
+            interp_params[valid] = ndinterp.map_coordinates(
+                grid, param_interps[valid].T, order=order, prefilter=False,
+                cval=np.nan)
+
+        for idx,key in enumerate(modelkeys):
+            if valid[idx] and np.isfinite(interp_params[idx]):
+                outputdict[key] = interp_params[idx]
+            elif 'Tex' in key:
+                # a species column below (or above) the grid contributes no
+                # emission: tau=0 and Tex=TCMB (finite & nonzero so the
+                # radiative transfer expression stays well-defined)
+                outputdict[key] = TCMB
+            else:
+                outputdict[key] = 0.0
+
+        return outputdict
+
+    return ammonia_sampler

--- a/pyspeckit/spectrum/models/hyperfine.py
+++ b/pyspeckit/spectrum/models/hyperfine.py
@@ -164,13 +164,13 @@ class hyperfinemodel(object):
 
     def hyperfine_amp(self, xarr, amp=None, xoff_v=0.0, width=1.0,
                       return_hyperfine_components=False, Tbackground=2.73,
-                      Tex=5.0, tau=0.1):
+                      Tex=5.0, tau=0.1, **kwargs):
         """
         wrapper of self.hyperfine with order of arguments changed
         """
         return self.hyperfine(xarr, amp=amp, Tex=Tex, tau=tau, xoff_v=xoff_v,
                 width=width, return_hyperfine_components=return_hyperfine_components,
-                Tbackground=Tbackground)
+                Tbackground=Tbackground, **kwargs)
 
     def hyperfine_tau(self, xarr, tau, xoff_v, width, **kwargs):
         """ same as hyperfine, but with arguments in a different order, AND
@@ -247,7 +247,7 @@ class hyperfinemodel(object):
     def hyperfine(self, xarr, Tex=5.0, tau=0.1, xoff_v=0.0, width=1.0,
                   return_hyperfine_components=False, Tbackground=2.73, amp=None,
                   return_tau=False, tau_total=None, vary_hyperfine_tau=False,
-                  vary_hyperfine_width=False):
+                  vary_hyperfine_width=False, **kwargs):
         """
         Generate a model spectrum given an excitation temperature, optical
         depth, offset velocity, and velocity width.

--- a/pyspeckit/spectrum/models/tests/test_ammonia_radex.py
+++ b/pyspeckit/spectrum/models/tests/test_ammonia_radex.py
@@ -1,0 +1,206 @@
+"""
+Tests for the RADEX-grid ammonia model (ammonia_grids / ammonia_radex /
+ammonia_model_radex), using a synthetic analytic model grid.
+"""
+import itertools
+
+import numpy as np
+import pytest
+from astropy import units as u
+from astropy.table import Table
+
+from ...classes import Spectrum, units
+from ..ammonia import ammonia_radex, ammonia_model_radex
+from ..ammonia_grids import ammonia_grids, parbounds, TCMB
+
+LINE_IDS = ['11', '22', '33', '44', '55', '66']
+PARA_IDS = ['11', '22', '44', '55']
+ORTHO_IDS = ['33', '66']
+
+
+def tau_func(ii, logn, logT, logN, logs):
+    """Smooth analytic opacity as a function of the (log) grid parameters"""
+    return (0.1 * (logN - 12) + 0.01 * logn + 0.002 * ii
+            - 0.02 * logs + 0.005 * logT)
+
+
+def tex_func(ii, logn, logT, logN, logs):
+    """Smooth analytic Tex as a function of the (log) grid parameters"""
+    return (5.0 + (logN - 13) + 0.1 * logn + 0.05 * ii
+            + 0.3 * logT + 0.1 * logs)
+
+
+@pytest.fixture(scope='module')
+def gridfile(tmp_path_factory):
+    """
+    Build a synthetic RADEX grid file: the first 12 columns are the model
+    outputs (tau_11...tau_66, Tex_11...Tex_66); the last four columns are
+    the model parameters (nH2, Temperature, Column, sigmav), as expected by
+    ammonia_grids.
+    """
+    nh2 = np.logspace(3, 6, 4)
+    temperature = np.array([5., 10., 20., 40.])
+    column = np.logspace(13, 15, 5)
+    sigmav = np.logspace(-1, 0.5, 4)
+
+    prod = np.array(list(itertools.product(nh2, temperature, column, sigmav)))
+    nn, TT, NN, ss = prod.T
+    logn, logT, logN, logs = np.log10(nn), np.log10(TT), np.log10(NN), np.log10(ss)
+
+    names = (['tau_' + lid for lid in LINE_IDS] +
+             ['Tex_' + lid for lid in LINE_IDS] +
+             ['nH2', 'Temperature', 'Column', 'sigmav'])
+    columns = ([tau_func(ii + 1, logn, logT, logN, logs)
+                for ii in range(len(LINE_IDS))] +
+               [tex_func(ii + 1, logn, logT, logN, logs)
+                for ii in range(len(LINE_IDS))] +
+               [nn, TT, NN, ss])
+
+    tbl = Table(columns, names=names)
+    fn = str(tmp_path_factory.mktemp('radexgrid') / 'grid.fits')
+    tbl.write(fn)
+    return fn
+
+
+@pytest.fixture(scope='module')
+def sampler(gridfile):
+    samp = ammonia_grids(gridfile=gridfile)
+    assert samp is not None
+    return samp
+
+
+def test_sampler_exact_at_gridpoint(sampler):
+    """
+    Order-1 interpolation must be exact at grid nodes.
+    """
+    logdens, tkin, ntot, sigma = 4.0, 10.0, 14.0, 1.0
+    out = sampler(logdens=logdens, tkin=tkin, ntot=ntot, fortho=0.0,
+                  sigma=sigma, scaling_method='none')
+
+    logn, logT, logN, logs = logdens, np.log10(tkin), ntot, np.log10(sigma)
+    for jj, lid in enumerate(PARA_IDS):
+        ii = LINE_IDS.index(lid) + 1
+        np.testing.assert_allclose(out['tau_' + lid],
+                                   tau_func(ii, logn, logT, logN, logs),
+                                   rtol=1e-6)
+        np.testing.assert_allclose(out['Tex_' + lid],
+                                   tex_func(ii, logn, logT, logN, logs),
+                                   rtol=1e-6)
+    # fortho = 0: ortho lines have no emission
+    for lid in ORTHO_IDS:
+        assert out['tau_' + lid] == 0.0
+        assert out['Tex_' + lid] == TCMB
+
+
+def test_fortho_invariance_para(sampler):
+    """
+    The para-line outputs must depend only on the para column
+    N_para = 10**ntot * (1 - fortho), independent of fortho.
+    (regression test for the fortho bug reported in PR #332)
+    """
+    N_para = 10**13.8
+    reference = None
+    for fortho in (0.1, 0.5, 0.9):
+        ntot = np.log10(N_para / (1 - fortho))
+        out = sampler(logdens=4.2, tkin=13., ntot=ntot, fortho=fortho,
+                      sigma=0.7, scaling_method='none')
+        vals = np.array([out[key] for key in
+                         ('tau_11', 'tau_22', 'Tex_11', 'Tex_22')])
+        assert np.all(np.isfinite(vals))
+        if reference is None:
+            reference = vals
+        else:
+            np.testing.assert_allclose(vals, reference, rtol=1e-6)
+
+
+def test_fortho_invariance_ortho(sampler):
+    """
+    Same as above for the ortho lines: they must depend only on
+    N_ortho = 10**ntot * fortho.
+    """
+    N_ortho = 10**13.8
+    reference = None
+    for fortho in (0.1, 0.5, 0.9):
+        ntot = np.log10(N_ortho / fortho)
+        out = sampler(logdens=4.2, tkin=13., ntot=ntot, fortho=fortho,
+                      sigma=0.7, scaling_method='none')
+        vals = np.array([out[key] for key in
+                         ('tau_33', 'tau_66', 'Tex_33', 'Tex_66')])
+        assert np.all(np.isfinite(vals))
+        if reference is None:
+            reference = vals
+        else:
+            np.testing.assert_allclose(vals, reference, rtol=1e-6)
+
+
+def test_fortho_edge_robustness(sampler):
+    """
+    Very small (but nonzero) fortho puts the ortho column far below the
+    grid; the sampler must return finite values with tau=0 for the ortho
+    lines rather than NaN.  fortho=0 and fortho=1 must also return
+    all-finite dictionaries.
+    """
+    out = sampler(logdens=4.0, tkin=10., ntot=14., fortho=1e-8,
+                  sigma=1.0, scaling_method='none')
+    assert all(np.isfinite(v) for v in out.values())
+    for lid in ORTHO_IDS:
+        assert out['tau_' + lid] == 0.0
+        assert out['Tex_' + lid] == TCMB
+    # para lines unaffected by the tiny ortho fraction
+    for lid in PARA_IDS:
+        assert out['tau_' + lid] > 0
+
+    for fortho in (0.0, 1.0):
+        out = sampler(logdens=4.0, tkin=10., ntot=14., fortho=fortho,
+                      sigma=1.0, scaling_method='none')
+        assert all(np.isfinite(v) for v in out.values())
+        # Tex of the skipped species must be finite and nonzero to avoid
+        # division-by-zero in the radiative transfer
+        skipped = ORTHO_IDS if fortho == 0 else PARA_IDS
+        for lid in skipped:
+            assert out['tau_' + lid] == 0.0
+            assert out['Tex_' + lid] == TCMB
+
+
+def test_parbounds(gridfile):
+    bounds = parbounds(gridfile)
+    np.testing.assert_allclose(bounds['logdens'], [3, 6])
+    np.testing.assert_allclose(bounds['tkin'], [5, 40])
+    np.testing.assert_allclose(bounds['ntot'], [13, 15])
+    np.testing.assert_allclose(bounds['sigmav'], [0.1, 10**0.5])
+
+
+def test_radex_model_fit(gridfile, sampler):
+    """
+    End-to-end: synthesize a spectrum from the grid model, add noise, fit
+    it with ammonia_model_radex, and check that the fitted model reproduces
+    the noiseless input.  (Parameter recovery can be degenerate, so we
+    assert on the model spectrum, not the parameters.)
+    """
+    np.random.seed(42)
+
+    # cover the NH3 (1,1) and (2,2) lines at 23.6944955 & 23.7226336 GHz
+    xarr = np.linspace(23.68, 23.73, 2000) * u.GHz
+
+    truepars = dict(tkin=15., ntot=14.2, logdens=4.5, width=0.6,
+                    xoff_v=0.0, fortho=0.0)
+    noiseless = ammonia_radex(units.SpectroscopicAxis(xarr),
+                              interpolator=sampler, **truepars)
+    assert noiseless.max() > 0.5  # sanity check: there are real lines here
+
+    stddev = 0.01
+    noise = np.random.randn(xarr.size) * stddev
+
+    sp = Spectrum(xarr=xarr, data=noiseless + noise,
+                  error=np.ones(xarr.size) * stddev)
+
+    mod = ammonia_model_radex(gridfile=gridfile)
+    sp.Registry.add_fitter('ammonia_radex', mod, 6)
+
+    sp.specfit(fittype='ammonia_radex',
+               guesses=[12., 14.0, 4.0, 0.4, 0.05, 0.0],
+               fixed=[False, False, False, False, False, True])
+
+    # the fitted model must reproduce the noiseless input spectrum
+    np.testing.assert_allclose(sp.specfit.model, noiseless,
+                               atol=5 * stddev)


### PR DESCRIPTION
Supersedes and closes #332.

## Summary

A port of @low-sky's RADEX-grid NH3 fitting onto current master (the 2020 branch had drifted too far to rebase; his authorship is preserved via Co-authored-by). Adds:

- `ammonia_grids.py`: `ammonia_grids(gridfile)` builds an interpolating sampler over a RADEX grid table (axes nH2 / Temperature / Column / sigmav; outputs tau/Tex per line), plus `parbounds()` for grid-derived fit limits and the linewidth `line_scaling_function`.
- `ammonia.py`: `tau` may now be a dict of per-line optical depths (complementing the tex-as-dict support already on master); new `ammonia_radex()` model function; new `ammonia_model_radex` fitter class with parameters (tkin, ntot, logdens, width, xoff_v, fortho) and grid-derived parameter bounds.
- `hyperfine.py`: kwargs tolerance on `hyperfine`/`hyperfine_amp` (needed by the dict-tex path).

## The fortho bug from the review thread

@SpandanCh reported unphysical `fortho ≈ 1e-8` fits and para-line predictions changing when only fortho changed at fixed para column. Root cause found: the sampler's interpolation coordinates come from `interp1d(..., bounds_error=False)`, which returns **NaN when a species column falls off the grid** — exactly what happens to the ortho-column coordinate `ntot + log10(fortho)` for small fortho — and NaN coordinates passed to `map_coordinates` are undefined behavior. Additionally, at fortho exactly 0/1 the skipped species' rows were interpolated with stale zero coordinates (sampling a grid corner) and the post-hoc override set Tex=0, which divides by zero in `exp(T0/Tex)`.

Fixed: rows are only interpolated when their coordinates are assigned and finite; out-of-grid or skipped species get **tau=0, Tex=T_CMB** (with tau=0 the `(1−exp(−τ))` factor zeroes the line regardless of Tex). The fortho-invariance property from the review thread is now a regression test: para-line outputs are identical (rtol 1e-6) across fortho ∈ {0.1, 0.5, 0.9} at fixed para column, and likewise for ortho lines.

Other deviations from the original branch: `gridfile`/`scaling_method` are not forwarded into `modelfunc_kwargs` (they would have been passed into every model evaluation and crashed); `ammonia_radex` forwards `fortho`; `scipy.ndimage.interpolation` → `scipy.ndimage`; stray `import pdb` and a bare `except:` removed.

## Validation

- 6 new tests (`test_ammonia_radex.py`) using a synthetic analytic grid: sampler node-exactness, para & ortho fortho-invariance, edge robustness (fortho ∈ {0, 1e-8, 1} all finite, tau_33 = 0 not NaN), `parbounds`, and an end-to-end `Registry` fit whose fitted model reproduces the noiseless input to 0.006 K against 0.01 K noise.
- Full suite: **2258 passed**, 3 xfailed, 31 xpassed on both Python 3.10 / numpy 1.26 and Python 3.12 / numpy 2.5 / astropy 7.2 (+6 tests; the extra xpass is the parametrized `test_moments` picking up the new module).

Note: no default grid file ships with pyspeckit (`default_filename = None`); the model requires a user-supplied grid, as in the original PR. Heads-up: this touches the same `ammonia.py` regions as #426, so whichever merges second will need a trivial rebase.

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv
