### PR TITLE
fiteach: fail fast with a clear error when no guesses are given (fixes #3)

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -774,6 +774,17 @@ class Cube(spectrum.Spectrum):
             warn("The multifit keyword is no longer required.  All fits "
                  "allow for multiple components.", DeprecationWarning)
 
+        if (not use_nearest_as_guess and not usemomentcube and
+                guesses is not None and hasattr(guesses, '__len__') and
+                len(guesses) == 0):
+            # fail before the (potentially hours-long) loop rather than on
+            # every single pixel (issue #3)
+            raise ValueError("No guesses were specified.  Provide initial "
+                             "parameter guesses via the `guesses` keyword "
+                             "(a list of length npars, or a [npars, ny, nx] "
+                             "cube), or set usemomentcube=True or "
+                             "use_nearest_as_guess=True.")
+
         if not hasattr(self.mapplot,'plane'):
             self.mapplot.makeplane()
 

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 import warnings
 import numpy as np
 from astropy.convolution import Gaussian1DKernel, Gaussian2DKernel
@@ -624,3 +625,13 @@ def test_nonuniform_chan_weights(shape=(1000, 1, 2), err11=0.01, err22=0.25,
 
     assert np.allclose(err_sigma, 9.696e-4, rtol=1e-3)
     assert np.allclose(err_Tkin, 1.5147, rtol=1e-3)
+
+
+def test_fiteach_no_guesses_fails_early(cubefile='test.fits'):
+    # regression test for issue 3: fiteach with no guesses must raise
+    # immediately instead of failing on every pixel
+    if not os.path.exists(cubefile):
+        make_test_cube((30, 3, 3), cubefile)
+    spc = Cube(cubefile)
+    with pytest.raises(ValueError, match="No guesses were specified"):
+        spc.fiteach(fittype='gaussian', signal_cut=0)


### PR DESCRIPTION
`fiteach` with empty `guesses` (and neither `usemomentcube` nor `use_nearest_as_guess`) previously attempted and failed the fit at every pixel, surfacing an unhelpful traceback only after the full loop — the issue's example wasted 26 minutes before crashing. Now raises `ValueError` with guidance before the loop starts. Regression test included.

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv