### PR TITLE
fiteach: don't blank legitimate zero-valued fit parameters; treat non-finite fits as failures (fixes #347)

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -980,16 +980,21 @@ class Cube(spectrum.Spectrum):
                     with np.errstate(divide='raise'):
                         sp.specfit(guesses=gg, quiet=verbose_level<=3,
                                    verbose=verbose_level>3, **fitkwargs)
-                    self.parcube[:,int(y),int(x)] = sp.specfit.modelpars
-                    self.errcube[:,int(y),int(x)] = sp.specfit.modelerrs
-                    if np.any(~np.isfinite(sp.specfit.modelpars)):
-                        log.exception("Fit result included nan for pixel {0},{1}: "
-                                      "{2}".format(x, y, sp.specfit.modelpars))
+                    if (np.any(~np.isfinite(sp.specfit.modelpars)) or
+                            np.any(~np.isfinite(sp.specfit.modelerrs))):
+                        # A fit that produced non-finite parameters or errors
+                        # is treated as a failed fit: blank it out and flag
+                        # it so `has_fit` stays False (issue #347)
+                        log.warning("Fit result included non-finite values for "
+                                    "pixel {0},{1}: pars={2} errs={3}"
+                                    .format(x, y, sp.specfit.modelpars,
+                                            sp.specfit.modelerrs))
+                        self.parcube[:,int(y),int(x)] = blank_value
+                        self.errcube[:,int(y),int(x)] = blank_value
                         success = False
-                        # this is basically a debug statement to try to get the
-                        # code to crash here
-                        raise KeyboardInterrupt
                     else:
+                        self.parcube[:,int(y),int(x)] = sp.specfit.modelpars
+                        self.errcube[:,int(y),int(x)] = sp.specfit.modelerrs
                         success = True
                 except Exception as ex:
                     exc_traceback = sys.exc_info()[2]
@@ -1002,8 +1007,6 @@ class Cube(spectrum.Spectrum):
                     log.exception("Guesses were: {0}".format(str(gg)))
                     log.exception("Fitkwargs were: {0}".format(str(fitkwargs)))
                     success = False
-                    if isinstance(ex, KeyboardInterrupt):
-                        raise ex
 
                 # keep this out of the 'try' statement
                 if integral and success:
@@ -1163,11 +1166,13 @@ class Cube(spectrum.Spectrum):
                                      " error shape don't match that of the "
                                      "parameter cubes")
                 if ((any([x is None for x in modelpars]) or
-                     np.any(np.isnan(modelpars)) or
+                     np.any(~np.isfinite(np.array(modelpars, dtype='float'))) or
                      any([x is None for x in modelerrs]) or
-                     np.any(np.isnan(modelerrs)))):
-                    self.parcube[:,int(y),int(x)] = np.nan
-                    self.errcube[:,int(y),int(x)] = np.nan
+                     np.any(~np.isfinite(np.array(modelerrs, dtype='float'))))):
+                    # non-finite parameters or errors mean the fit failed
+                    # (issue #347); blank the pixel and mark it as unfit
+                    self.parcube[:,int(y),int(x)] = blank_value
+                    self.errcube[:,int(y),int(x)] = blank_value
                     self.has_fit[int(y),int(x)] = False
                 else:
                     self.parcube[:,int(y),int(x)] = modelpars
@@ -1192,15 +1197,17 @@ class Cube(spectrum.Spectrum):
             log.info("Finished final fit %i.  "
                      "Elapsed time was %0.1f seconds" % (len(valid_pixels), time.time()-t0))
 
-        # blank out the errors (and possibly the values) wherever they are
-        # zero = assumed bad.  This is done after the fitting loop completes
-        # (rather than per-pixel) so that it also applies when multicore > 1
-        # and so that the errcube mask is computed before parcube is
-        # overwritten.
+        # blank out the parameters and errors of all pixels that do not have
+        # a successful fit (skipped by the signal cut, failed fits, or fits
+        # that produced non-finite values).  This is done after the fitting
+        # loop completes (rather than per-pixel) so that it also applies when
+        # multicore > 1.  Note that this must be keyed on ``has_fit`` rather
+        # than on ``parcube == 0``: a successful fit can legitimately include
+        # a parameter whose value is exactly zero (e.g., an amplitude pegged
+        # at a zero lower limit; see issue #347).
         if blank_value != 0:
-            bad = self.parcube == 0
-            self.parcube[bad] = blank_value
-            self.errcube[bad] = blank_value
+            self.parcube[:, ~self.has_fit] = blank_value
+            self.errcube[:, ~self.has_fit] = blank_value
 
         pars_are_finite = np.all(np.isfinite(self.parcube), axis=0)
 

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -462,6 +462,99 @@ def test_fiteach_blank_value_nan():
     assert np.all(np.isfinite(spc.errcube[:, :, 2:]))
     assert np.all(spc.has_fit[:, 2:])
 
+def make_test_cube_2comp(shape=(60,6,6), outfile='test_2comp.fits', snr=30,
+                         sigma=None, seed=2):
+    """
+    Like `make_test_cube`, but with two Gaussian components along the
+    spectral axis (centered at 1/4 and 3/4 of the axis).  Adapted from the
+    reproducer in issue #347.
+    """
+    if sigma is None:
+        sigma1d, sigma2d = shape[0] / 10., np.mean(shape[1:]) / 5.
+    else:
+        sigma1d, sigma2d = sigma
+
+    from astropy.modeling.functional_models import Gaussian1D
+    gauss1d1 = Gaussian1D(mean=shape[0]/2 - shape[0]/4, stddev=sigma1d)
+    gauss1d2 = Gaussian1D(mean=shape[0]/2 + shape[0]/4, stddev=sigma1d)
+    x_arr = np.arange(shape[0])
+    gauss1d = gauss1d1(x_arr) + gauss1d2(x_arr)
+    gauss2d = Gaussian2DKernel(x_stddev=sigma2d, y_stddev=sigma2d,
+                               x_size=shape[1], y_size=shape[2])
+    signal_cube = gauss1d[:, None, None] * gauss2d.array
+    signal_cube = signal_cube / signal_cube.max()
+
+    np.random.seed(seed)
+    noise_std = signal_cube.max() / snr
+    noise_cube = np.random.normal(loc=0, scale=noise_std,
+                                  size=signal_cube.shape)
+    test_cube = signal_cube + noise_cube
+
+    cdelt1, cdelt2, cdelt3 = -(4e-3 + 1e-8), 4e-3 + 1e-8, -0.1
+    keylist = {'CTYPE1': 'RA---GLS', 'CTYPE2': 'DEC--GLS', 'CTYPE3': 'VRAD',
+               'CDELT1': cdelt1, 'CDELT2': cdelt2, 'CDELT3': cdelt3,
+               'CRVAL1': 0, 'CRVAL2': 0, 'CRVAL3': 5,
+               'CRPIX1': 9, 'CRPIX2': 0, 'CRPIX3': 5,
+               'CUNIT1': 'deg', 'CUNIT2': 'deg', 'CUNIT3': 'km s-1',
+               'BMAJ': cdelt2 * 3, 'BMIN': cdelt2 * 3, 'BPA': 0.0,
+               'BUNIT': 'K', 'EQUINOX': 2000.0, 'RESTFREQ': 300e9,
+               'RMSLVL': noise_std, 'SEED': seed}
+    test_header = fits.Header()
+    test_header.update(keylist)
+    test_hdu = fits.PrimaryHDU(data=test_cube, header=test_header)
+    test_hdu.writeto(outfile, overwrite=True, checksum=True)
+
+def test_fiteach_positive_constrained_twocomp():
+    """
+    Regression test for issue #347: fitting two positive-constrained
+    gaussian components over noise-dominated pixels used to trip the
+    "Non-finite parameters found in fits" assertion at the end of fiteach.
+
+    A noise-dominated pixel can converge with an amplitude pegged exactly at
+    the zero lower limit; the post-fit blanking step used to treat any
+    parameter equal to zero as "unfit" and replace it with blank_value (NaN),
+    leaving a pixel with has_fit=True but non-finite parameters.
+    """
+    cubefile = 'test_2comp.fits'
+    shape = (60, 6, 6)
+    make_test_cube_2comp(shape=shape, outfile=cubefile, snr=30, seed=2)
+
+    for multicore in (1, 2):
+        spc = Cube(cubefile)
+        rmsmap = np.zeros_like(spc.cube[0]) + spc.header['RMSLVL']
+        # velocity axis runs from ~5.4 down by 0.1 km/s per channel;
+        # the two components sit at channels shape[0]/4 and 3*shape[0]/4
+        v1 = 5 - 0.1 * (shape[0]/4 - 4)
+        v2 = 5 - 0.1 * (3*shape[0]/4 - 4)
+        guesses = [1, v1 + 0.5, 1, 1, v2 - 0.5, 1]
+        # amplitudes and widths constrained positive, centroids free
+        spc.fiteach(fittype='gaussian',
+                    guesses=guesses,
+                    errmap=rmsmap,
+                    parlimited=[(True, False), (False, False), (True, False)]*2,
+                    parlimits=[(0, 0)]*6,
+                    signal_cut=2,
+                    blank_value=np.nan,
+                    start_from_point=(shape[1]//2, shape[2]//2),
+                    multicore=multicore,
+                    verbose=False, verbose_level=0)
+
+        # the invariant fiteach asserts internally: every pixel with
+        # non-finite parameters must be flagged as not having a fit
+        pars_are_finite = np.all(np.isfinite(spc.parcube), axis=0)
+        assert np.all(~spc.has_fit[~pars_are_finite])
+        # equivalently: every pixel flagged as fit has all-finite parameters
+        assert np.all(np.isfinite(spc.parcube[:, spc.has_fit]))
+        assert np.all(np.isfinite(spc.errcube[:, spc.has_fit]))
+        # unfit pixels are blanked with blank_value=nan
+        assert np.all(np.isnan(spc.parcube[:, ~spc.has_fit]))
+        assert np.all(np.isnan(spc.errcube[:, ~spc.has_fit]))
+        # this seed produces at least one successful fit with an amplitude
+        # pegged exactly at the zero lower limit; it must be preserved
+        # (not blanked), otherwise this test is not exercising the
+        # regression scenario
+        assert np.any(spc.parcube[:, spc.has_fit] == 0)
+
 def make_nh3_cube(shape, pars, errs11, errs22, seed=42):
     """
     Tinkers with two test gaussian cubes, overwriting their spectra with NH3


### PR DESCRIPTION
## Summary

Reproduced the issue's minimal example on current master (`AssertionError: Non-finite parameters found in fits`). Root cause: the post-loop blanking used the heuristic `bad = parcube == 0` to identify never-fit pixels — but a *successful* fit can legitimately have a parameter pegged exactly at a 0.0 lower limit (here, a positive-constrained second amplitude). Those elements were converted to NaN while `has_fit` stayed True, violating the final invariant.

Fixes:
- Post-loop blanking is now keyed on `~has_fit` instead of `parcube == 0`; pegged-at-zero parameters survive.
- Serial path: a fit returning non-finite modelpars/modelerrs is now treated as a **failed** fit (blanked, `has_fit=False`) instead of writing NaNs into parcube and raising a debug `KeyboardInterrupt` — which, being a `BaseException`, sailed past the `except Exception` handler and would abort the entire fiteach on noise-dominated pixels (the `cubefit_may2021.py` failure mode).
- Multicore merge made consistent: `~np.isfinite` (catches inf too) and `blank_value` instead of hard-coded NaN.

The final assert is retained as a genuine invariant and now holds on both paths.

## Validation

- New regression test (`test_fiteach_positive_constrained_twocomp`): two-component positive-constrained fit over a 60×6×6 cube at multicore 1 and 2, asserting completion, the has_fit/finite invariant, blanking of unfit pixels, and that a pegged-at-zero parameter survives. **Fails on unfixed master, passes with the fix.**
- The issue's original repro completes cleanly in both envs at multicore 1 and 4.
- cubes+spectrum suites: **2234 passed** on both numpy 1.26 and numpy 2.5 envs.

Fixes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv