### PR TITLE
Modernize CI: real pytest suite, Python 3.10-3.13 matrix, passing strict docs build (fixes #418)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,46 +16,37 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python-version: 3.9
-            name: Py3.9 mindeps
-            toxenv: py39-test
-          - os: ubuntu-latest
             python-version: '3.10'
-            name: Py3.10 mindeps
+            name: Py3.10
             toxenv: py310-test
           - os: ubuntu-latest
-            python-version: 3.11
-            name: Py3.11 mindeps
+            python-version: '3.11'
+            name: Py3.11
             toxenv: py311-test
           - os: ubuntu-latest
-            python-version: 3.8
-            name: Py3.8 mindeps
-            toxenv: py38-test
+            python-version: '3.12'
+            name: Py3.12
+            toxenv: py312-test
           - os: ubuntu-latest
-            python-version: 3.9
-            name: Py3.9 dev
-            toxenv: py39-test-dev
+            python-version: '3.13'
+            name: Py3.13
+            toxenv: py313-test
           - os: ubuntu-latest
-            python-version: 3.11
-            name: Py3.11 dev
-            toxenv: py311-test-dev
+            python-version: '3.12'
+            name: Py3.12 dev astropy
+            toxenv: py312-test-dev
           - os: ubuntu-latest
-            python-version: 3.9
+            python-version: '3.12'
             name: Documentation
             toxenv: build_docs
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install testing dependencies
-      run: python -m pip install tox codecov
+      run: python -m pip install tox
     - name: Run tests with ${{ matrix.name }}
       run: tox -v -e ${{ matrix.toxenv }}
-    - name: Upload coverage to codecov
-      if: ${{ contains(matrix.toxenv,'-cov') }}
-      uses: codecov/codecov-action@v3
-      with:
-        file: ./coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ _*/
 *backup
 *.index
 *.fit
+.tox/

--- a/docs/example_vega_echelle.py
+++ b/docs/example_vega_echelle.py
@@ -1,0 +1,65 @@
+import pyspeckit
+from pylab import *
+
+if 'wav2rgb' not in globals():
+    # this is to deal with python3 not being able to execfile
+    import wav2rgb
+
+if not 'interactive' in globals():
+    interactive=False
+if not 'savedir' in globals():
+    savedir = ''
+
+
+speclist = pyspeckit.wrappers.load_IRAF_multispec('evega.0039.rs.ec.dispcor.fits')
+
+for spec in speclist:
+    spec.unit="Counts"
+
+SP = pyspeckit.Spectra(speclist)
+SPa = pyspeckit.Spectra(speclist,xunit='angstrom',quiet=False)
+
+SP.plotter(figure=figure(1))
+SPa.plotter(figure=figure(2))
+
+figure(3)
+clf()
+figure(4)
+clf()
+
+#clr = [list(clr) for clr in matplotlib.cm.brg(linspace(0,1,len(speclist)))]
+clr = [wav2rgb.wav2RGB(c) + [1.0] for c in linspace(380,780,len(speclist))]
+for ii,(color,spec) in enumerate(zip(clr[::-1],speclist)):
+    spec.plotter(figure=figure(3), clear=False, reset=False, color=color,
+            refresh=False) 
+
+    fig4=figure(4)
+    fig4.subplots_adjust(hspace=0.35,top=0.97,bottom=0.03)
+    spec.plotter(axis=subplot(10,1,ii%10+1), clear=False, reset=False,
+            color=color, refresh=False) 
+    spec.plotter.axis.yaxis.set_major_locator(matplotlib.ticker.MaxNLocator(4)) 
+
+    if ii % 10 == 9: 
+        spec.plotter.refresh()
+        spec.plotter.savefig(savedir+'vega_subplots_%03i.png' % (ii/10+1))
+        clf()
+
+draw() # refresh all
+figure(3)
+savefig(savedir+'vega_colorized.png')
+
+#[s.plotter() for s in splist[:5]]
+#[s.plotter() for s in speclist[:5]]
+#[(subplot(5,1,ii),s.plotter()) for ii,s in enumerate(speclist[:5])]
+#[(subplot(5,1,ii),s.plotter()) for ii,s in enumerate(speclist[:5])]
+#[(subplot(5,1,ii),s.plotter(axis=subplot(5,1,ii))) for ii,s in enumerate(speclist[:5])]
+#[(subplot(5,1,ii),s.plotter(axis=subplot(15,1,ii))) for ii,s in enumerate(speclist[:15])]
+#len (speclist)
+#subpot
+#[(s.plotter(axis=subplot(15,1,ii))) for ii,s in enumerate(speclist[:15])]
+#[(s.plotter(axis=subplot(15,1,ii+1))) for ii,s in enumerate(speclist[:15])]
+#s.units
+#for s in speclist: s.units='counts' 
+#[(s.plotter(axis=subplot(15,1,ii+1))) for ii,s in enumerate(speclist[:15])]
+#savefig('vega_echelle_example.png')
+#get_ipython().system(u"open ./")

--- a/docs/example_vega_echelle.rst
+++ b/docs/example_vega_echelle.rst
@@ -3,7 +3,7 @@
 Optical Plotting - Echelle spectrum of Vega (in color!)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. import:: example_vega_echelle.py
+.. include:: example_vega_echelle.py
    :literal:
 
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -47,6 +47,7 @@ If you are already in a python session, you can enable interactive plotting by
 doing:
 
 .. code:: python
+
    from matplotlib import pyplot
    pyplot.ion()
    pyplot.show()
@@ -59,6 +60,7 @@ If you want to make sure this is enabled automatically on startup, you can
 start your python session with
 
 .. code:: bash
+
    ipython --matplotlib
 
 (I tend to use ``ipython --pylab``, but it's `deprecated

--- a/docs/lorentzian_model.rst
+++ b/docs/lorentzian_model.rst
@@ -1,0 +1,6 @@
+Lorentzian Profile model
+========================
+
+
+.. automodule:: pyspeckit.spectrum.models.inherited_lorentzian
+    :members:

--- a/docs/registration.rst
+++ b/docs/registration.rst
@@ -47,4 +47,5 @@ API
     :members:
 
 .. automodule:: pyspeckit.spectrum.fitters
+    :noindex:
     :members:

--- a/pyspeckit/spectrum/models/tests/test_astropy_models.py
+++ b/pyspeckit/spectrum/models/tests/test_astropy_models.py
@@ -11,12 +11,17 @@ except ImportError:
 def test_powerlaw(scale=5., alpha=2.):
     x = np.linspace(10,100)
     y = scale * (x)**(-alpha)
-    plm = powerlaws.PowerLaw1D(1,1,1)
+    plm = powerlaws.PowerLaw1D(amplitude=1, x_0=1, alpha=1)
+    # amplitude and x_0 are fully degenerate in PowerLaw1D
+    # (amplitude*(x/x_0)**-alpha), and letting both vary can drive the
+    # optimizer through x_0 <= 0 where the model is non-finite (which
+    # newer astropy fitters reject with NonFiniteValueError)
+    plm.x_0.fixed = True
     fitter = fitting.LevMarLSQFitter()
     result = fitter(plm, x, y)
-    print("Result: ",result)
-    print("plm.params: ",plm)
-    return plm
+    np.testing.assert_allclose(result.alpha.value, alpha, rtol=1e-6)
+    np.testing.assert_allclose(result.amplitude.value, scale, rtol=1e-6)
+    return result
 
 if __name__ == "__main__":
     scale,alpha = 5.,2.

--- a/pyspeckit/spectrum/tests/test_fitter.py
+++ b/pyspeckit/spectrum/tests/test_fitter.py
@@ -66,6 +66,7 @@ class TestFitter(object):
         """
         Regression test for #223: make sure lmfitter returns proper pars
         """
+        pytest.importorskip("lmfit")
         self.test_fitter(use_lmfit=True)
 
     def test_set_pars(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311}-test{,-dev}
+    py{310,311,312,313}-test{,-dev}
     build_docs
     codestyle
 requires =
@@ -11,6 +11,8 @@ set_env =
 
 [testenv]
 passenv = HOME,DISPLAY,LC_ALL,LC_CTYPE,ON_TRAVIS
+setenv =
+    MPLBACKEND = Agg
 #changedir = .tmp/{envname}
 description = run tests
 deps =
@@ -35,7 +37,10 @@ allowlist_externals =
 commands =
     dev: pip install -U -i https://pypi.anaconda.org/astropy/simple astropy --pre
     pip freeze
-    python setup.py test
+    # `python setup.py test` (the deprecated astropy TestRunner) collected
+    # with python_files = *_example.py and therefore never ran the actual
+    # test_*.py suite; run pytest on the real test directories instead
+    pytest pyspeckit/spectrum/tests pyspeckit/cubes/tests pyspeckit/spectrum/models/tests pyspeckit/spectrum/readers/tests -o python_files=test_*.py -p no:cacheprovider {posargs}
 
 [testenv:build_docs]
 changedir =

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ deps =
     spectral-cube
     radio-beam
     pytest
+    lmfit
     pytest_remotedata
     pytest_doctestplus
     pytest_astropy_header


### PR DESCRIPTION
## Why CI has been silent

1. GitHub **auto-disabled the 'Run tests' workflow for repository inactivity** (it has a cron trigger; 60 days without activity disables the workflow). None of the recently merged PRs ran CI. I re-enabled it via the API, but it needs activity to stay alive — this PR also gives it a green state to return to.
2. Even when it ran, tox invoked `python setup.py test` — the deprecated astropy TestRunner (#418), removed in modern setuptools — and because of the historical `python_files = *_example.py` pytest setting, **the actual `test_*.py` suite was never collected in CI**. That's a big part of how the bugs fixed over the past few days survived so long.

## Changes

- **tox.ini**: run pytest directly on the four real test directories with `python_files=test_*.py` (the exact invocation used to validate all the recent PRs — 2300+ tests); `MPLBACKEND=Agg`; envlist py310–py313 (3.8/3.9 are EOL; 3.8 is not installable on ubuntu-latest).
- **workflow**: `actions/checkout@v4`, `setup-python@v5`; matrix = Py3.10/3.11/3.12/3.13, a Py3.12 dev-astropy job, and the Documentation job; dead codecov step removed (no `-cov` env exists).
- **docs**: made `sphinx-build -W` (what the build_docs job runs) actually pass: two malformed `.. code::` directives in faq.rst, a nonexistent `.. import::` directive in the Vega echelle example (the code block has silently never rendered — now a literal `.. include::` with the script copied into docs/), the missing `lorentzian_model` page referenced by the models toctree, and a duplicate `automodule` of `spectrum.fitters` (`:noindex:` in registration.rst).

## Validation

- `sphinx-build -W -b html docs/ ...` → **build succeeded** locally (sphinx 7.2.6).
- `tox -l` parses the new config; workflow YAML validated.
- The pytest invocation is the one that has validated every PR this week on Python 3.10/numpy 1.26 and Python 3.12/numpy 2.5/astropy 7.2 (2302/2292 passed).
- The true test: this PR's own CI run, now that the workflow is re-enabled.

Fixes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv