### PR TITLE
write_fit: remove stale spectral WCS from parameter-cube headers (fixes #277)

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -1476,11 +1476,30 @@ class Cube(spectrum.Spectrum):
                 parname = "e"+par['parname'].strip('0123456789')
                 fitcubefile.header[kw] = parname
 
-            # overwrite the WCS
-            fitcubefile.header['CDELT3'] = 1
-            fitcubefile.header['CTYPE3'] = 'FITPAR'
-            fitcubefile.header['CRVAL3'] = 0
-            fitcubefile.header['CRPIX3'] = 1
+            # overwrite the WCS: the third axis is now the fit parameter
+            # plane index, so the spectral description of that axis
+            # inherited from the original cube's header no longer applies.
+            # (value, comment) tuples are used so that stale comments
+            # (e.g., "[m/s] Coordinate increment...") are also replaced.
+            fitcubefile.header['CDELT3'] = (1, 'Fit parameter plane index increment')
+            fitcubefile.header['CTYPE3'] = ('FITPAR', 'Fit parameter plane axis; see PLANE# keywords')
+            fitcubefile.header['CRVAL3'] = (0, 'Fit parameter plane index reference value')
+            fitcubefile.header['CRPIX3'] = (1, 'Fit parameter plane index reference pixel')
+            # remove leftover spectral-axis & spectral-frame keywords that
+            # would otherwise incorrectly describe the parameter axis
+            # (regression: issue #277)
+            for kw in ('CUNIT3', 'CROTA3', 'SPECSYS', 'SSYSOBS', 'SSYSSRC',
+                       'VELREF', 'VELOSYS', 'ZSOURCE', 'RESTFRQ', 'RESTFREQ',
+                       'RESTWAV', 'CD1_3', 'CD2_3', 'CD3_1', 'CD3_2',
+                       'PC1_3', 'PC2_3', 'PC3_1', 'PC3_2',
+                       'PC01_03', 'PC02_03', 'PC03_01', 'PC03_02'):
+                if kw in fitcubefile.header:
+                    del fitcubefile.header[kw]
+            # if a CD/PC matrix is used, its axis-3 diagonal element must be
+            # reset to unity to match CDELT3 = 1
+            for kw in ('CD3_3', 'PC3_3', 'PC03_03'):
+                if kw in fitcubefile.header:
+                    fitcubefile.header[kw] = 1
         except AttributeError:
             log.exception("Make sure you run the cube fitter first.")
             return

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -176,6 +176,67 @@ def test_fiteach(save_cube=None, save_pars=None, show_plot=False):
     assert map_seed == 0
     assert err_frac == 0.34
 
+def test_write_fit_header(tmp_path):
+    """
+    Regression test for #277: the header written by Cube.write_fit must
+    describe the parameter cube correctly: one PLANE# keyword per plane
+    (including the last fitted parameter, which used to be overwritten by
+    the first error plane), and no stale spectral-axis descriptors (CUNIT3,
+    RESTFRQ, SPECSYS, ...) left over from the original cube.
+    """
+    cubefile = str(tmp_path / 'test_write_fit.fits')
+    parfile = str(tmp_path / 'test_write_fit_pars.fits')
+    make_test_cube((30, 3, 3), cubefile)
+    spc = Cube(cubefile)
+    spc.fiteach(fittype='gaussian', guesses=[1, 5, 1.0], multicore=1,
+                verbose_level=0, signal_cut=0)
+    spc.write_fit(parfile, overwrite=True)
+
+    with fits.open(parfile) as hdul:
+        hdu = hdul[0]
+        # the header must verify cleanly against the FITS standard
+        hdu.verify('exception')
+        header = hdu.header
+
+        # the third axis is the fit parameter plane index
+        assert header['CTYPE3'] == 'FITPAR'
+        assert header['CDELT3'] == 1
+        assert header['CRVAL3'] == 0
+        assert header['CRPIX3'] == 1
+
+        # no stale spectral-axis / spectral-frame descriptors may remain
+        for kw in ('CUNIT3', 'RESTFRQ', 'RESTFREQ', 'RESTWAV', 'SPECSYS',
+                   'VELREF', 'VELOSYS', 'SSYSOBS', 'SSYSSRC', 'ZSOURCE',
+                   'CD1_3', 'CD2_3', 'CD3_1', 'CD3_2',
+                   'PC1_3', 'PC2_3', 'PC3_1', 'PC3_2'):
+            assert kw not in header, "stale spectral keyword: " + kw
+
+        # the celestial WCS must be kept
+        assert header['CTYPE1'].startswith('RA--')
+        assert header['CTYPE2'].startswith('DEC-')
+
+        # exactly one PLANE# keyword per plane, in the documented order:
+        # all fitted parameters first, then all the errors (issue #277 had
+        # PLANE3='eTEX' where 'WIDTH' should have been)
+        nplanes = header['NAXIS3']
+        assert nplanes == 6
+        planes = [header['PLANE%i' % ii] for ii in range(nplanes)]
+        assert planes == ['AMPLITUDE', 'SHIFT', 'WIDTH',
+                          'eAMPLITUDE', 'eSHIFT', 'eWIDTH']
+        assert 'PLANE%i' % nplanes not in header
+
+        # the header should parse as a WCS without triggering FITS fixups
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', wcs.FITSFixedWarning)
+            wcs.WCS(header)
+
+    # and the file must round-trip through load_model_fit
+    spc2 = Cube(cubefile)
+    spc2.xarr.velocity_convention = 'radio'
+    spc2.load_model_fit(parfile, npars=3)
+    np.testing.assert_allclose(spc2.parcube, spc.parcube)
+    np.testing.assert_allclose(spc2.errcube, spc.errcube)
+
 def test_get_modelcube(cubefile=None, parfile=None, multicore=1):
     """
     Tests get_modelcube() method for Cube and CubeStack classes.


### PR DESCRIPTION
Of #277's two symptoms, the PLANE# off-by-one was already fixed (a318a0d0), but the stale spectral WCS is still present on master: the written header claims the fit-parameter axis is a velocity axis (`CUNIT3='km s-1'`, '[m/s]' comments on CRVAL3/CDELT3, RESTFRQ/RESTFREQ left over). `write_fit` now writes proper (value, comment) cards for the FITPAR axis, strips leftover spectral/frame keywords (CUNIT3, SPECSYS, VELREF, RESTFRQ, ... and PC/CD axis-3 cross terms), and keeps the celestial WCS untouched. Verified: strict FITS verification passes, `wcs.WCS` parses with FITSFixedWarning escalated to error, and `load_model_fit` round-trips exactly. Regression test covers all of it including the original missing-WIDTH plane bug. Suites green on numpy 1.26 and 2.5.

Fixes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv