### PR TITLE
Make EQW midpt_location='fitted' robust (fixes #96)

### DIFF
--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -474,14 +474,24 @@ class Specfit(interactive.Interactive):
                 midpt_pixel = int(np.round((xmin+xmax)/2.0))
                 midpt       = self.Spectrum.xarr[midpt_pixel].value
             elif midpt_location == 'fitted':
-                try:
-                    shifts = np.array([self.Spectrum.specfit.parinfo[x].value
-                                       for x in self.Spectrum.specfit.parinfo.keys()
-                                       if 'SHIFT' in x])
-                except AttributeError:
+                if self.parinfo is None:
                     raise AttributeError("Can only specify midpt_location="
-                                         "fitted if there is a SHIFT parameter"
-                                         "for the fitted model")
+                                         "'fitted' after a fit has been "
+                                         "performed")
+                # the fitted line center is the SHIFT parameter (e.g., the
+                # gaussian fitter's parameters are AMPLITUDE0, SHIFT0, WIDTH0)
+                shifts = np.array([self.parinfo[x].value
+                                   for x in self.parinfo.keys()
+                                   if 'SHIFT' in x.upper()])
+                if shifts.size == 0 and getattr(self.fitter, 'centroid_par', None):
+                    # some models declare a centroid parameter with a
+                    # different name (e.g., XOFF_V)
+                    shifts = np.array(self.fitter.analytic_centroids())
+                if shifts.size == 0:
+                    raise AttributeError("Can only specify midpt_location="
+                                         "'fitted' if there is a SHIFT "
+                                         "parameter (or a declared centroid "
+                                         "parameter) for the fitted model")
                 # We choose to display the eqw fit at the center of the fitted
                 # line set, closest to the passed window.
                 # Note that this has the potential to show a eqw "rectangle"

--- a/pyspeckit/spectrum/tests/test_eqw.py
+++ b/pyspeckit/spectrum/tests/test_eqw.py
@@ -1,6 +1,8 @@
 import numpy as np
 import warnings
 
+import pytest
+
 from pyspeckit.spectrum import Spectrum
 
 
@@ -41,3 +43,55 @@ def test_eqw_plot():
     np.testing.assert_almost_equal(eqw_cont, (1-y).sum() * dx, decimal=5)
     np.testing.assert_almost_equal(eqw_nofit, (1-y).sum() * dx, decimal=4)
     return sp
+
+def test_eqw_fitted_midpt():
+    # Regression test for issue #96: EQW(plot=True, midpt_location='fitted')
+    # used to crash (undefined variable `sp` and unset midpt_pixel)
+    dx = 0.1
+    x = np.arange(-6,6,dx)
+    y = 1-np.exp(-x**2 / 2.)
+    with warnings.catch_warnings():
+        # ignore warning about creating an empty header
+        warnings.simplefilter('ignore')
+        sp = Spectrum(xarr=x, data=y)
+    sp.plotter()
+    sp.baseline(exclude=[-5,5], order=0, subtract=False)
+    sp.specfit(fittype='gaussian', guesses=(-1, 0, 0.5))
+    eqw_default = sp.specfit.EQW()
+    eqw_fitted = sp.specfit.EQW(plot=True, midpt_location='fitted')
+    assert np.isfinite(eqw_fitted)
+    # midpt_location only affects where the EQW box is drawn, not the value
+    np.testing.assert_almost_equal(eqw_fitted, eqw_default, decimal=6)
+    np.testing.assert_almost_equal(eqw_fitted, (1-y).sum() * dx, decimal=5)
+    # the plotted EQW rectangle should be centered on the fitted line center
+    verts = sp.specfit.EQW_plots[-1].get_paths()[0].vertices
+    box_center = (verts[:,0].min() + verts[:,0].max()) / 2.
+    np.testing.assert_almost_equal(box_center,
+                                   sp.specfit.parinfo['SHIFT0'].value,
+                                   decimal=6)
+    return sp
+
+def test_eqw_fitted_midpt_no_shift_param():
+    # Regression test for issue #96: a model without any SHIFT parameter
+    # should raise an informative AttributeError, not an obscure ValueError
+    from pyspeckit.spectrum.models import model
+
+    def offset_gaussian(x, amp, xoff_v, width):
+        return amp * np.exp(-(x - xoff_v)**2 / (2. * width**2))
+
+    fitter = model.SpectralModel(offset_gaussian, 3,
+                                 parnames=['amplitude', 'xoff_v', 'width'],
+                                 shortvarnames=('A', 'v', 'w'))
+    dx = 0.1
+    x = np.arange(-6,6,dx)
+    y = 1-np.exp(-x**2 / 2.)
+    with warnings.catch_warnings():
+        # ignore warning about creating an empty header
+        warnings.simplefilter('ignore')
+        sp = Spectrum(xarr=x, data=y)
+    sp.plotter()
+    sp.baseline(exclude=[-5,5], order=0, subtract=False)
+    sp.specfit.register_fitter('offset_gaussian', fitter, 3)
+    sp.specfit(fittype='offset_gaussian', guesses=(-1, 0, 0.5))
+    with pytest.raises(AttributeError):
+        sp.specfit.EQW(plot=True, midpt_location='fitted')


### PR DESCRIPTION
## Summary

The literal 2015 crash in #96 (undefined `sp` / unset `midpt_pixel`) was fixed back then by Mike Lum's PR, but the issue stayed open — and the branch still had residual bugs, reproduced on current master: for any model whose centroid parameter isn't named `SHIFT` (e.g. `xoff_v` models), the parname scan comes back empty and crashes with `ValueError: attempt to get argmin of an empty sequence` (the `except AttributeError` guard around it was dead code), and calling EQW before any fit gave an unhelpful `None.keys()` error.

Fix in `Specfit.EQW`'s fitted branch: explicit no-fit check; case-insensitive SHIFT parname match on `self.parinfo` (dropping the vestigial `self.Spectrum.specfit` indirection); fallback to the fitter's declared `centroid_par` via `analytic_centroids()` for differently-named centroids; and the documented informative error when no centroid can be found. Semantics unchanged (closest fitted shift to the window center); the multi-line design question from the issue comments is deliberately untouched.

## Validation

- New tests: fitted-midpoint EQW on a synthetic gaussian equals the default-midpoint EQW (6 decimals) and the analytic value (5), with the EQW box centered on the fitted shift; a no-SHIFT model raises the documented AttributeError instead of the ValueError.
- Full suite: **2266 passed**, 3 xfailed, 33 xpassed on both numpy 1.26 and numpy 2.5 envs.

Fixes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv