### PR TITLE
Fix moment-plane indices in fit_nh3_cube example (fixes #344)

### DIFF
--- a/examples/fit_nh3_cube.py
+++ b/examples/fit_nh3_cube.py
@@ -105,8 +105,9 @@ else:
     guesses[0,:,:] = 20                    # Kinetic temperature
     guesses[1,:,:] = 5                     # Excitation  Temp
     guesses[2,:,:] = 14.5                  # log(column)
-    guesses[3,:,:] = momentcube[3,:,:] / 5 # Line width / 5 (the NH3 moment overestimates linewidth)
-    guesses[4,:,:] = momentcube[2,:,:]     # Line centroid
+    # momenteach produces a 3-plane cube: [amplitude, centroid, width]
+    guesses[3,:,:] = momentcube[2,:,:] / 5 # Line width / 5 (the NH3 moment overestimates linewidth)
+    guesses[4,:,:] = momentcube[1,:,:]     # Line centroid
     guesses[5,:,:] = 0.5                   # F(ortho) - ortho NH3 fraction (fixed)
 
     guesscube = pyfits.PrimaryHDU(data=guesses, header=cube11.header)


### PR DESCRIPTION
`Cube.momenteach()` produces a 3-plane momentcube `[amplitude, centroid, width]`, but `examples/fit_nh3_cube.py` indexed planes 3 (IndexError — the crash reported in #344) and 2 (which would seed the centroid guess with the width map). Adjusted to planes 2 and 1 with a clarifying comment.

Fixes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv