### PR TITLE
Use np.char.find in lte_molecule tag-match branch (np.core regression from #425)

### DIFF
--- a/pyspeckit/spectrum/models/lte_molecule.py
+++ b/pyspeckit/spectrum/models/lte_molecule.py
@@ -276,7 +276,7 @@ def get_molecular_parameters(molecule_name, tex=50, fmin=1*u.GHz, fmax=1*u.THz,
             match = speciestab[molcol] == molecule_name
             if match.sum() == 0:
                 # retry using partial string matching
-                match = np.core.defchararray.find(speciestab[molcol], molecule_name) != -1
+                match = np.char.find(speciestab[molcol], molecule_name) != -1
         molecule_name = jpltbl['name']
 
         if match.sum() != 1:


### PR DESCRIPTION
One-liner: #425 added a tag-match branch to `get_molecular_parameters` that reused the pre-#422 `np.core.defchararray.find` spelling; `np.core` was privatized in numpy 2.0. Same replacement as #422. Models test suite green under numpy 2.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv