### PR TITLE
Make echelle orders writable: strip stale multispec WCS keywords on write

### DIFF
--- a/docs/example_vega_echelle.rst
+++ b/docs/example_vega_echelle.rst
@@ -7,6 +7,36 @@ Optical Plotting - Echelle spectrum of Vega (in color!)
    :literal:
 
 
+Modifying and saving echelle orders
+-----------------------------------
+
+`~pyspeckit.wrappers.load_IRAF_multispec.load_IRAF_multispec` returns a
+list of `~pyspeckit.spectrum.classes.Spectrum` objects, one per echelle
+order.  There is no writer for the IRAF multispec format itself, but each
+order can be modified and written out as a standard (linear-wavelength)
+1D FITS spectrum with `Spectrum.write`::
+
+    import pyspeckit
+
+    orders = pyspeckit.wrappers.load_IRAF_multispec('evega.0039.rs.ec.dispcor.fits')
+
+    # modify the flux of each order however you like, e.g.:
+    for sp in orders:
+        sp.data = sp.data * 2
+
+    # save each order to its own FITS file
+    for ii, sp in enumerate(orders):
+        sp.write('vega_order{0:03d}.fits'.format(ii), type='fits')
+
+    # the saved files are standard 1D spectra; they can be re-loaded with
+    sp10 = pyspeckit.Spectrum('vega_order010.fits')
+
+By default the error spectrum is written as a second row in the output
+file; pass ``errspecnum=1`` to `pyspeckit.Spectrum` to recover it when
+re-loading, or ``write_error=False`` to `Spectrum.write` to write only
+the flux.
+
+
 .. figure:: images/vega_colorized.png
         :figwidth: 800
         :width: 800

--- a/pyspeckit/spectrum/readers/fits_reader.py
+++ b/pyspeckit/spectrum/readers/fits_reader.py
@@ -302,6 +302,16 @@ def read_echelle(pyfits_hdu):
             xax,naxis,headerkws = make_linear_axis(hdr, axsplit, WAT1_dict)
         elif hdr['CTYPE1'] == 'MULTISPE':
             xax,naxis,headerkws = make_multispec_axis(hdr, axsplit, WAT1_dict)
+        else:
+            raise ValueError("Header has IRAF multispec WAT keywords but "
+                             "CTYPE1={0!r}, which is not a recognized IRAF "
+                             "echelle dispersion type (expected 'LINEAR' or "
+                             "'MULTISPE').  If this file was written by an "
+                             "old version of pyspeckit, the multispec "
+                             "keywords are probably stale leftovers from the "
+                             "original echelle file; delete the WAT*_* "
+                             "keywords from the header to read it as a "
+                             "normal 1D spectrum.".format(hdr['CTYPE1']))
 
         cards = [pyfits.Card(k,v) for (k,v) in headerkws.items()]
         header = pyfits.Header(cards)

--- a/pyspeckit/spectrum/tests/test_echelle_roundtrip.py
+++ b/pyspeckit/spectrum/tests/test_echelle_roundtrip.py
@@ -1,0 +1,111 @@
+"""
+Regression tests for issue #410: loading an IRAF multispec (echelle)
+spectrum, modifying an order, writing it out, and reading it back.
+
+Uses a small synthesized multispec FITS file rather than a real echelle
+spectrum so no large data files are needed.
+"""
+import numpy as np
+import pytest
+from astropy.io import fits
+
+import pyspeckit
+from pyspeckit.wrappers import load_IRAF_multispec
+
+NPIX = 100
+# order number, beam, dtype (0=linear), crval, cdelt, npix, z, aplow, aphigh
+ORDERS = [(1, 51, 0, 6000.0, 0.5, NPIX, 0.0, 1.0, 2.0),
+          (2, 52, 0, 6500.0, 0.4, NPIX, 0.0, 3.0, 4.0)]
+
+
+def make_multispec_file(filename):
+    """Create a minimal IRAF multispec echelle FITS file."""
+    rng = np.random.RandomState(42)
+    data = rng.rand(len(ORDERS), NPIX).astype('float32')
+
+    hdu = fits.PrimaryHDU(data=data)
+    hdr = hdu.header
+    hdr['CTYPE1'] = 'MULTISPE'
+    hdr['CTYPE2'] = 'MULTISPE'
+    hdr['CDELT1'] = 1.0
+    hdr['CDELT2'] = 1.0
+    hdr['CD1_1'] = 1.0
+    hdr['CD2_2'] = 1.0
+    hdr['LTM1_1'] = 1.0
+    hdr['LTM2_2'] = 1.0
+    hdr['WCSDIM'] = 2
+    hdr['WAT0_001'] = 'system=multispec'
+    hdr['WAT1_001'] = 'wtype=multispec label=Wavelength units=angstroms'
+    watspec = ' '.join(['spec{0} = "{0} {1} {2} {3} {4} {5} {6} {7} {8}"'
+                        .format(*order) for order in ORDERS])
+    watspec = 'wtype=multispec ' + watspec
+    # split into 68-character WAT2_xxx cards, as IRAF does
+    for ii in range(0, len(watspec), 68):
+        hdr['WAT2_%03i' % (ii // 68 + 1)] = watspec[ii:ii + 68]
+    hdu.writeto(filename)
+
+    return data
+
+
+def test_load_write_reload_echelle_order(tmp_path):
+    """load_IRAF_multispec -> modify flux -> write -> re-read (issue #410)"""
+    msfn = str(tmp_path / 'multispec.fits')
+    data = make_multispec_file(msfn)
+
+    orders = load_IRAF_multispec(msfn)
+    assert len(orders) == len(ORDERS)
+
+    for sp, order, dd in zip(orders, ORDERS, data):
+        crval, cdelt = order[3], order[4]
+        np.testing.assert_allclose(np.asarray(sp.xarr.value),
+                                   crval + cdelt * np.arange(NPIX))
+        np.testing.assert_allclose(np.asarray(sp.data), dd)
+
+    # modify the flux of one order and write it out
+    sp = orders[0]
+    sp.data = sp.data * 2.0
+    outfn = str(tmp_path / 'order0.fits')
+    sp.write(outfn, type='fits')
+
+    # writing must not strip the multispec keywords from the in-memory
+    # headers (the orders share a single header object)
+    assert 'WAT2_001' in sp.header
+    assert 'WAT2_001' in orders[1].header
+
+    # the written single-order file must not carry stale multispec keywords
+    outhdr = fits.getheader(outfn)
+    assert 'WAT0_001' not in outhdr
+    assert 'WAT2_001' not in outhdr
+    assert 'CD1_1' not in outhdr
+    assert outhdr.get('CTYPE2') != 'MULTISPE'
+
+    # ...and must round-trip through the standard 1D reader
+    sp2 = pyspeckit.Spectrum(outfn)
+    np.testing.assert_allclose(np.asarray(sp2.data), data[0] * 2.0,
+                               rtol=1e-6)
+    np.testing.assert_allclose(np.asarray(sp2.xarr.value),
+                               np.asarray(sp.xarr.value))
+
+    # the error spectrum is stored as the second row
+    sp3 = pyspeckit.Spectrum(outfn, errspecnum=1)
+    np.testing.assert_allclose(np.asarray(sp3.error),
+                               np.asarray(sp.error))
+
+
+def test_stale_multispec_keywords_error(tmp_path):
+    """
+    A 2D file with multispec WAT keywords but a non-echelle CTYPE1 (as
+    produced by pyspeckit versions that did not strip the stale keywords)
+    should raise a comprehensible error, not UnboundLocalError.
+    """
+    hdu = fits.PrimaryHDU(data=np.zeros((2, NPIX), dtype='float32'))
+    hdr = hdu.header
+    hdr['CTYPE1'] = 'WAVE'
+    hdr['WAT0_001'] = 'system=multispec'
+    hdr['WAT1_001'] = 'wtype=multispec label=Wavelength units=angstroms'
+    hdr['WAT2_001'] = 'wtype=multispec spec1 = "1 51 0 6000. 0.5 %i 0. 1. 2."' % NPIX
+    fn = str(tmp_path / 'stale.fits')
+    hdu.writeto(fn)
+
+    with pytest.raises(ValueError, match='MULTISPE'):
+        pyspeckit.Spectrum(fn)

--- a/pyspeckit/spectrum/writers/fits_writer.py
+++ b/pyspeckit/spectrum/writers/fits_writer.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import re
 from six import iteritems
 import astropy
 import numpy as np
@@ -13,6 +14,45 @@ except ImportError:
     import pyfits
 except ImportError:
     fitscheck = False
+
+
+def strip_multispec_wcs(header):
+    """
+    Remove IRAF echelle/multispec WCS keywords from a header (in-place).
+
+    Spectra loaded from IRAF multispec (echelle) files - e.g., via
+    `pyspeckit.wrappers.load_IRAF_multispec` - inherit the original file's
+    multispec WCS keywords (``WATi_jjj``, ``CTYPEn = 'MULTISPE'``, etc.).
+    When a single order is written back out as a standard linear-WCS
+    spectrum, those keywords are stale and cause the file to be
+    mis-identified as an echelle spectrum when read back in.
+    """
+    if 'multispec' not in str(header.get('WAT0_001', '')):
+        return header
+
+    for key in list(header.keys()):
+        # WATi_jjj: the multispec dispersion specification itself
+        # CDi_j / LTMi_j: placeholder (identity) transforms in multispec
+        # files; if left in place they override the linear CRVAL/CDELT
+        # keywords when the file is read back in
+        if key and re.match(r'^(WAT[0-9]+_[0-9]+|CD[0-9]+_[0-9]+|LTM[0-9]+_[0-9]+|LTV[0-9]+)$',
+                            key):
+            del header[key]
+
+    for key in ('WCSDIM', 'WAXMAP01'):
+        if key in header:
+            del header[key]
+
+    # axis-2+ multispec keywords describe the order stacking, which no
+    # longer exists in a single written spectrum
+    for ii in range(2, 8):
+        if header.get('CTYPE%i' % ii) == 'MULTISPE':
+            for prefix in ('CTYPE', 'CUNIT', 'CRVAL', 'CRPIX', 'CDELT'):
+                if '%s%i' % (prefix, ii) in header:
+                    del header['%s%i' % (prefix, ii)]
+
+    return header
+
 
 class write_fits(Writer):
     def write_data(self, filename=None, newsuffix='out', overwrite=True,
@@ -29,7 +69,12 @@ class write_fits(Writer):
         else:
             fn = filename
 
-        header = self.Spectrum.header
+        # copy so that writing does not modify the spectrum's own header
+        # (multiple spectra - e.g. echelle orders - may share one header)
+        header = self.Spectrum.header.copy()
+        # remove stale IRAF multispec WCS keywords (e.g. for a single
+        # echelle order loaded with pyspeckit.wrappers.load_IRAF_multispec)
+        strip_multispec_wcs(header)
         header['ORIGIN'] = 'pyspeckit version %s' % pyspeckit.__version__
         header['OBJECT'] = self.Spectrum.specname
         unit = self.Spectrum.unit or self.Spectrum.header.get('BUNIT')


### PR DESCRIPTION
## Summary

Resolves the workflow asked about in #410: load an IRAF multispec echelle spectrum with `pyspeckit.wrappers.load_IRAF_multispec`, modify per-order fluxes, and save each order to a new file.

`load_IRAF_multispec` returns a list of `Spectrum` objects (one per order), and `Spectrum.write` nominally supports them — but the round trip was broken:

- `write_fits.write_data` kept the original IRAF multispec keywords (`WATi_jjj`, `CTYPEn='MULTISPE'`, placeholder `CD i_j`/`LTM i_j` identity matrices) in the output header. On re-read, the file was mis-identified as an echelle spectrum and crashed in `read_echelle` with `UnboundLocalError`; even past that, the stale `CD1_1 = 1.0` overrode the correct `CDELT1`, corrupting the wavelength axis.
- Writing also mutated the spectrum's header **in place** — and all orders returned by `load_IRAF_multispec` share a single header object, so writing one order polluted every other order's header.

## Changes

- `pyspeckit/spectrum/writers/fits_writer.py`: `write_data` now works on a **copy** of the header and strips the stale IRAF multispec WCS keywords (new `strip_multispec_wcs` helper, only active when `WAT0_001` says `system=multispec`), so the written file is a standard linear-WCS 1D spectrum that round-trips through `pyspeckit.Spectrum`.
- `pyspeckit/spectrum/readers/fits_reader.py`: `read_echelle` raises an informative `ValueError` instead of `UnboundLocalError` when `CTYPE1` is neither `LINEAR` nor `MULTISPE` (e.g. files written by previous pyspeckit versions with stale multispec keywords).
- `pyspeckit/spectrum/tests/test_echelle_roundtrip.py`: regression test using a small synthesized multispec FITS file (no large data files needed) covering load → modify flux → write → re-read, header non-mutation, and the stale-keyword error path.
- `docs/example_vega_echelle.rst`: documents the save-each-order recipe.

## Verified recipe (for the issue)

```python
import pyspeckit

# load: returns a list of Spectrum objects, one per echelle order
orders = pyspeckit.wrappers.load_IRAF_multispec('evega.0039.rs.ec.dispcor.fits')

# modify the flux of each order however you like, e.g.:
for sp in orders:
    sp.data = sp.data * 2

# save each order to its own standard 1D FITS file
for ii, sp in enumerate(orders):
    sp.write('vega_order{0:03d}.fits'.format(ii), type='fits')

# re-load a saved order (errspecnum=1 recovers the error spectrum,
# which is written as the second row; or pass write_error=False above)
sp10 = pyspeckit.Spectrum('vega_order010.fits', errspecnum=1)
```

## Testing

- End-to-end against a real APO 3.5m echelle spectrum of Vega (107 orders, 2048 pix): load → modify → write all 107 orders → re-read → flux, wavelength axis, and error spectrum all match; sibling orders' headers untouched.
- `pyspeckit/spectrum/tests/ pyspeckit/spectrum/readers/tests/ pyspeckit/cubes/tests/ pyspeckit/spectrum/models/tests/`: 2312 passed, 3 skipped, 3 xfailed, 33 xpassed (numpy 1.26.4).
- `pyspeckit/spectrum/tests/ pyspeckit/spectrum/readers/tests/`: 2242 passed under numpy 2.5.0 / astropy 7.2.0, plus the Vega end-to-end run.

Fixes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv
