### PR TITLE
Add pyproject.toml build-system declaration; add scipy/matplotlib to install_requires (fixes #378, #19)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61", "setuptools_scm", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,8 @@ setup_requires =
 install_requires =
     astropy
     numpy>=1.8.0
+    scipy
+    matplotlib
     radio_beam>=0.3.3
     six
     dask[array]


### PR DESCRIPTION
## Summary

- **#378**: `pip install pyspeckit` fails on pip ≥ 23.1 because no `pyproject.toml` declares the build system, so pip's legacy PEP-517 fallback builds in an isolated env without `setuptools_scm` (declared only via the deprecated `setup_requires` path). Added a minimal 3-line `pyproject.toml`; all metadata stays in `setup.cfg`.
- **#19**: added `scipy` and `matplotlib` to `install_requires`. matplotlib is imported unconditionally at `import pyspeckit` time (plotters/fitters/baseline/model/mapplot); scipy is required by core documented functionality (voigt profile, baseline splines, model-grid interpolation, ammonia_grids).

## Validation

Fresh venv with pip 26.1.2: `pip install <repo>` succeeds (previously failed), pulls scipy/matplotlib, and `import pyspeckit` works; `python -m build --sdist --wheel` succeeds. Test suite unaffected (2216 passed in spectrum/tests).

Fixes #378
Fixes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv