### PR TITLE
Fix get_molecular_parameters catalog queries (fixes #421, closes #365)

### DIFF
--- a/pyspeckit/spectrum/models/lte_molecule.py
+++ b/pyspeckit/spectrum/models/lte_molecule.py
@@ -205,7 +205,7 @@ def get_molecular_parameters(molecule_name, tex=50, fmin=1*u.GHz, fmax=1*u.THz,
                              parse_name_locally=True,
                              flags=0,
                              return_table=False,
-                             use_get_molecule=True,
+                             use_get_molecule=None,
                              **kwargs):
     """
     Get the molecular parameters for a molecule from the JPL or CDMS catalog
@@ -230,12 +230,33 @@ def get_molecular_parameters(molecule_name, tex=50, fmin=1*u.GHz, fmax=1*u.THz,
         If specified, this will override the molecule name.  You can specify
         molecules based on the 'TAG' column in the JPL table
     parse_name_locally : bool
-        Option passed to the query tool to specify whether to use regex to
-        search for the molecule name
+        If exact and substring matching of ``molecule_name`` against the
+        catalog species table both fail, treat ``molecule_name`` as a regular
+        expression and search the species table with it
     flags : int
         Regular expression flags to pass to the regex search
     return_table : bool
         Also return the parameter table?
+    use_get_molecule : bool or None
+        Use the astroquery ``get_molecule`` interface, which downloads the
+        full catalog file for the (resolved) species tag and selects the
+        lines in the requested frequency range locally, instead of the
+        ``query_lines`` web-form interface.  The default (None) selects
+        ``get_molecule`` for the JPL catalog (whose web form has been
+        unreliable; see pyspeckit issue #421) and ``query_lines`` for CDMS
+        (astroquery's CDMS catalog-file parser has an off-by-one column bug
+        that corrupts the GUP [upper-state degeneracy] column whenever
+        GUP >= 100; see the note below).
+
+    Notes
+    -----
+    As of astroquery 0.4.12.dev, ``CDMS.get_molecule`` misparses the
+    fixed-width catalog files: it uses column starts ELO=32, GUP=42 instead
+    of ELO=31, GUP=41, so the hundreds digit of GUP is appended to ELO as a
+    bogus fifth decimal digit (e.g. GUP=595 is read as 95) and letter-coded
+    GUP values (>=1000) make ELO a string column, which crashes downstream
+    unit conversion.  Until that is fixed upstream, ``use_get_molecule=True``
+    with ``catalog='CDMS'`` should not be trusted.
 
     Examples
     --------
@@ -249,7 +270,11 @@ def get_molecular_parameters(molecule_name, tex=50, fmin=1*u.GHz, fmax=1*u.THz,
     ...                                                          fmax=100*u.GHz)
     """
     if catalog == 'JPL':
-        from astroquery.jplspec import JPLSpec as QueryTool
+        try:
+            from astroquery.linelists.jplspec import JPLSpec as QueryTool
+        except ImportError:
+            # older astroquery
+            from astroquery.jplspec import JPLSpec as QueryTool
     elif catalog == 'CDMS':
         from astroquery.linelists.cdms import CDMS as QueryTool
     else:
@@ -263,55 +288,97 @@ def get_molecular_parameters(molecule_name, tex=50, fmin=1*u.GHz, fmax=1*u.THz,
     else:
         raise ValueError(f"Did not find NAME or molecule in table columns: {speciestab.colnames}")
 
-    if use_get_molecule:
-        if molecule_tag is not None:
-            jpltbl = QueryTool.get_molecule(molecule=molecule_tag, catalog=catalog)
-            tagcol = 'tag' if 'tag' in speciestab.colnames else 'TAG'
-            match = speciestab[tagcol] == molecule_tag
-        else:
-            jpltbl = QueryTool.get_molecule(molecule=molecule_name,
-                                            catalog=catalog,
-                                            parse_name_locally=parse_name_locally,
-                                            flags=flags)
-            match = speciestab[molcol] == molecule_name
-            if match.sum() == 0:
-                # retry using partial string matching
-                match = np.char.find(speciestab[molcol], molecule_name) != -1
-        molecule_name = jpltbl['name']
+    tagcol = 'TAG' if 'TAG' in speciestab.colnames else 'tag'
 
-        if match.sum() != 1:
-            raise ValueError(f"Too many or too few matches ({match.sum()}) to {molecule_name}")
-        # jpltable (the species table row) holds the partition function
-        # metadata used by partfunc below
-        jpltable = speciestab[match]
+    if use_get_molecule is None:
+        # default: use get_molecule for JPL (the JPL query_lines web form has
+        # been unreliable; pyspeckit issue #421), but query_lines for CDMS
+        # (astroquery's CDMS.get_molecule catalog-file parser has an
+        # off-by-one bug that corrupts GUP >= 100; see docstring Notes)
+        use_get_molecule = (catalog == 'JPL')
+    elif use_get_molecule and catalog == 'CDMS':
+        log.warning("use_get_molecule=True with catalog='CDMS' relies on "
+                    "astroquery's CDMS catalog-file parser, which corrupts "
+                    "the GUP (degeneracy) column for GUP >= 100.  "
+                    "The results may be incorrect.")
 
+    if use_get_molecule and not hasattr(QueryTool, 'get_molecule'):
+        # older versions of astroquery do not provide get_molecule
+        log.warning("The installed version of astroquery does not provide "
+                    "get_molecule; falling back to query_lines.")
+        use_get_molecule = False
+
+    # resolve the molecule name and tag from the species table
+    if molecule_tag is not None:
+        match = speciestab[tagcol] == molecule_tag
+        if molecule_name is not None:
+            log.warning(f"molecule_tag={molecule_tag} overrides molecule_name={molecule_name}.")
     else:
-        if molecule_tag is not None:
-            tagcol = 'tag' if 'tag' in speciestab.colnames else 'TAG'
-            match = speciestab[tagcol] == molecule_tag
-            molecule_name = speciestab[match][molcol][0]
-            if catalog == 'CDMS':
-                molsearchname = f'{molecule_tag:06d} {molecule_name}'
-            else:
-                molsearchname = f'{molecule_tag} {molecule_name}'
-            parse_names_locally = False
-            if molecule_name is not None:
-                log.warning(f"molecule_tag overrides molecule_name.  New molecule_name={molecule_name}.  Searchname = {molsearchname}")
-            else:
-                log.info(f"molecule_name={molecule_name} for tag molecule_tag={molecule_tag}.  Searchname = {molsearchname}")
-        else:
-            molsearchname = molecule_name
-            match = speciestab[molcol] == molecule_name
-            if match.sum() == 0:
-                # retry using partial string matching
-                match = np.char.find(speciestab[molcol], molecule_name) != -1
+        match = speciestab[molcol] == molecule_name
+        if match.sum() == 0:
+            # retry using partial string matching
+            match = np.char.find(speciestab[molcol], molecule_name) != -1
+        if match.sum() == 0 and parse_name_locally:
+            # retry using regular expression matching
+            import re
+            try:
+                match = np.array([re.search(molecule_name, str(nm), flags)
+                                  is not None
+                                  for nm in speciestab[molcol]], dtype=bool)
+            except re.error:
+                # molecule names like H2C(CN)2 are not valid regexes
+                pass
 
-        if match.sum() != 1:
-            raise ValueError(f"Too many or too few matches ({match.sum()}) to {molecule_name}")
-        jpltable = speciestab[match]
+    if match.sum() != 1:
+        matched_names = list(speciestab[molcol][match]) if 0 < match.sum() <= 25 else ''
+        raise ValueError(f"Too many or too few matches ({match.sum()}) to "
+                         f"molecule_name={molecule_name}, molecule_tag={molecule_tag} "
+                         f"in the {catalog} catalog. "
+                         f"{('Matched species: ' + str(matched_names)) if matched_names else ''}")
+
+    # jpltable (the species table row) holds the partition function
+    # metadata used by partfunc below
+    jpltable = speciestab[match]
+    molecule_tag = int(jpltable[tagcol][0])
+    molecule_name = str(jpltable[molcol][0])
+
+    if use_get_molecule:
+        # get_molecule retrieves the full catalog file for the species
+        # specified by its tag; frequency selection is done below
+        jpltbl = QueryTool.get_molecule(molecule_tag)
+    else:
+        # the tag has been resolved above, so we can query for it directly
+        # (exact tag-based queries are far more reliable than name matching)
+        if catalog == 'CDMS':
+            # the CDMS query tool expects "tag name", with the tag
+            # zero-padded to 6 digits
+            molsearchname = f'{molecule_tag:06d} {molecule_name}'
+        else:
+            # the JPL query tool accepts a bare tag
+            molsearchname = str(molecule_tag)
+        log.info(f"Searching for molecule name={molecule_name} tag={molecule_tag} "
+                 f"with search name '{molsearchname}'")
 
         jpltbl = QueryTool.query_lines(fmin, fmax, molecule=molsearchname,
-                                    parse_name_locally=parse_name_locally, **kwargs)
+                                       parse_name_locally=False, **kwargs)
+
+    if not np.issubdtype(jpltbl['ELO'].dtype, np.number):
+        raise ValueError("The ELO (lower-state energy) column was not parsed "
+                         "as a number; this is a known bug in astroquery's "
+                         "CDMS catalog-file parser for species with "
+                         "degeneracies >= 1000.  Try use_get_molecule=False.")
+
+    # select lines in the requested frequency range.  get_molecule retrieves
+    # the full catalog, and the JPL query_lines web form has been observed to
+    # ignore the requested limits, so this is enforced client-side for both.
+    fmin_MHz, fmax_MHz = sorted([fmin.to(u.MHz, u.spectral()),
+                                 fmax.to(u.MHz, u.spectral())])
+    inrange = ((jpltbl['FREQ'].quantity >= fmin_MHz) &
+               (jpltbl['FREQ'].quantity <= fmax_MHz))
+    jpltbl = jpltbl[inrange]
+    if len(jpltbl) == 0:
+        raise ValueError(f"No lines found for {molecule_name} "
+                         f"(tag={molecule_tag}) between {fmin} and {fmax}.")
 
     def partfunc(tem):
         """

--- a/pyspeckit/spectrum/models/tests/test_lte_molecule.py
+++ b/pyspeckit/spectrum/models/tests/test_lte_molecule.py
@@ -1,0 +1,252 @@
+"""
+Tests for lte_molecule.get_molecular_parameters.
+
+The offline tests monkeypatch the astroquery query tools with small fake
+species/catalog tables so that the name/tag resolution and table-handling
+logic is exercised without network access (regression tests for issues
+#421 and #365).
+
+The tests marked ``remote_data`` query the live JPL/CDMS services and are
+only run when pytest is invoked with ``--remote-data``.
+"""
+import numpy as np
+import pytest
+
+from astropy import units as u
+from astropy.table import Table
+
+astroquery = pytest.importorskip("astroquery")
+
+from ..lte_molecule import get_molecular_parameters
+
+
+JPL_TEMPERATURES = [300, 225, 150, 75, 37.5, 18.5, 9.375]
+
+
+def fake_jpl_species_table():
+    tab = Table()
+    tab['TAG'] = [40001, 32003, 33004]
+    tab['NAME'] = ['CH3CCH', 'CH3OH', 'CH3CH2OH']
+    # Q = 10 * T (so the interpolated partition function is easy to predict)
+    for ii, tem in enumerate(JPL_TEMPERATURES):
+        tab[f'QLOG{ii + 1}'] = np.log10([10 * tem] * 3)
+    tab.meta = {'Temperature (K)': JPL_TEMPERATURES}
+    return tab
+
+
+def fake_cdms_species_table():
+    tab = Table()
+    tab['tag'] = [40001, 66506]
+    tab['molecule'] = ['CH3CCH', 'H2C(CN)2']
+    for tem in [300., 225., 150., 75., 37.5, 18.75, 9.375]:
+        tab[f'lg(Q({tem}))'] = np.log10([10 * tem] * 2)
+    tab.meta = {'Temperature (K)': [300., 225., 150., 75., 37.5, 18.75,
+                                    9.375]}
+    return tab
+
+
+def fake_catalog_table(tag=40001):
+    """A minimal SPCAT-style catalog table like those astroquery returns."""
+    tab = Table()
+    tab['FREQ'] = np.array([50000., 65000., 105000.]) * u.MHz
+    tab['ERR'] = np.array([0.01, 0.01, 0.01]) * u.MHz
+    tab['LGINT'] = [-5.0, -4.0, -4.5]
+    tab['DR'] = [3, 3, 3]
+    tab['ELO'] = np.array([0.0, 5.0, 10.0]) * u.cm**-1
+    tab['GUP'] = [3, 5, 7]
+    tab['TAG'] = [tag] * 3
+    tab['QNFMT'] = [202] * 3
+    return tab
+
+
+@pytest.fixture
+def fake_jpl(monkeypatch):
+    """Monkeypatch the JPLSpec query tool with fake tables."""
+    from astroquery.linelists.jplspec import JPLSpec
+
+    calls = {'get_molecule': [], 'query_lines': []}
+
+    def get_species_table(**kwargs):
+        return fake_jpl_species_table()
+
+    def get_molecule(molecule_id, **kwargs):
+        calls['get_molecule'].append(molecule_id)
+        return fake_catalog_table(tag=molecule_id)
+
+    def query_lines(fmin, fmax, **kwargs):
+        calls['query_lines'].append(kwargs)
+        return fake_catalog_table()
+
+    monkeypatch.setattr(JPLSpec, 'get_species_table', get_species_table)
+    monkeypatch.setattr(JPLSpec, 'get_molecule', get_molecule)
+    monkeypatch.setattr(JPLSpec, 'query_lines', query_lines)
+    return calls
+
+
+@pytest.fixture
+def fake_cdms(monkeypatch):
+    """Monkeypatch the CDMS query tool with fake tables."""
+    from astroquery.linelists.cdms import CDMS
+
+    calls = {'get_molecule': [], 'query_lines': []}
+
+    def get_species_table(**kwargs):
+        return fake_cdms_species_table()
+
+    def get_molecule(molecule_id, **kwargs):
+        calls['get_molecule'].append(molecule_id)
+        return fake_catalog_table(tag=molecule_id)
+
+    def query_lines(fmin, fmax, **kwargs):
+        calls['query_lines'].append(kwargs)
+        return fake_catalog_table()
+
+    monkeypatch.setattr(CDMS, 'get_species_table', get_species_table)
+    monkeypatch.setattr(CDMS, 'get_molecule', get_molecule)
+    monkeypatch.setattr(CDMS, 'query_lines', query_lines)
+    return calls
+
+
+def test_jpl_name_resolution_and_freq_filter(fake_jpl):
+    """
+    Regression test for issue #421: the molecule name must be resolved to a
+    tag locally and passed to get_molecule, and the returned catalog must be
+    restricted to the requested frequency range.
+    """
+    freqs, aij, deg, EU, partfunc = get_molecular_parameters(
+        'CH3CCH', fmin=60 * u.GHz, fmax=110 * u.GHz)
+
+    # name resolved to the correct tag, passed to get_molecule
+    assert fake_jpl['get_molecule'] == [40001]
+    # JPL default path must not use the (unreliable) query_lines form
+    assert fake_jpl['query_lines'] == []
+
+    # the 50 GHz line is out of range; the 65 and 105 GHz lines are kept
+    np.testing.assert_allclose(freqs.to(u.MHz).value, [65000., 105000.])
+    np.testing.assert_array_equal(deg, [5, 7])
+    assert np.all(np.isfinite(aij))
+    assert np.all(EU > 0)
+
+    # Q = 10 * T at the tabulated points; 150 K is a node of the interpolant
+    assert partfunc(150) == pytest.approx(1500, rel=1e-6)
+
+
+def test_jpl_tag_selection(fake_jpl):
+    freqs, aij, deg, EU, partfunc = get_molecular_parameters(
+        None, molecule_tag=32003, fmin=60 * u.GHz, fmax=110 * u.GHz)
+    assert fake_jpl['get_molecule'] == [32003]
+    assert len(freqs) == 2
+
+
+def test_jpl_partial_name_match(fake_jpl):
+    # 'H3CC' is a substring of only CH3CCH
+    freqs, aij, deg, EU, partfunc = get_molecular_parameters(
+        'H3CC', fmin=60 * u.GHz, fmax=110 * u.GHz)
+    assert fake_jpl['get_molecule'] == [40001]
+
+
+def test_jpl_regex_name_match(fake_jpl):
+    # not a substring of any entry, but a regex matching only CH3CCH
+    freqs, aij, deg, EU, partfunc = get_molecular_parameters(
+        'CH3..H$', fmin=60 * u.GHz, fmax=110 * u.GHz)
+    assert fake_jpl['get_molecule'] == [40001]
+
+
+def test_jpl_ambiguous_name(fake_jpl):
+    # 'CH3' matches all three fake species
+    with pytest.raises(ValueError, match='Too many or too few matches'):
+        get_molecular_parameters('CH3', fmin=60 * u.GHz, fmax=110 * u.GHz)
+
+
+def test_jpl_unknown_name(fake_jpl):
+    with pytest.raises(ValueError, match='Too many or too few matches'):
+        get_molecular_parameters('NOTAMOLECULE',
+                                 fmin=60 * u.GHz, fmax=110 * u.GHz)
+
+
+def test_jpl_no_lines_in_range(fake_jpl):
+    with pytest.raises(ValueError, match='No lines found'):
+        get_molecular_parameters('CH3CCH', fmin=1 * u.GHz, fmax=2 * u.GHz)
+
+
+def test_cdms_name_resolution(fake_cdms):
+    """
+    Regression test for issue #365: names with regex special characters,
+    like H2C(CN)2, must resolve; the CDMS default path goes through
+    query_lines with a '<zero-padded tag> <name>' search string.
+    """
+    freqs, aij, deg, EU, partfunc = get_molecular_parameters(
+        'H2C(CN)2', catalog='CDMS', fmin=60 * u.GHz, fmax=110 * u.GHz)
+
+    # CDMS default path must use query_lines (astroquery's CDMS
+    # catalog-file parser is buggy; see get_molecular_parameters docstring)
+    assert fake_cdms['get_molecule'] == []
+    assert len(fake_cdms['query_lines']) == 1
+    assert fake_cdms['query_lines'][0]['molecule'] == '066506 H2C(CN)2'
+    assert fake_cdms['query_lines'][0]['parse_name_locally'] is False
+
+    np.testing.assert_allclose(freqs.to(u.MHz).value, [65000., 105000.])
+    assert np.all(np.isfinite(aij))
+
+
+def test_cdms_freq_filter(fake_cdms):
+    freqs, aij, deg, EU, partfunc = get_molecular_parameters(
+        'CH3CCH', catalog='CDMS', fmin=60 * u.GHz, fmax=70 * u.GHz)
+    assert fake_cdms['query_lines'][0]['molecule'] == '040001 CH3CCH'
+    np.testing.assert_allclose(freqs.to(u.MHz).value, [65000.])
+    np.testing.assert_array_equal(deg, [5])
+
+
+def test_cdms_get_molecule_bad_elo(fake_cdms, monkeypatch):
+    """
+    astroquery's CDMS._parse_cat returns a string-typed ELO column for
+    species with letter-coded degeneracies (issue #365); make sure this is
+    reported as a clear error instead of a cryptic TypeError.
+    """
+    from astroquery.linelists.cdms import CDMS
+
+    def get_molecule(molecule_id, **kwargs):
+        tab = fake_catalog_table(tag=molecule_id)
+        tab.replace_column('ELO', ['0.0', '5.0', '10.0A'])
+        return tab
+
+    monkeypatch.setattr(CDMS, 'get_molecule', get_molecule)
+
+    with pytest.raises(ValueError, match='ELO'):
+        get_molecular_parameters('H2C(CN)2', catalog='CDMS',
+                                 fmin=60 * u.GHz, fmax=110 * u.GHz,
+                                 use_get_molecule=True)
+
+
+@pytest.mark.remote_data
+def test_issue421_ch3cch_jpl():
+    """https://github.com/pyspeckit/pyspeckit/issues/421"""
+    freqs, aij, deg, EU, partfunc = get_molecular_parameters(
+        'CH3CCH', fmin=60 * u.GHz, fmax=110 * u.GHz)
+    assert len(freqs) > 0
+    assert np.all((freqs >= 60 * u.GHz) & (freqs <= 110 * u.GHz))
+    # J=4-3, 5-4, 6-5 K-ladders
+    assert np.any(np.isclose(freqs.to(u.MHz).value, 102547.9842, atol=1))
+    assert np.issubdtype(np.asarray(deg).dtype, np.number)
+    assert np.all(np.isfinite(aij))
+    assert partfunc(50) > 0
+
+
+@pytest.mark.remote_data
+def test_issue365_h2ccnc2_cdms():
+    """https://github.com/pyspeckit/pyspeckit/issues/365"""
+    freqs, aij, deg, EU, partfunc = get_molecular_parameters(
+        "H2C(CN)2", catalog="CDMS",
+        fmin=232567.224454 * u.MHz, fmax=234435.809432 * u.MHz)
+    assert len(freqs) > 0
+    assert np.issubdtype(np.asarray(deg).dtype, np.number)
+    assert np.all(np.isfinite(aij))
+    assert np.all(np.isfinite(EU))
+
+
+@pytest.mark.remote_data
+def test_ch3oh_jpl():
+    freqs, aij, deg, EU, partfunc = get_molecular_parameters(
+        'CH3OH', fmin=60 * u.GHz, fmax=70 * u.GHz)
+    assert len(freqs) > 0
+    assert np.all((freqs >= 60 * u.GHz) & (freqs <= 70 * u.GHz))


### PR DESCRIPTION
## Summary

**#421 (JPL, 'Zero lines found')** — reproduced, plus worse: on current master every call crashed with `TypeError: get_molecule() got an unexpected keyword argument 'molecule'` — the `use_get_molecule=True` default was written against a never-released astroquery API (released astroquery is `get_molecule(molecule_id)`: tag-only, full-catalog download, no frequency args). And the original 2025 symptom is the JPL `query_lines` web form misbehaving server-side (astroquery#3363) — verified still broken today (it ignores the frequency limits entirely, returning the full 813-line CH3CCH catalog).

Fix: resolve `molecule_name → TAG` locally against the species table (exact → substring → regex when `parse_name_locally`), call `get_molecule(tag)`, and enforce fmin/fmax **client-side** on both query paths. JPL defaults to `get_molecule`; clear `ValueError`s for unknown/ambiguous names and empty ranges.

**#365 (CDMS, GUP TypeError)** — the 2022 crash itself was fixed upstream in astroquery's letter-coded-GUP parser, and with this PR the exact call from the issue now returns 49 lines with integer degeneracies. Along the way a **new upstream astroquery bug** was precisely characterized (not worked around): `CDMS._parse_cat` uses column starts ELO=32/GUP=42 instead of the SPCAT-format 31/41, silently truncating GUP ≥ 100 (595→95) and corrupting ELO; hence CDMS here defaults to `query_lines` with a zero-padded tag search string, and forcing `get_molecule` for CDMS warns. This deserves an astroquery issue.

Also: dead `parse_names_locally` typo removed; deprecated `astroquery.jplspec` import updated with fallback.

## Live evidence

- CH3CCH 60–110 GHz → 15 lines (J=4-3/5-4/6-5 K-ladders, 68.35–102.55 GHz), Q(50 K)=387.4, identical via both query paths
- CH3OH 60–70 GHz → 133 lines; H2O by tag 18003 → 183.310 GHz
- The exact #365 call → 49 lines (232.59–234.44 GHz), finite aij, int64 deg

## Tests

10 offline tests (monkeypatched species/catalog tables: name/tag/regex resolution, tag zero-padding, frequency filtering, error paths — CI-safe) + 3 `@pytest.mark.remote_data` live tests. Full suites green on numpy 1.26 and numpy 2.5 envs.

Fixes #421
Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv