### PR TITLE
Keep declared refX_unit when refX is unset (fixes #63)

### DIFF
--- a/pyspeckit/spectrum/tests/test_units.py
+++ b/pyspeckit/spectrum/tests/test_units.py
@@ -234,6 +234,73 @@ class TestUnits(object):
         np.testing.assert_almost_equal(xarr2.cdelt().value, dx.value)
         assert len(xarr2) == len(xarr2.dxarr)
 
+    def test_refX_quantity_updates_refX_unit(self):
+        # regression test for issue 63: setting refX to a Quantity after
+        # initialization must synchronize refX_unit
+        xarr = SpectroscopicAxis(np.linspace(-100, 100, 100), unit='Hz')
+        xarr.refX = 4 * u.GHz
+        assert xarr.refX == 4 * u.GHz
+        assert u.Unit(xarr.refX_unit) == u.GHz
+
+        # and the new refX must actually be used for velocity conversion
+        xarr = SpectroscopicAxis(np.linspace(4e9 - 1e6, 4e9 + 1e6, 101),
+                                 unit='Hz')
+        xarr.refX = 4 * u.GHz
+        varr = xarr.as_unit('km/s', velocity_convention='radio')
+        np.testing.assert_almost_equal(varr[50].value, 0.0)
+
+    def test_refX_plain_float_keeps_refX_unit(self):
+        # issue 63: assigning a bare number to refX should be interpreted
+        # in the pre-existing refX_unit
+        xarr = SpectroscopicAxis(np.linspace(-100, 100, 100), unit='km/s',
+                                 refX=4.8, refX_unit='GHz',
+                                 velocity_convention='radio')
+        xarr.refX = 4.9
+        assert xarr.refX == 4.9 * u.GHz
+        assert u.Unit(xarr.refX_unit) == u.GHz
+
+        # a declared refX_unit must survive even if refX was not set at
+        # construction time (it used to be silently discarded)
+        xarr = SpectroscopicAxis(np.linspace(-100, 100, 100), unit='km/s',
+                                 refX_unit='GHz')
+        xarr.refX = 4.829
+        assert xarr.refX == 4.829 * u.GHz
+
+        # with no explicit refX_unit, a frequency axis defaults refX_unit
+        # to the axis unit, so a bare-number refX is interpretable
+        xarr = SpectroscopicAxis(np.linspace(4e9 - 1e6, 4e9 + 1e6, 101),
+                                 unit='Hz')
+        xarr.refX = 4e9
+        assert xarr.refX == 4e9 * u.Hz
+        varr = xarr.as_unit('km/s', velocity_convention='radio')
+        np.testing.assert_almost_equal(varr[50].value, 0.0)
+
+    def test_refX_construction_paths_unchanged(self):
+        # Quantity refX at construction
+        xarr = SpectroscopicAxis(np.linspace(-100, 100, 100), unit='km/s',
+                                 refX=4.829 * u.GHz,
+                                 velocity_convention='radio')
+        assert xarr.refX == 4.829 * u.GHz
+        assert u.Unit(xarr.refX_unit) == u.GHz
+
+        # float refX + string refX_unit at construction
+        xarr = SpectroscopicAxis(np.linspace(-100, 100, 100), unit='km/s',
+                                 refX=4.829, refX_unit='GHz',
+                                 velocity_convention='radio')
+        assert xarr.refX == 4.829 * u.GHz
+        assert u.Unit(xarr.refX_unit) == u.GHz
+
+        # refX/refX_unit survive slicing and copying
+        for xarr2 in (xarr[10:20], xarr.copy()):
+            assert xarr2.refX == 4.829 * u.GHz
+            assert u.Unit(xarr2.refX_unit) == u.GHz
+
+        # the documented set-refX-then-refX_unit pattern still works
+        xarr = SpectroscopicAxis(np.linspace(-100, 100, 100), unit='Hz')
+        xarr.refX = 5.0
+        xarr.refX_unit = 'GHz'
+        assert xarr.refX == 5.0 * u.GHz
+
 
 
 

--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -452,14 +452,25 @@ class SpectroscopicAxis(u.Quantity):
 
     @property
     def refX_unit(self):
+        # refX is stored as a Quantity, so its unit is authoritative
+        # (this keeps refX_unit synchronized when refX is assigned a
+        # Quantity after initialization; see issue 63)
         if hasattr(self.refX, 'unit'):
             return self.refX.unit
+        # if refX has not been set yet, fall back to the declared unit so
+        # that a later bare-number assignment to refX (e.g., ``xarr.refX =
+        # 5.0``) can be interpreted in that unit
+        return getattr(self, '_refX_unit', None)
 
     @refX_unit.setter
     def refX_unit(self, value):
-        if value is None or self.refX is None:
+        if value is None:
             return
-        if hasattr(self.refX, 'unit'):
+        if self.refX is None:
+            # remember the declared unit for later bare-number assignments
+            # to refX (previously this was silently discarded; issue 63)
+            self._refX_unit = value
+        elif hasattr(self.refX, 'unit'):
             self.refX = u.Quantity(self.refX.value, value)
         else:
             self.refX = u.Quantity(self.refX, value)


### PR DESCRIPTION
## Summary

The headline scenario from #63 (`sp.refX = 4*u.GHz` leaving `refX_unit` stale) was already fixed when refX/refX_unit became properties, but the issue was never closed — and verifying it exposed a residual bug in the same machinery: the `refX_unit` setter **silently discarded** the value whenever `refX` was still None. That lost the default computed in `__new__` and any `refX_unit=` constructor kwarg passed without `refX`, so a later bare-number assignment (`sp.refX = 4e9` on an Hz axis — the pattern the `convert_to_unit` docstrings advertise) produced a **dimensionless** refX and `as_unit('km/s', velocity_convention='radio')` crashed with `UnitsError: The 'rest' value must be a spectral equivalent`.

Fix (~13 lines): while `refX` is unset, the declared unit is stored in `_refX_unit` and the getter falls back to it; once `refX` is a Quantity its own unit stays authoritative, exactly as before. Fully backward compatible (the set-refX-then-refX_unit relabeling pattern still works; slicing/copy/`as_unit` propagation unchanged).

## Tests

3 new tests in `test_units.py`: the issue scenario including velocity-centering at exactly 0 km/s; the formerly-crashing bare-float paths; construction/slicing/relabeling invariants. Full suite: **2267 passed**, 3 xfailed, 33 xpassed on both numpy 1.26 and numpy 2.5 / astropy 7.2.

Fixes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv