### PR TITLE
Add log-likelihood, AIC, AICc, and BIC properties to Specfit

### DIFF
--- a/docs/fitting.rst
+++ b/docs/fitting.rst
@@ -8,6 +8,56 @@ General documentation for model fitting is below.  There are several multi-compo
  * `Jonny Henshaw's SCOUSE <https://github.com/jdhenshaw/scousepy>`_
  * `Jared Keown's astroclover <https://github.com/jakeown/astroclover>`_
 
+Model comparison: log-likelihood, AIC, and BIC
+----------------------------------------------
+
+After a fit, the `Specfit` object provides the (Gaussian) log-likelihood and
+the common information criteria as properties: ``logL``, ``AIC`` (Akaike
+information criterion), ``AICc`` (AIC with the small-sample correction), and
+``BIC`` (Bayesian information criterion).  These assume normally-distributed,
+uncorrelated errors given by the error spectrum:
+
+.. math::
+
+    \ln L = -\frac{1}{2}\chi^2 - \sum_i \ln\left(\sqrt{2\pi}\,\sigma_i\right)
+
+with :math:`\mathrm{AIC} = 2k - 2\ln L` and
+:math:`\mathrm{BIC} = k\ln(n) - 2\ln L`, where :math:`k` is the number of
+*free* parameters (fixed and tied parameters are not counted; see
+``Specfit.n_free_parameters``) and :math:`n` is the number of pixels included
+in the fit (``Specfit.npix_fitted``).  Lower values indicate a preferred
+model, so these can be used to decide, e.g., how many velocity components a
+spectrum contains::
+
+    import numpy as np
+    from pyspeckit import Spectrum
+
+    # synthetic two-component spectrum with known noise
+    xarr = np.linspace(-6, 6, 240)
+    sigma = 0.1
+    data = (1.5 * np.exp(-(xarr + 2.5)**2 / (2 * 0.5**2)) +
+            1.0 * np.exp(-(xarr - 2.5)**2 / (2 * 0.4**2)) +
+            np.random.randn(xarr.size) * sigma)
+    sp = Spectrum(xarr=xarr, data=data, error=np.ones(xarr.size)*sigma)
+
+    # one-component fit
+    sp.specfit(fittype='gaussian', guesses=[1.2, -2.0, 0.6])
+    aic_one, bic_one = sp.specfit.AIC, sp.specfit.BIC
+
+    # two-component fit
+    sp.specfit(fittype='gaussian',
+               guesses=[1.2, -2.0, 0.6, 0.8, 2.0, 0.5])
+    aic_two, bic_two = sp.specfit.AIC, sp.specfit.BIC
+
+    print("Delta-AIC (1comp - 2comp) = {0}".format(aic_one - aic_two))
+    print("Delta-BIC (1comp - 2comp) = {0}".format(bic_one - bic_two))
+    # both are strongly positive: the two-component model is preferred
+
+If no error spectrum is provided, the errors are estimated from the data and
+the log-likelihood (and therefore the absolute value of the information
+criteria) is only defined up to an additive constant; differences between
+models evaluated on the same spectrum remain meaningful.
+
 .. automodule:: pyspeckit.spectrum.fitters
 .. autoclass:: Specfit
     :show-inheritance:

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -639,6 +639,111 @@ class Specfit(interactive.Interactive):
 
         #self.dof  = self.includemask.sum()-self.npeaks*self.Registry.npars[self.fittype]-vheight+np.sum(self.parinfo.fixed)
 
+    @property
+    def n_free_parameters(self):
+        """
+        The number of *free* parameters in the most recent fit.
+
+        Parameters that are fixed (``parinfo[ii].fixed == True``) or tied to
+        other parameters (``parinfo[ii].tied != ''``) are totally constrained
+        and are therefore not counted as free.  This is the ``k`` used by the
+        information criteria (`AIC`, `AICc`, `BIC`).
+        """
+        if self.parinfo is None:
+            raise AttributeError("No fit has been performed, so the number "
+                                 "of free parameters is not defined.")
+        return int(sum((not par.fixed) and (par.tied.strip() == '')
+                       for par in self.parinfo))
+
+    @property
+    def logL(self):
+        """
+        The log-likelihood :math:`\\ln L` of the most recent fit, under the
+        assumption of Gaussian (normally-distributed) uncorrelated errors:
+
+        .. math::
+
+            \\ln L = -\\frac{1}{2}\\chi^2
+                     - \\sum_i \\ln\\left(\\sqrt{2\\pi}\\,\\sigma_i\\right)
+
+        where the sum is over the :math:`n =` ``npix_fitted`` pixels included
+        in the fit and :math:`\\sigma_i` is the error spectrum.
+
+        .. note::
+
+            If no error spectrum was provided (``Spectrum.error`` is None or
+            all zeros), the errors used here are estimated from the data
+            (see `seterrspec`), so the absolute value of the log-likelihood
+            is meaningful only up to an additive constant; a warning is
+            raised in this case.  Differences of information criteria
+            (`AIC`, `BIC`, etc.) between models evaluated with the *same*
+            error spectrum remain meaningful.
+        """
+        if self.model is None or not hasattr(self, 'npix_fitted'):
+            raise AttributeError("No fit has been performed, so the "
+                                 "log-likelihood is not defined.")
+        if self.Spectrum.error is None or np.all(self.Spectrum.error == 0):
+            warnings.warn("Spectrum.error was not specified, so the errors "
+                          "used to compute the log-likelihood were estimated "
+                          "from the data.  The log-likelihood (and any "
+                          "derived information criteria) is therefore only "
+                          "defined up to an additive constant.")
+        included = self.includemask & ~self.mask
+        errs = self.errspec[included]
+        return -0.5 * self.chi2 - np.sum(np.log(np.sqrt(2 * np.pi) * errs))
+
+    @property
+    def AIC(self):
+        """
+        The Akaike information criterion of the most recent fit,
+
+        .. math:: \\mathrm{AIC} = 2 k - 2 \\ln L
+
+        where :math:`k` is the number of free parameters
+        (`n_free_parameters`) and :math:`\\ln L` is the Gaussian
+        log-likelihood (`logL`).  Lower values indicate a preferred model;
+        see e.g. `astropy.stats.akaike_info_criterion`.
+        """
+        return 2 * self.n_free_parameters - 2 * self.logL
+
+    @property
+    def AICc(self):
+        """
+        The Akaike information criterion with the small-sample-size
+        correction,
+
+        .. math::
+
+            \\mathrm{AICc} = \\mathrm{AIC} + \\frac{2 k (k+1)}{n - k - 1}
+
+        where :math:`k` is the number of free parameters
+        (`n_free_parameters`) and :math:`n` is the number of pixels included
+        in the fit (``npix_fitted``).  The correction is generally
+        recommended when :math:`n / k \\lesssim 40`.
+        """
+        k = self.n_free_parameters
+        n = self.npix_fitted
+        if n - k - 1 <= 0:
+            raise ValueError("The AICc correction is undefined for "
+                             "n_samples - n_free_parameters - 1 <= 0 "
+                             "(n={0}, k={1}).".format(n, k))
+        return self.AIC + 2. * k * (k + 1) / (n - k - 1)
+
+    @property
+    def BIC(self):
+        """
+        The Bayesian information criterion of the most recent fit,
+
+        .. math:: \\mathrm{BIC} = k \\ln(n) - 2 \\ln L
+
+        where :math:`k` is the number of free parameters
+        (`n_free_parameters`), :math:`n` is the number of pixels included in
+        the fit (``npix_fitted``), and :math:`\\ln L` is the Gaussian
+        log-likelihood (`logL`).  Lower values indicate a preferred model;
+        see e.g. `astropy.stats.bayesian_info_criterion`.
+        """
+        return (self.n_free_parameters * np.log(self.npix_fitted)
+                - 2 * self.logL)
 
     @property
     def mask_sliced(self):

--- a/pyspeckit/spectrum/tests/test_information_criteria.py
+++ b/pyspeckit/spectrum/tests/test_information_criteria.py
@@ -1,0 +1,205 @@
+"""
+Tests for log-likelihood and information-criterion (AIC/AICc/BIC) access on
+Specfit (https://github.com/pyspeckit/pyspeckit/issues/246)
+"""
+import warnings
+
+import numpy as np
+import pytest
+from astropy.stats import (akaike_info_criterion, akaike_info_criterion_lsq,
+                           bayesian_info_criterion)
+
+from .. import Spectrum
+
+SIGMA = 0.1
+
+
+def gaussian(x, amp, cen, wid):
+    return amp * np.exp(-(x - cen)**2 / (2. * wid**2))
+
+
+def make_spectrum(x, y_true, sigma=SIGMA, seed=0, with_error=True):
+    rng = np.random.RandomState(seed)
+    data = y_true + rng.randn(x.size) * sigma
+    error = np.ones(x.size) * sigma if with_error else None
+    with warnings.catch_warnings():
+        # ignore warning about creating an empty header
+        warnings.simplefilter('ignore')
+        sp = Spectrum(xarr=x, data=data, error=error)
+    return sp
+
+
+class TestInformationCriteria(object):
+
+    def setup_method(self):
+        # n/k = 240/3 = 80 > 40, so astropy's akaike_info_criterion applies
+        # no small-sample correction here
+        self.x = np.linspace(-6, 6, 240)
+        self.sp_one = make_spectrum(self.x, gaussian(self.x, 1.5, 0.0, 0.5),
+                                    seed=42)
+        y_two = (gaussian(self.x, 1.5, -2.5, 0.5) +
+                 gaussian(self.x, 1.0, 2.5, 0.4))
+        self.sp_two = make_spectrum(self.x, y_two, seed=1234)
+
+    def test_logL_hand_computed(self):
+        """logL must match the hand-computed Gaussian log-likelihood"""
+        sp = self.sp_one
+        sp.specfit(fittype='gaussian', guesses=[1.4, 0.1, 0.6])
+
+        n = sp.specfit.npix_fitted
+        assert n == self.x.size
+
+        residuals = sp.data - sp.specfit.get_full_model()
+        chi2 = np.sum((residuals / SIGMA)**2)
+        logL_hand = -0.5 * chi2 - n * np.log(np.sqrt(2 * np.pi) * SIGMA)
+
+        np.testing.assert_allclose(sp.specfit.logL, logL_hand, rtol=1e-10)
+        # sanity check: the fit is good, so chi2 ~ n
+        assert 0.7 * n < chi2 < 1.3 * n
+
+    def test_aic_bic_hand_computed_and_astropy(self):
+        """AIC/AICc/BIC must match both the textbook formulas and astropy"""
+        sp = self.sp_one
+        sp.specfit(fittype='gaussian', guesses=[1.4, 0.1, 0.6])
+
+        k = sp.specfit.n_free_parameters
+        n = sp.specfit.npix_fitted
+        logL = sp.specfit.logL
+        assert k == 3
+
+        # hand-computed
+        np.testing.assert_allclose(sp.specfit.AIC, 2 * k - 2 * logL,
+                                   rtol=1e-10)
+        np.testing.assert_allclose(sp.specfit.AICc,
+                                   2 * k - 2 * logL
+                                   + 2. * k * (k + 1) / (n - k - 1),
+                                   rtol=1e-10)
+        np.testing.assert_allclose(sp.specfit.BIC, k * np.log(n) - 2 * logL,
+                                   rtol=1e-10)
+
+        # astropy cross-checks; n/k = 80 > 40 so this is the uncorrected AIC
+        np.testing.assert_allclose(sp.specfit.AIC,
+                                   akaike_info_criterion(logL, k, n),
+                                   rtol=1e-10)
+        np.testing.assert_allclose(sp.specfit.BIC,
+                                   bayesian_info_criterion(logL, k, n),
+                                   rtol=1e-10)
+
+    def test_aicc_matches_astropy_small_sample(self):
+        """
+        astropy's akaike_info_criterion automatically applies the
+        small-sample correction when n/k < 40; check AICc against it
+        """
+        x = np.linspace(-4, 4, 60)  # n/k = 20 < 40
+        sp = make_spectrum(x, gaussian(x, 1.5, 0.0, 0.5), seed=7)
+        sp.specfit(fittype='gaussian', guesses=[1.4, 0.1, 0.6])
+
+        k = sp.specfit.n_free_parameters
+        n = sp.specfit.npix_fitted
+        assert n == 60 and k == 3
+
+        np.testing.assert_allclose(sp.specfit.AICc,
+                                   akaike_info_criterion(sp.specfit.logL, k,
+                                                         n),
+                                   rtol=1e-10)
+
+    def test_aic_matches_astropy_lsq(self):
+        """
+        astropy's akaike_info_criterion_lsq computes AIC from the sum of
+        squared residuals, i.e., for the maximum-likelihood variance
+        sigma^2 = SSR/n, and drops the constant -n/2*(1 + ln(2*pi)) from the
+        log-likelihood.  If we refit using exactly that sigma as the error
+        spectrum, our AIC must equal the astropy lsq AIC plus that constant.
+        """
+        sp = self.sp_one
+        sp.specfit(fittype='gaussian', guesses=[1.4, 0.1, 0.6])
+
+        n = sp.specfit.npix_fitted
+        ssr = np.sum((sp.data - sp.specfit.get_full_model())**2)
+
+        # uniform rescaling of the errors does not move the best-fit
+        # parameters, so SSR is unchanged by this refit
+        sp.error[:] = np.sqrt(ssr / n)
+        sp.specfit(fittype='gaussian', guesses=list(sp.specfit.parinfo.values))
+
+        k = sp.specfit.n_free_parameters
+        assert sp.specfit.npix_fitted == n
+        np.testing.assert_allclose(
+            np.sum((sp.data - sp.specfit.get_full_model())**2), ssr,
+            rtol=1e-6)
+
+        np.testing.assert_allclose(
+            sp.specfit.AIC,
+            akaike_info_criterion_lsq(ssr, k, n) + n * (1 + np.log(2*np.pi)),
+            rtol=1e-6)
+
+    def test_model_selection_two_component_data(self):
+        """on genuinely 2-component data, the 2-component fit must win"""
+        sp = self.sp_two
+        sp.specfit(fittype='gaussian', guesses=[1.2, -2.0, 0.6])
+        aic1 = sp.specfit.AIC
+        aicc1 = sp.specfit.AICc
+        bic1 = sp.specfit.BIC
+
+        sp.specfit(fittype='gaussian',
+                   guesses=[1.2, -2.0, 0.6, 0.8, 2.0, 0.5])
+        assert sp.specfit.n_free_parameters == 6
+        aic2 = sp.specfit.AIC
+        aicc2 = sp.specfit.AICc
+        bic2 = sp.specfit.BIC
+
+        assert aic2 < aic1
+        assert aicc2 < aicc1
+        assert bic2 < bic1
+
+    def test_model_selection_one_component_data(self):
+        """on 1-component data, the extra component must lose"""
+        sp = self.sp_one
+        sp.specfit(fittype='gaussian', guesses=[1.4, 0.1, 0.6])
+        aic1 = sp.specfit.AIC
+        bic1 = sp.specfit.BIC
+
+        sp.specfit(fittype='gaussian',
+                   guesses=[1.4, 0.1, 0.6, 0.2, 3.0, 0.5])
+        aic2 = sp.specfit.AIC
+        bic2 = sp.specfit.BIC
+
+        assert aic1 < aic2
+        assert bic1 < bic2
+
+    def test_fixed_parameters_reduce_k(self):
+        sp = self.sp_one
+        sp.specfit(fittype='gaussian', guesses=[1.4, 0.0, 0.5],
+                   fixed=[False, True, False])
+        assert sp.specfit.n_free_parameters == 2
+        np.testing.assert_allclose(sp.specfit.AIC,
+                                   2 * 2 - 2 * sp.specfit.logL, rtol=1e-10)
+        np.testing.assert_allclose(
+            sp.specfit.BIC,
+            2 * np.log(sp.specfit.npix_fitted) - 2 * sp.specfit.logL,
+            rtol=1e-10)
+
+    def test_tied_parameters_reduce_k(self):
+        sp = self.sp_two
+        sp.specfit(fittype='gaussian',
+                   guesses=[1.2, -2.0, 0.45, 0.8, 2.0, 0.45],
+                   tied=['', '', '', '', '', 'p[2]'])
+        assert sp.specfit.n_free_parameters == 5
+        np.testing.assert_allclose(sp.specfit.AIC,
+                                   2 * 5 - 2 * sp.specfit.logL, rtol=1e-10)
+
+    def test_no_error_spectrum_warns(self):
+        sp = make_spectrum(self.x, gaussian(self.x, 1.5, 0.0, 0.5), seed=42,
+                           with_error=False)
+        sp.specfit(fittype='gaussian', guesses=[1.4, 0.1, 0.6])
+        with pytest.warns(UserWarning,
+                          match="only.*defined up to an additive constant"):
+            logL = sp.specfit.logL
+        assert np.isfinite(logL)
+
+    def test_no_fit_raises(self):
+        sp = make_spectrum(self.x, gaussian(self.x, 1.5, 0.0, 0.5), seed=42)
+        with pytest.raises(AttributeError):
+            sp.specfit.logL
+        with pytest.raises(AttributeError):
+            sp.specfit.n_free_parameters


### PR DESCRIPTION
## Summary

Implements #246: easy access to the log-likelihood and information criteria after a fit, for comparing models with different numbers of velocity components.

New read-only properties on `Specfit` (`pyspeckit/spectrum/fitters.py`):

| Property | Definition |
|---|---|
| `logL` | Gaussian log-likelihood: `lnL = -chi2/2 - sum_i ln(sqrt(2*pi)*sigma_i)`, summed over the pixels included in the fit |
| `n_free_parameters` | `k` = number of `parinfo` entries that are neither `fixed` nor `tied` (addresses the free-parameter-counting concern in the issue; the `vheight` background parameter is included in `parinfo`, so it is counted automatically) |
| `AIC` | `2k - 2 lnL` |
| `AICc` | `AIC + 2k(k+1)/(n-k-1)` with `n = npix_fitted` |
| `BIC` | `k ln(n) - 2 lnL` |

Design notes:

- `n = npix_fitted` (the pixels selected via `selectregion`/`includemask`, minus masked pixels), consistent with the existing `dof` property, so restricting the fit window addresses the sample-size concern raised in the issue.
- The Gaussian-errors assumption is documented on `logL`. If no error spectrum is provided (`Spectrum.error` is `None`/all-zero), the errors are estimated from the data (existing `seterrspec` behavior) and accessing `logL` raises a warning that the value is then only defined up to an additive constant; differences between models evaluated with the same error spectrum remain meaningful.
- Accessing the properties before any fit raises `AttributeError`, matching `dof`.
- A "Model comparison: log-likelihood, AIC, and BIC" section with a 1- vs 2-component example was added to `docs/fitting.rst`.

## Validation

New tests in `pyspeckit/spectrum/tests/test_information_criteria.py` (synthetic Gaussians with known noise):

- `logL`, `AIC`, `AICc`, `BIC` match hand-computed formulas to 1e-10.
- Cross-checked against `astropy.stats.akaike_info_criterion` (both the large-sample and the small-sample/AICc branches) and `astropy.stats.bayesian_info_criterion`.
- Cross-checked against `astropy.stats.akaike_info_criterion_lsq`: refitting with the maximum-likelihood variance `sigma^2 = SSR/n` as the error spectrum reproduces the lsq AIC up to its dropped constant `n*(1 + ln(2*pi))`, exactly as expected.
- 2-component fit beats 1-component on genuinely 2-component data (delta-AIC ~ 1365) and loses on 1-component data (delta-AIC ~ 4.5, delta-BIC ~ 15).
- `fixed` and `tied` parameters reduce `k` (and hence AIC/BIC).
- No-error-spectrum warning and no-fit `AttributeError` behavior.

Full suite (`pyspeckit/spectrum/tests`, `pyspeckit/cubes/tests`, `pyspeckit/spectrum/models/tests`, `pyspeckit/spectrum/readers/tests`): 2320 passed on the default environment and 2310 passed on a numpy 2 environment, 0 failures. Strict docs build (`sphinx-build -W`) succeeds.

Fixes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv
