### PR TITLE
Fix negative degrees of freedom in Specfit (issue #258)

### DIFF
--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -628,14 +628,32 @@ class Specfit(interactive.Interactive):
         return mask
 
     @property
+    def n_free_parameters(self):
+        """
+        The number of free parameters in the most recent fit: the total
+        number of model parameters (including a constant background term, if
+        one was fit) minus those that are fixed or tied to another parameter.
+        """
+        return (self.vheight + self.npeaks * self.Registry.npars[self.fittype]
+                - np.sum(self.parinfo.fixed)
+                - np.sum([x != '' for x in self.parinfo.tied]))
+
+    @property
     def dof(self):
         """ degrees of freedom in fit """
         if not hasattr(self, 'npix_fitted'):
             raise AttributeError('No fit has been run, so npix_fitted is not '
                                  'defined and dof cannot be computed.')
-        return (self.npix_fitted - self.vheight - self.npeaks *
-                self.Registry.npars[self.fittype] + np.sum(self.parinfo.fixed) +
-                np.sum([x != '' for x in self.parinfo.tied]))
+        dof = self.npix_fitted - self.n_free_parameters
+        if dof <= 0:
+            warnings.warn("The fit is under-determined: {0} pixels were "
+                          "included in the fit, but the model has {1} free "
+                          "parameters, so the degrees of freedom = {2} <= 0. "
+                          "Statistics (e.g., reduced chi^2) computed from "
+                          "this fit are not meaningful."
+                          .format(self.npix_fitted, self.n_free_parameters,
+                                  dof))
+        return dof
 
         #self.dof  = self.includemask.sum()-self.npeaks*self.Registry.npars[self.fittype]-vheight+np.sum(self.parinfo.fixed)
 
@@ -860,8 +878,10 @@ class Specfit(interactive.Interactive):
 
         # calculate the number of pixels included in the fit.  This should
         # *only* be done when fitting, not when selecting data.
-        # (see self.dof)
-        self.npix_fitted = self.includemask.sum() - self.mask.sum()
+        # Masked (e.g., NaN) pixels only reduce the count if they are within
+        # the included region; masked pixels elsewhere in the spectrum are
+        # irrelevant to the fit (see self.dof and issue #258)
+        self.npix_fitted = (self.includemask & (~self.mask)).sum()
 
         self.history_fitpars()
 
@@ -1030,7 +1050,9 @@ class Specfit(interactive.Interactive):
         # make sure the full model is populated
         self._full_model(debug=debug)
 
-        self.npix_fitted = self.includemask.sum() - self.mask.sum()
+        # see the comment in multifit: masked pixels only count against the
+        # fit if they are within the included region (issue #258)
+        self.npix_fitted = (self.includemask & (~self.mask)).sum()
 
         log.debug("2. Guesses, fits after vheight removal: {0},{1}"
                   .format(self.guesses, mpp))
@@ -1909,8 +1931,16 @@ class Specfit(interactive.Interactive):
         chi2 = np.sum((self.fullresiduals[modelmask]/self.errspec[modelmask])**2)
 
         if reduced:
-            # vheight included here or not?  assuming it should be...
-            dof = modelmask.sum() - self.fitter.npars
+            # n_free_parameters includes vheight (if it was fit) and accounts
+            # for all peaks and for fixed/tied parameters
+            dof = modelmask.sum() - self.n_free_parameters
+            if dof <= 0:
+                warnings.warn("The reduced chi^2 is not meaningful: {0} "
+                              "pixels are above the significance threshold, "
+                              "but the model has {1} free parameters, so the "
+                              "degrees of freedom = {2} <= 0."
+                              .format(modelmask.sum(),
+                                      self.n_free_parameters, dof))
             return chi2 / dof
         else:
             return chi2

--- a/pyspeckit/spectrum/tests/test_dof.py
+++ b/pyspeckit/spectrum/tests/test_dof.py
@@ -1,0 +1,118 @@
+"""
+Regression tests for issue #258: the fitter could report negative degrees of
+freedom.
+
+The root cause: ``npix_fitted`` was computed as ``includemask.sum() -
+mask.sum()``, where ``mask`` (non-finite data pixels) was summed over the
+*whole* spectrum.  A spectrum with more blanked (NaN) pixels outside the
+fitted region than pixels inside it went negative, silently producing a
+negative dof and negative reduced chi^2.
+
+Separately, a fit whose included region genuinely contains fewer pixels than
+the model has free parameters is under-determined; dof <= 0 now emits a
+warning (but the arithmetic is not clamped).
+"""
+import warnings
+
+import numpy as np
+import pytest
+
+import pyspeckit
+
+
+def make_two_gaussian_spectrum(nan_edge=0):
+    xarr = pyspeckit.units.SpectroscopicAxis(np.linspace(-25, 25, 100),
+                                             unit='km/s')
+    data = (5 * np.exp(-xarr.value**2 / 2.) +
+            3 * np.exp(-(xarr.value - 5)**2 / 2.))
+    if nan_edge:
+        data[:nan_edge] = np.nan
+    with warnings.catch_warnings():
+        # ignore warning about creating an empty header
+        warnings.simplefilter('ignore')
+        return pyspeckit.Spectrum(data=data, xarr=xarr,
+                                  error=np.ones(data.size) * 0.1)
+
+
+GUESSES_2G = [5, 0, 1, 3, 5, 1]  # 2 gaussians = 6 parameters
+
+
+def test_dof_ignores_masked_pixels_outside_selection():
+    # Regression test for issue #258: 20 NaN pixels at the band edge, well
+    # outside the fitted region, used to be subtracted from npix_fitted,
+    # yielding npix_fitted = 14 - 20 = -6 and dof = -12.
+    sp = make_two_gaussian_spectrum(nan_edge=20)
+    with warnings.catch_warnings(record=True) as wlist:
+        warnings.simplefilter('always')
+        sp.specfit(fittype='gaussian', guesses=GUESSES_2G,
+                   xmin=-1.5, xmax=5.5)
+        dof = sp.specfit.dof
+    assert sp.specfit.includemask.sum() == 14
+    assert sp.specfit.mask.sum() == 20
+    assert sp.specfit.npix_fitted == 14
+    assert dof == 14 - 6
+    assert not any('under-determined' in str(w.message) for w in wlist)
+
+
+def test_dof_counts_masked_pixels_inside_selection():
+    # NaN pixels *inside* the included region do reduce npix_fitted
+    sp = make_two_gaussian_spectrum()
+    sp.data[50] = np.nan  # x = +0.25 km/s, inside the fit region
+    sp.specfit(fittype='gaussian', guesses=GUESSES_2G, xmin=-5, xmax=10)
+    included = sp.specfit.includemask.sum()
+    assert sp.specfit.npix_fitted == included - 1
+    with warnings.catch_warnings(record=True) as wlist:
+        warnings.simplefilter('always')
+        assert sp.specfit.dof == included - 1 - 6
+        assert not any('under-determined' in str(w.message) for w in wlist)
+
+
+def test_underdetermined_fit_warns():
+    # A wide window with most of it excluded leaves only 4 included pixels
+    # for a 6-parameter model: dof = 4 - 6 = -2.  The dof arithmetic must be
+    # preserved (no silent clamping), but a warning must be emitted.
+    sp = make_two_gaussian_spectrum()
+    with pytest.warns(UserWarning, match='under-determined'):
+        sp.specfit(fittype='gaussian', guesses=GUESSES_2G,
+                   xmin=-2., xmax=12., exclude=[-1, 11])
+    assert sp.specfit.includemask.sum() == 4
+    assert sp.specfit.npix_fitted == 4
+    assert sp.specfit.n_free_parameters == 6
+    with pytest.warns(UserWarning, match='4 pixels.*6 free parameters'):
+        assert sp.specfit.dof == 4 - 6
+
+
+def test_dof_normal_fit_no_warning():
+    sp = make_two_gaussian_spectrum()
+    with warnings.catch_warnings(record=True) as wlist:
+        warnings.simplefilter('always')
+        sp.specfit(fittype='gaussian', guesses=GUESSES_2G)
+        n = sp.specfit.npix_fitted
+        assert n == sp.specfit.includemask.sum() == 100
+        assert sp.specfit.n_free_parameters == 6
+        assert sp.specfit.dof == n - 6
+        assert not any('under-determined' in str(w.message) for w in wlist)
+
+
+def test_dof_respects_fixed_and_tied():
+    sp = make_two_gaussian_spectrum()
+    # fix the width of the first component; tie the second amplitude to the
+    # first => 6 parameters, only 4 free
+    sp.specfit(fittype='gaussian', guesses=GUESSES_2G,
+               fixed=[False, False, True, False, False, False],
+               tied=['', '', '', '0.6*p[0]', '', ''])
+    assert sp.specfit.n_free_parameters == 4
+    assert sp.specfit.dof == sp.specfit.npix_fitted - 4
+
+
+def test_optimal_chi2_dof_counts_all_free_parameters():
+    # optimal_chi2 used self.fitter.npars (per-component: 3 for a gaussian),
+    # ignoring npeaks, fixed, and tied parameters
+    sp = make_two_gaussian_spectrum()
+    sp.specfit(fittype='gaussian', guesses=GUESSES_2G)
+    modelmask = sp.specfit._compare_to_threshold(threshold='error')
+    chi2 = sp.specfit.optimal_chi2(reduced=False, threshold='error')
+    reduced = sp.specfit.optimal_chi2(reduced=True, threshold='error')
+    expected_dof = modelmask.sum() - 6
+    assert expected_dof > 0
+    np.testing.assert_allclose(reduced, chi2 / expected_dof)


### PR DESCRIPTION
## The bug (reconstructed failure mode)

Issue #258 reported that the interactive fitter "occasionally" returns negative degrees of freedom, but the reporter could not reproduce it. The cause is in how `npix_fitted` was computed after every fit (`fitters.py`, both the `multifit` and `peakbgfit` paths):

```python
self.npix_fitted = self.includemask.sum() - self.mask.sum()
```

`self.mask` is the non-finite-data (NaN) mask over the **entire spectrum**, while `includemask` covers only the selected fit region. Whenever the spectrum contains more blanked pixels *outside* the fit region than there are pixels *inside* it, `npix_fitted` — and therefore `dof` — goes negative, silently yielding a negative reduced chi². This is exactly the "occasionally, can't repeat" signature: it depends on how many NaN pixels happen to exist elsewhere in the spectrum (e.g., blanked band edges) relative to the size of the interactively selected window.

Deterministic reproduction on master (non-interactive):

```python
xarr = pyspeckit.units.SpectroscopicAxis(np.linspace(-25, 25, 100), unit='km/s')
data = 5*np.exp(-xarr.value**2/2.) + 3*np.exp(-(xarr.value-5)**2/2.)
data[:20] = np.nan                      # blanked band edge, outside the fit window
sp = pyspeckit.Spectrum(data=data, xarr=xarr, error=np.ones(100)*0.1)
sp.specfit(fittype='gaussian', guesses=[5,0,1,3,5,1], xmin=-1.5, xmax=5.5)
sp.specfit.npix_fitted   # -6   (14 included pixels minus 20 unrelated NaNs)
sp.specfit.dof           # -12  -- silently negative
```

A second, distinct route to `dof < 0` is a genuinely under-determined selection: a wide fit window with most pixels excluded (e.g. `xmin=-2, xmax=12, exclude=[-1, 11]` leaves 4 included pixels for a 6-parameter 2-Gaussian fit). Excluded in-window pixels are still passed to mpfit with inflated errors, so mpfit's own `ndata >= nfree` guard never trips.

## The fix

- `npix_fitted` is now `(includemask & ~mask).sum()`: masked pixels only count against the fit when they fall inside the included region (fixed in both `multifit` and `peakbgfit`).
- New `Specfit.n_free_parameters` property: total model parameters (including a fitted constant background) minus fixed and tied parameters. `dof` was already crediting fixed/tied parameters back; this factors that logic out with identical arithmetic.
- When `dof <= 0`, a clear `UserWarning` is emitted ("The fit is under-determined: N pixels were included in the fit, but the model has k free parameters..."). The arithmetic is left intact — dof is **not** clamped.
- `optimal_chi2(reduced=True)` previously subtracted `self.fitter.npars`, the **per-component** parameter count — wrong normalization for multi-peak fits, and it ignored `vheight` and fixed/tied parameters. It now uses `n_free_parameters` and also warns when its dof is `<= 0`.

## Tests

New `pyspeckit/spectrum/tests/test_dof.py`:

- NaN pixels outside the selection no longer reduce `npix_fitted`; `dof = 14 - 6` with no warning (the master repro above).
- NaN pixels *inside* the selection still reduce `npix_fitted`.
- Under-determined fit (4 pixels, 6 parameters) fires the warning and preserves `dof == -2`.
- Normal fit: no warning, `dof = n - k`.
- `fixed`/`tied` correctly reduce the free-parameter count (6 params, 1 fixed + 1 tied → `n_free_parameters == 4`, `dof = n - 4`).
- `optimal_chi2` reduced/unreduced ratio matches `modelmask.sum() - 6` for a 2-peak fit.

## Validation

- `MPLBACKEND=Agg python -m pytest pyspeckit/spectrum/tests/ pyspeckit/cubes/tests/ pyspeckit/spectrum/models/tests/ pyspeckit/spectrum/readers/tests/ -o python_files='test_*.py'`:
  - numpy 1.26.4 (py3.10): **2316 passed**, 3 skipped, 3 xfailed, 33 xpassed
  - numpy 2.5.0 env: **2306 passed**, 2 skipped, 3 xfailed, 33 xpassed

Fixes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv
