### PR TITLE
Make load_model_fit robust to failed validation fits and unregistered fittypes (fixes #210)

### DIFF
--- a/pyspeckit/cubes/SpectralCube.py
+++ b/pyspeckit/cubes/SpectralCube.py
@@ -1385,14 +1385,29 @@ class Cube(spectrum.Spectrum):
 
 
         # make sure params are within limits
+        if fittype not in self.specfit.Registry.multifitters:
+            raise KeyError("'{0}' is not a registered fittype.  The "
+                           "registered fittypes are: {1}.  If you are using "
+                           "a custom model, register it first with, e.g., "
+                           "cube.specfit.Registry.add_fitter('{0}', "
+                           "fitter_instance, npars)."
+                           .format(fittype,
+                                   sorted(self.specfit.Registry.multifitters)))
         fitter = self.specfit.Registry.multifitters[fittype]
         guesses,throwaway = fitter._make_parinfo(npeaks=npeaks)
 
+        # fit a single spectrum to initialize the specfit data structures.
+        # If this fails (e.g., because the stored parameters at the selected
+        # pixel violate the model's parameter limits), fall back to
+        # initializing the fitter directly from the registry below.
+        sp = None
+        fit_succeeded = False
         try:
             x,y = _temp_fit_loc
             sp = self.get_spectrum(x,y)
             guesses.values = self.parcube[:,int(y),int(x)]
             sp.specfit(fittype=fittype, guesses=guesses.values)
+            fit_succeeded = True
         except Exception as ex1:
             try:
                 OKmask = np.any(self.parcube, axis=0) & ~nanvals_flat
@@ -1401,15 +1416,34 @@ class Cube(spectrum.Spectrum):
                 sp = self.get_spectrum(x,y)
                 guesses.values = self.parcube[:,int(y),int(x)]
                 sp.specfit(fittype=fittype, guesses=guesses.values)
+                fit_succeeded = True
             except Exception as ex2:
                 log.error("Fitting the pixel at location {0} failed with error: {1}.  "
                           "Re-trying at location {2} failed with error {3}.  "
                           "Try setting _temp_fit_loc to a valid pixel".format(_temp_fit_loc, ex1,
                                                                               (x,y), ex2))
 
-        self.specfit.fitter = sp.specfit.fitter
-        self.specfit.fittype = sp.specfit.fittype
-        self.specfit.parinfo = sp.specfit.parinfo
+        if fit_succeeded and sp.specfit.parinfo is not None:
+            self.specfit.fitter = sp.specfit.fitter
+            self.specfit.fittype = sp.specfit.fittype
+            self.specfit.parinfo = sp.specfit.parinfo
+        else:
+            # The validation fit failed; initialize the fitter from the
+            # registry instead so that the loaded parameter cube remains
+            # usable (e.g., with get_modelcube).  See issue #210: previously
+            # this code path crashed with an unhelpful AttributeError or left
+            # specfit.parinfo set to None.
+            warn("The validation fit failed, so the parameter values could "
+                 "not be checked against the model limits.  The fitter has "
+                 "been initialized from the registry instead; parameter "
+                 "values in the cube may be invalid (e.g., out of the "
+                 "model's limits).", PyspeckitWarning)
+            fitter.npeaks = npeaks
+            if fitter.parinfo is None:
+                fitter.parinfo = guesses
+            self.specfit.fitter = fitter
+            self.specfit.fittype = fittype
+            self.specfit.parinfo = guesses
 
     def smooth(self,factor,**kwargs):
         """

--- a/pyspeckit/cubes/tests/test_cubetools.py
+++ b/pyspeckit/cubes/tests/test_cubetools.py
@@ -7,9 +7,11 @@ from astropy.io import fits
 from astropy import wcs
 import astropy
 import multiprocessing
+import pytest
 
 from .. import cubes, Cube, CubeStack
 from ...parallel_map import parallel_map
+from ...specwarnings import PyspeckitWarning
 from ...spectrum.models import n2hp, ammonia_constants
 from ...spectrum.models.ammonia import cold_ammonia_model
 
@@ -696,3 +698,83 @@ def test_fiteach_no_guesses_fails_early(cubefile='test.fits'):
     spc = Cube(cubefile)
     with pytest.raises(ValueError, match="No guesses were specified"):
         spc.fiteach(fittype='gaussian', signal_cut=0)
+
+
+def test_load_model_fit_roundtrip(cubefile='test_i210_cube.fits',
+                                  parfile='test_i210_pars.fits'):
+    """
+    Regression test for #210: fiteach -> write_fit -> load_model_fit into a
+    fresh Cube should restore parcube, errcube, and has_fit, and leave the
+    specfit machinery (fitter, fittype, parinfo) properly initialized.
+    """
+    spc = do_fiteach(save_cube=cubefile, save_pars=parfile)
+
+    fresh = Cube(cubefile)
+    fresh.load_model_fit(parfile, npars=3, fittype='gaussian')
+
+    assert np.allclose(fresh.parcube, spc.parcube, equal_nan=True)
+    assert np.allclose(fresh.errcube, spc.errcube, equal_nan=True)
+    assert (fresh.has_fit == spc.has_fit).all()
+    # the fit machinery must be initialized (used by, e.g., get_modelcube
+    # and write_fit); accessing .fitter raises AttributeError if it is not
+    assert fresh.specfit.fittype == 'gaussian'
+    assert fresh.specfit.fitter is not None
+    assert fresh.specfit.parinfo is not None
+    assert len(fresh.specfit.parinfo) == 3
+
+
+def test_load_model_fit_cold_ammonia(cubefile='test_i210_cube_nh3.fits',
+                                     parfile='test_i210_pars_nh3.fits'):
+    """
+    Regression test for #210: load_model_fit(fittype='cold_ammonia') must
+    not raise a KeyError (cold_ammonia is registered by default), and a
+    parameter cube that is inconsistent with the model (e.g., parameter
+    values outside the model limits, so the validation fit fails) must not
+    crash with an AttributeError; instead a PyspeckitWarning is issued and
+    the fitter is initialized from the registry.
+    """
+    make_test_cube((30, 9, 9), cubefile)
+
+    # synthesize a cold_ammonia parameter cube (6 parameters + 6 errors)
+    # with tkin below the CMB temperature, which makes the per-pixel
+    # validation fit inside load_model_fit fail everywhere
+    pardata = np.zeros((12, 9, 9))
+    pardata[0] = 0.5    # tkin, below the 2.7315 K limit
+    pardata[1] = 5.0    # tex
+    pardata[2] = 14.0   # ntot
+    pardata[3] = 0.5    # width
+    pardata[4] = 0.0    # xoff_v
+    pardata[5] = 0.5    # fortho
+    pardata[6:] = 0.1   # errors
+    hdr = fits.getheader(cubefile)
+    fits.PrimaryHDU(data=pardata, header=hdr).writeto(parfile,
+                                                      overwrite=True)
+
+    spc = Cube(cubefile)
+    with pytest.warns(PyspeckitWarning, match='validation fit failed'):
+        spc.load_model_fit(parfile, npars=6, fittype='cold_ammonia')
+
+    assert spc.specfit.fittype == 'cold_ammonia'
+    assert isinstance(spc.specfit.fitter, cold_ammonia_model)
+    assert spc.specfit.parinfo is not None
+    assert len(spc.specfit.parinfo) == 6
+    assert np.allclose(spc.parcube, pardata[:6])
+    assert np.allclose(spc.errcube, pardata[6:])
+
+
+def test_load_model_fit_unregistered_fittype(
+        cubefile='test_i210_cube_unreg.fits',
+        parfile='test_i210_pars_unreg.fits'):
+    """
+    Regression test for #210: an unregistered fittype should raise a
+    KeyError with a helpful message rather than a bare KeyError.
+    """
+    make_test_cube((30, 9, 9), cubefile)
+    pardata = np.ones((6, 9, 9))
+    hdr = fits.getheader(cubefile)
+    fits.PrimaryHDU(data=pardata, header=hdr).writeto(parfile,
+                                                      overwrite=True)
+
+    spc = Cube(cubefile)
+    with pytest.raises(KeyError, match='not a registered fittype'):
+        spc.load_model_fit(parfile, npars=3, fittype='not_a_real_model')


### PR DESCRIPTION
Of #210's two problems: the `cold_ammonia` KeyError was fixed when that fittype was registered (3be0e748), but two descendants of the report remained on master, both reproduced: (1) any *unregistered* fittype still raised a bare `KeyError` — now a helpful error listing the registered fittypes and how to add one; (2) when `load_model_fit`'s internal validation fit fails at both candidate pixels (e.g. a stored parcube violating model limits, exactly the reporter's tkin < T_CMB case), the cube was left with silently-corrupt `specfit.parinfo = None` (formerly the reported AttributeError) — now it warns ('validation fit failed...') and initializes fitter/fittype/parinfo from the registry so the loaded cube stays usable.

3 new tests: gaussian write/load round-trip (parcube/errcube/has_fit equality), out-of-limits cold_ammonia parcube load (warns, no crash, correct 6-par parinfo), unregistered-fittype error message. Suites green on numpy 1.26 and 2.5 (2252 passed each).

Fixes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv