### PR TITLE
Fix key_press AttributeError with matplotlib >= 3.8 in interactive mode (fixes #414)

### DIFF
--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -14,34 +14,6 @@ import copy
 import inspect
 from astropy import log
 
-# this mess is to handle a nested hell of different versions of matplotlib
-# (>=1.3 has BoundMethodProxy somewhere, >=3 gets rid of it) and python
-# (python >=3.4 has WeakMethod, earlier versions don't)
-try:
-    from matplotlib.cbook import BoundMethodProxy
-except ImportError:
-    try:
-        from matplotlib.cbook import _BoundMethodProxy as BoundMethodProxy
-    except ImportError:
-        try:
-            from matplotlib.cbook import WeakMethod
-        except ImportError:
-            try:
-                from weakref import WeakMethod
-            except ImportError:
-                try:
-                    from weakrefmethod import WeakMethod
-                except ImportError:
-                    raise ImportError("Could not import WeakMethod from "
-                                      "anywhere.  Try installing the "
-                                      "weakrefmethod package or use a more "
-                                      "recent version of python or matplotlib")
-
-        class BoundMethodProxy(WeakMethod):
-            @property
-            def func(self):
-                return self()
-
 from . import widgets
 from ..specwarnings import warn
 
@@ -149,37 +121,50 @@ class Plotter(object):
 
     def _disconnect_matplotlib_keys(self):
         """
-        Disconnected the matplotlib key-press callbacks
+        Disconnect matplotlib's built-in key-press handler (the one that
+        implements the default 'k', 'l', 'g', 's', ... shortcuts) so it does
+        not conflict with pyspeckit's interactive keys while an interactive
+        session is active.  The handler is restored by
+        `_reconnect_matplotlib_keys`.
         """
-        if self.figure is not None:
-            cbs = self.figure.canvas.callbacks.callbacks
-            # this may cause problems since the dict of key press events is a
-            # dict, i.e. not ordered, and we want to pop the first one...
-            mpl_keypress_handler = self.figure.canvas.manager.key_press_handler_id
-            try:
-                self._mpl_key_callbacks = {mpl_keypress_handler:
-                                           cbs['key_press_event'].pop(mpl_keypress_handler)}
-            except KeyError:
-                bmp = BoundMethodProxy(self.figure.canvas.manager.key_press)
-                self._mpl_key_callbacks = {mpl_keypress_handler:
-                                           bmp}
+        if self.figure is None:
+            return
+        canvas = self.figure.canvas
+        manager = getattr(canvas, 'manager', None)
+        handler_id = getattr(manager, 'key_press_handler_id', None)
+        if handler_id is not None:
+            # mpl_disconnect is a no-op if the callback id is stale, so this
+            # is safe even if something else already disconnected it
+            canvas.mpl_disconnect(handler_id)
+            manager.key_press_handler_id = None
+            self._mpl_keys_disconnected = True
 
     def _reconnect_matplotlib_keys(self):
         """
-        Reconnect the previously disconnected matplotlib keys
+        Reconnect the default matplotlib key-press handler that was
+        disconnected by `_disconnect_matplotlib_keys`.
         """
-        if self.figure is not None and hasattr(self,'_mpl_key_callbacks'):
-            self.figure.canvas.callbacks.callbacks['key_press_event'].update(self._mpl_key_callbacks)
-        elif self.figure is not None:
-            mpl_keypress_handler = self.figure.canvas.manager.key_press_handler_id
-            try:
-                bmp = BoundMethodProxy(self.figure.canvas.manager.key_press)
-                self.figure.canvas.callbacks.callbacks['key_press_event'].update({mpl_keypress_handler:
-                                                                                  bmp})
-            except AttributeError as ex:
-                print(f"Error {ex} was raised when trying to connect the key_press handler.  "
-                      "Please file an issue on github.  You may try a different matplotlib backend "
-                      "as a temporary workaround")
+        if self.figure is None or not getattr(self, '_mpl_keys_disconnected',
+                                              False):
+            return
+        canvas = self.figure.canvas
+        manager = getattr(canvas, 'manager', None)
+        if manager is None:
+            return
+        if manager.key_press_handler_id is None:
+            if hasattr(manager, 'key_press'):
+                # matplotlib < 3.8: the default handler is the manager's
+                # (bound) key_press method
+                callback = manager.key_press
+            else:
+                # matplotlib >= 3.8 removed FigureManagerBase.key_press; the
+                # default handler is the key_press_handler function, which
+                # pulls the canvas from the event
+                from matplotlib.backend_bases import key_press_handler
+                callback = key_press_handler
+            manager.key_press_handler_id = canvas.mpl_connect(
+                'key_press_event', callback)
+        self._mpl_keys_disconnected = False
 
     def __call__(self, figure=None, axis=None, clear=True, autorefresh=None,
                  plotscale=1.0, override_plotkwargs=False, **kwargs):

--- a/pyspeckit/spectrum/tests/test_interactive_keys.py
+++ b/pyspeckit/spectrum/tests/test_interactive_keys.py
@@ -1,0 +1,87 @@
+"""
+Regression tests for issue #414: on matplotlib >= 3.8,
+``FigureManagerBase.key_press`` no longer exists, so starting an interactive
+fitting session printed
+
+    Error '...' object has no attribute 'key_press' was raised when trying to
+    connect the key_press handler.  Please file an issue on github. ...
+
+and matplotlib's built-in key-press handler was never actually disconnected.
+"""
+import warnings
+
+import numpy as np
+
+from .. import Spectrum
+
+
+def _make_spectrum():
+    x = np.linspace(-50, 50, 101)
+    y = np.exp(-x**2 / (2 * 5.0**2))
+    with warnings.catch_warnings():
+        # ignore warning about creating an empty header
+        warnings.simplefilter('ignore')
+        return Spectrum(xarr=x, data=y, xarrkwargs={'unit': 'km/s'})
+
+
+def test_interactive_session_no_keypress_error(capsys):
+    """
+    Starting and ending an interactive fit session must not emit the
+    "Please file an issue on github" key_press error, and must
+    disconnect/restore matplotlib's default key handler.
+    """
+    sp = _make_spectrum()
+    sp.plotter()
+
+    manager = sp.plotter.figure.canvas.manager
+    original_handler_id = getattr(manager, 'key_press_handler_id', None)
+
+    sp.specfit(interactive=True)
+
+    if original_handler_id is not None:
+        # matplotlib's default key handler must be disconnected while the
+        # interactive session is active, so that its keybindings ('g', 'l',
+        # 'k', ...) do not conflict with pyspeckit's
+        assert manager.key_press_handler_id is None
+
+    # end the interactive session (equivalent to pressing 'd' = done)
+    sp.specfit.clear_all_connections()
+
+    if original_handler_id is not None:
+        # the default handler must be restored afterwards
+        assert manager.key_press_handler_id is not None
+
+    out, err = capsys.readouterr()
+    combined = out + err
+    assert 'Please file an issue on github' not in combined
+    assert 'was raised when trying to connect the key_press handler' not in combined
+
+    # plotting and fitting must still work after the interactive session
+    sp.plotter()
+    sp.specfit(fittype='gaussian', guesses=[1, 0, 5])
+    np.testing.assert_allclose(sp.specfit.parinfo.values, [1, 0, 5], atol=1e-3)
+
+
+def test_disconnect_reconnect_idempotent():
+    """
+    The disconnect/reconnect helpers must be safe to call repeatedly and in
+    either order (e.g. clear_all_connections calls reconnect before any
+    disconnect has ever happened).
+    """
+    sp = _make_spectrum()
+    sp.plotter()
+
+    manager = sp.plotter.figure.canvas.manager
+    original_handler_id = getattr(manager, 'key_press_handler_id', None)
+
+    # reconnect with nothing disconnected: no-op, no error
+    sp.plotter._reconnect_matplotlib_keys()
+    assert getattr(manager, 'key_press_handler_id', None) == original_handler_id
+
+    sp.plotter._disconnect_matplotlib_keys()
+    sp.plotter._disconnect_matplotlib_keys()
+    sp.plotter._reconnect_matplotlib_keys()
+    sp.plotter._reconnect_matplotlib_keys()
+
+    if original_handler_id is not None:
+        assert manager.key_press_handler_id is not None


### PR DESCRIPTION
## Summary

matplotlib 3.8 removed `FigureManagerBase.key_press`, which `Plotter._disconnect_matplotlib_keys`/`_reconnect_matplotlib_keys` referenced — so every `specfit(interactive=True)` session printed `Error 'FigureManagerTk' object has no attribute 'key_press' ... Please file an issue on github`, and matplotlib's default key handler was never actually disconnected (its shortcuts conflicted with pyspeckit's interactive keys).

Rewritten using the public API: disconnect via `canvas.mpl_disconnect(manager.key_press_handler_id)`; reconnect via `manager.key_press` on mpl < 3.8 or `matplotlib.backend_bases.key_press_handler` on >= 3.8; reconnect is now a no-op unless a disconnect actually happened (the premature-reconnect path was the crash trigger). The 25-line `BoundMethodProxy` import-fallback maze is gone.

## Validation

- Before: repro prints the reported error on both Agg and TkAgg (mpl 3.10.8). After: clean on both; `key_press_handler_id` is None during the session and a fresh cid after; fitting still works afterwards.
- 2 new regression tests (`test_interactive_keys.py`) fail on unpatched master, pass with the fix.
- spectrum test suite: **2218 passed** on numpy 1.26 and numpy 2.5 envs.

Fixes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv