### PR TITLE
Replace removed ArtistList mutation APIs across plotting code (fixes #397)

### DIFF
--- a/pyspeckit/cubes/mapplot.py
+++ b/pyspeckit/cubes/mapplot.py
@@ -345,10 +345,13 @@ class MapPlotter(object):
                 if mark in self.FITSFigure._layers:
                     self.FITSFigure.remove_layer(mark)
         else:
-            for mark in self._click_marks:
+            # iterate over a copy since we mutate _click_marks in the loop
+            for mark in self._click_marks[:]:
                 self._click_marks.remove(mark)
-                if mark in self.axis.lines:
-                    self.axis.lines.remove(mark)
+                # axis.plot returns a list of Line2D objects
+                for line in (mark if isinstance(mark, list) else [mark]):
+                    if line in self.axis.lines:
+                        line.remove()
             self.refresh()
 
     def _add_circle(self,x,y,x2,y2,**kwargs):
@@ -366,7 +369,7 @@ class MapPlotter(object):
             r = np.linalg.norm(np.array([x,y])-np.array([x2,y2]))
             circle = matplotlib.patches.Circle([x,y],radius=r,**kwargs)
             self._circles.append( circle )
-            self.axis.patches.append(circle)
+            self.axis.add_patch(circle)
             self.refresh()
 
     def _remove_circle(self):
@@ -377,9 +380,10 @@ class MapPlotter(object):
                 if layername in self.FITSFigure._layers:
                     self.FITSFigure.remove_layer(layername)
         else:
-            for circle in self._circles:
+            # iterate over a copy since we mutate _circles in the loop
+            for circle in self._circles[:]:
                 if circle in self.axis.patches:
-                    self.axis.patches.remove(circle)
+                    circle.remove()
                 self._circles.remove(circle)
             self.refresh()
 

--- a/pyspeckit/spectrum/baseline.py
+++ b/pyspeckit/spectrum/baseline.py
@@ -381,38 +381,24 @@ class Baseline(interactive.Interactive):
                           self.Spectrum.plotter.axis.viewLim))
 
         # clear out the errorplot.  This should not be relevant...
+        # (use Artist.remove() rather than mutating axis.lines/.collections;
+        # matplotlib >=3.7 makes those immutable ArtistList views)
         if self.Spectrum.plotter.errorplot is not None:
             for p in self.Spectrum.plotter.errorplot:
                 if isinstance(p,matplotlib.collections.PolyCollection):
                     if p in self.Spectrum.plotter.axis.collections:
-                        try:
-                            self.Spectrum.plotter.axis.lines.remove(p)
-                        except AttributeError:
-                            try:
-                                p.remove()
-                            except Exception as ex:
-                                pass
+                        p.remove()
                 if isinstance(p,matplotlib.lines.Line2D):
                     if p in self.Spectrum.plotter.axis.lines:
-                        try:
-                            self.Spectrum.plotter.axis.lines.remove(p)
-                        except AttributeError:
-                            try:
-                                p.remove()
-                            except Exception as ex:
-                                pass
+                        p.remove()
 
         # if we subtract the baseline, replot the now-subtracted data with rescaled Y axes
         if self.subtracted:
             if self.Spectrum.plotter.axis is not None:
-                for p in self.Spectrum.plotter.axis.lines:
-                    try:
-                        self.Spectrum.plotter.axis.lines.remove(p)
-                    except AttributeError:
-                        try:
-                            p.remove()
-                        except Exception as ex:
-                            pass
+                # iterate over a copy: removing while iterating over the live
+                # ArtistList view would skip elements
+                for p in list(self.Spectrum.plotter.axis.lines):
+                    p.remove()
             plotmask = self.OKmask*False # include nothing...
             plotmask[self.xmin:self.xmax] = self.OKmask[self.xmin:self.xmax] # then include everything OK in range
             self.Spectrum.plotter.ymin = abs(self.Spectrum.data[plotmask].min())*1.1*np.sign(self.Spectrum.data[plotmask].min())
@@ -425,13 +411,7 @@ class Baseline(interactive.Interactive):
             for p in self._plots:
                 # remove the old baseline plots
                 if p in self.Spectrum.plotter.axis.lines:
-                    try:
-                        self.Spectrum.plotter.axis.lines.remove(p)
-                    except AttributeError:
-                        try:
-                            p.remove()
-                        except Exception as ex:
-                            pass
+                    p.remove()
             self._plots += self.Spectrum.plotter.axis.plot(
                     self.Spectrum.xarr,
                     self.basespec,

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -1424,19 +1424,13 @@ class Specfit(interactive.Interactive):
         if hasattr(self,'residualplot'):
             for L in self.residualplot:
                 if L in self.Spectrum.plotter.axis.lines:
-                    if hasattr(self.Spectrum.plotter.axis.lines, 'remove'):
-                        self.Spectrum.plotter.axis.lines.remove(L)
-                    else:
-                        L.remove()
+                    L.remove()
 
     def _clearcomponents(self):
         for pc in self._plotted_components:
             pc.set_visible(False)
             if pc in self.Spectrum.plotter.axis.lines:
-                if hasattr(self.Spectrum.plotter.axis.lines, 'remove'):
-                    self.Spectrum.plotter.axis.lines.remove(pc)
-                else:
-                    pc.remove()
+                pc.remove()
         if self.Spectrum.plotter.autorefresh:
             self.Spectrum.plotter.refresh()
 

--- a/pyspeckit/spectrum/interactive.py
+++ b/pyspeckit/spectrum/interactive.py
@@ -391,10 +391,7 @@ class Interactive(object):
         for p in self.button1plot:
             p.set_visible(False)
             if self.Spectrum.plotter.axis and p in self.Spectrum.plotter.axis.lines:
-                if hasattr(self.Spectrum.plotter.axis.lines, 'remove'):
-                    self.Spectrum.plotter.axis.lines.remove(p)
-                else:
-                    p.remove()
+                p.remove()
         self.button1plot = [] # I should be able to just remove from the list... but it breaks the loop...
         self.Spectrum.plotter.refresh()
 

--- a/pyspeckit/spectrum/speclines/radio.py
+++ b/pyspeckit/spectrum/speclines/radio.py
@@ -151,14 +151,12 @@ class radio_lines(object):
         """
         for text in self._linenames:
             if text in self.Spectrum.plotter.axis.texts:
-                self.Spectrum.plotter.axis.texts.remove(text)
-        for text in self._linenames:
-            self._linenames.remove(text)
+                text.remove()
+        self._linenames = []
         for line in self._lines:
             if line in self.Spectrum.plotter.axis.collections:
-                self.Spectrum.plotter.axis.collections.remove(line)
-        for line in self._lines:
-            self._lines.remove(line)
+                line.remove()
+        self._lines = []
 
         if self.Spectrum.plotter.autorefresh:
             self.Spectrum.plotter.refresh()

--- a/pyspeckit/spectrum/tests/test_mpl_artist_removal.py
+++ b/pyspeckit/spectrum/tests/test_mpl_artist_removal.py
@@ -1,0 +1,194 @@
+"""
+Regression tests for issue #397.
+
+matplotlib >= 3.7 turned ``Axes.lines``, ``Axes.patches``,
+``Axes.collections``, and ``Axes.texts`` into immutable ``ArtistList``
+views: calling ``.remove(artist)`` or ``.append(artist)`` on them raises
+``AttributeError: 'ArtistList' object has no attribute 'remove'``.
+
+These tests exercise the plot-artist removal paths (clearing fits,
+re-fitting, baseline replotting, map click-marks/circles, line-ID
+overlays, slider widgets) headlessly with the Agg backend and check that
+the artists really are removed from the axes.
+"""
+import warnings
+
+import matplotlib
+matplotlib.use('Agg')
+
+import numpy as np
+
+from .. import Spectrum
+
+
+def make_gaussian_spectrum():
+    dx = 0.1
+    x = np.arange(-6, 6, dx)
+    y = np.exp(-x**2 / 2.) + 0.5
+    with warnings.catch_warnings():
+        # ignore warning about creating an empty header
+        warnings.simplefilter('ignore')
+        sp = Spectrum(xarr=x, data=y, error=np.full(x.size, 0.1))
+    return sp
+
+
+def test_specfit_clear_removes_lines():
+    """Specfit.clear() must not raise and must remove component lines."""
+    sp = make_gaussian_spectrum()
+    sp.plotter()
+    sp.specfit(fittype='gaussian', guesses=[1, 0, 1])
+    sp.specfit.plot_fit(show_components=True)
+    axis = sp.plotter.axis
+
+    assert len(sp.specfit._plotted_components) > 0
+    n_before = len(axis.lines)
+
+    sp.specfit.clear()
+
+    assert sp.specfit._plotted_components == []
+    assert len(axis.lines) < n_before
+
+
+def test_refit_after_plotted_fit():
+    """
+    Reporter's scenario in #397: fitting a second time clears the plotted
+    artifacts of the first fit and used to raise AttributeError.
+    """
+    sp = make_gaussian_spectrum()
+    sp.plotter()
+    sp.specfit(fittype='gaussian', guesses=[1, 0, 1])
+    sp.specfit(fittype='gaussian', guesses=[1, 0, 1])
+    # (the continuum offset biases the amplitude; we only care that the
+    # second fit completed without an AttributeError from artist removal)
+    assert np.isfinite(sp.specfit.parinfo[0].value)
+    assert abs(sp.specfit.parinfo[1].value) < 0.1
+
+
+def test_clear_highlights():
+    """Interactive.clear_highlights hits axis.lines removal."""
+    sp = make_gaussian_spectrum()
+    sp.plotter()
+    sp.specfit.selectregion(xmin=-3, xmax=3, highlight=True)
+    axis = sp.plotter.axis
+
+    assert len(sp.specfit.button1plot) > 0
+    n_before = len(axis.lines)
+
+    sp.specfit.clear_highlights()
+
+    assert sp.specfit.button1plot == []
+    assert len(axis.lines) < n_before
+
+
+def test_baseline_overplot_twice():
+    """
+    Baseline.plotbaseline with subtract=False removes the previously
+    plotted baseline lines on the second call.
+    """
+    sp = make_gaussian_spectrum()
+    sp.plotter()
+    sp.baseline(order=0, subtract=False)
+    old_plots = list(sp.baseline._plots)
+    assert len(old_plots) > 0
+
+    sp.baseline(order=0, subtract=False)
+
+    for p in old_plots:
+        assert p not in sp.plotter.axis.lines
+
+
+def test_baseline_subtract_replots():
+    """
+    Baseline with subtract=True clears every line from the axis before
+    replotting the subtracted spectrum.
+    """
+    sp = make_gaussian_spectrum()
+    # errstyle='fill' creates a PolyCollection errorplot, exercising the
+    # errorplot-clearing branch of plotbaseline as well
+    sp.plotter(errstyle='fill')
+    sp.baseline(order=0, subtract=True)
+
+    # the replotted (baseline-subtracted) spectrum must be there
+    assert len(sp.plotter.axis.lines) > 0
+
+
+def test_mapplot_click_marks_and_circles(tmp_path):
+    """MapPlotter click marks and circles: add and remove."""
+    from ...cubes.tests.test_cubetools import make_test_cube
+    from ...cubes import Cube
+
+    fname = str(tmp_path / 'test_mapplot.fits')
+    make_test_cube((30, 9, 9), outfile=fname)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        cube = Cube(fname)
+    cube.mapplot(useaplpy=False, colorbar=False)
+    mp = cube.mapplot
+
+    mp._add_click_mark(3, 3)
+    mp._add_click_mark(4, 4)
+    assert len(mp._click_marks) == 2
+    n_lines = len(mp.axis.lines)
+    assert n_lines >= 2
+
+    mp._clear_click_marks()
+    assert mp._click_marks == []
+    assert len(mp.axis.lines) == n_lines - 2
+
+    mp._add_circle(3, 3, 5, 5)
+    assert len(mp._circles) == 1
+    assert len(mp.axis.patches) == 1
+
+    mp._remove_circle()
+    assert mp._circles == []
+    assert len(mp.axis.patches) == 0
+
+
+def test_radio_lines_hide():
+    """radio_lines.hide removes texts and vline collections."""
+    from ..speclines.radio import radio_lines
+
+    sp = make_gaussian_spectrum()
+    sp.plotter()
+    axis = sp.plotter.axis
+
+    # __init__ needs a splatalogue table, so build the instance manually
+    # and populate it with real artists as show() would
+    rl = radio_lines.__new__(radio_lines)
+    rl.Spectrum = sp
+    rl._lines = [axis.vlines([0.0, 1.0], 0, 1)]
+    rl._linenames = [axis.text(0.0, 0.5, 'testline', rotation='vertical')]
+
+    n_texts = len(axis.texts)
+    n_collections = len(axis.collections)
+
+    rl.hide()
+
+    assert rl._lines == []
+    assert rl._linenames == []
+    assert len(axis.texts) == n_texts - 1
+    assert len(axis.collections) == n_collections - 1
+
+
+def test_modifiable_slider_valmin_valmax():
+    """ModifiableSlider.set_valmin/set_valmax replace the vline in place."""
+    import matplotlib.pyplot as plt
+    from ..widgets import ModifiableSlider
+
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+    slider = ModifiableSlider(ax, 'test', 0, 10, valinit=5)
+    assert slider.vline in slider.ax.lines
+    n_lines = len(slider.ax.lines)
+
+    # valinit (5) < new valmin (6): triggers removal & re-creation of vline
+    slider.set_valmin(6)
+    assert slider.vline in slider.ax.lines
+    assert len(slider.ax.lines) == n_lines
+
+    # valinit (now 8) > new valmax (7): triggers the set_valmax branch
+    slider.set_valmax(7)
+    assert slider.vline in slider.ax.lines
+    assert len(slider.ax.lines) == n_lines
+
+    plt.close(fig)

--- a/pyspeckit/spectrum/widgets.py
+++ b/pyspeckit/spectrum/widgets.py
@@ -61,10 +61,7 @@ class ModifiableSlider(Slider):
         if self.valinit < self.valmin:
             self.valinit = (self.valmax-self.valmin)/2. + self.valmin
             if self.vline in self.ax.lines:
-                if hasattr(self.ax.lines, 'remove'):
-                    self.ax.lines.remove(self.vline)
-                else:
-                    self.vline.remove()
+                self.vline.remove()
             self.vline = self.ax.axvline(self.valinit,0,1, color='r', lw=1)
 
     def set_valmax(self, valmax):
@@ -78,10 +75,7 @@ class ModifiableSlider(Slider):
         if self.valinit > self.valmax:
             self.valinit = (self.valmax-self.valmin)/2. + self.valmin
             if self.vline in self.ax.lines:
-                if hasattr(self.ax.lines, 'remove'):
-                    self.ax.lines.remove(self.vline)
-                else:
-                    self.vline.remove()
+                self.vline.remove()
             self.vline = self.ax.axvline(self.valinit,0,1, color='r', lw=1)
 
 class FitterSliders(Widget):


### PR DESCRIPTION
## Summary

matplotlib >= 3.7 made `Axes.lines/.patches/.collections/.texts` immutable `ArtistList` views, so `.remove(artist)`/`.append(artist)` raise `AttributeError: 'ArtistList' object has no attribute 'remove'` (#397). All 14 sites are converted to the modern `artist.remove()` / `axis.add_patch()` forms: `baseline.py` (4), `widgets.py` (2), `interactive.py`, `fitters.py` (2), `mapplot.py` (3), `speclines/radio.py` (2).

Latent bugs fixed along the way: baseline tried to remove a PolyCollection from `axis.lines` (the except-fallback was silently doing the real work); three loops mutated the list they iterated (skipping every other artist); mapplot's click marks stored the *list* returned by `axis.plot()`, so the membership check never matched and marks were never removed.

## Validation

- 8 new tests (`test_mpl_artist_removal.py`) exercising `Specfit.clear`, re-fit after plot (the reporter's scenario), `clear_highlights`, both baseline unplot branches, mapplot click marks/circles, `radio_lines.hide()`, and the slider vline paths — asserting artists are actually removed.
- Negative control: with the fix stashed, the mapplot and radio_lines tests fail with the exact reported `AttributeError`.
- spectrum+cubes suites: **2241 passed** on both numpy 1.26 (mpl 3.10.8) and numpy 2.5 (mpl 3.11) envs.

Fixes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv