### PR TITLE
Fix long-broken legacy readers, writers, measurements, and interactive handler cleanup

### DIFF
--- a/pyspeckit/cubes/mapplot.py
+++ b/pyspeckit/cubes/mapplot.py
@@ -288,7 +288,9 @@ class MapPlotter(object):
                     self._remove_circle()
                     clear=True
                     color = 'k'
-                    linestyle = 'steps-mid'
+                    # 'steps-mid' is no longer a valid linestyle in matplotlib;
+                    # the plotter already defaults to drawstyle='steps-mid'
+                    linestyle = '-'
                 else:
                     color = next(self.overplot_colorcycle)
                     linestyle = self.overplot_linestyle

--- a/pyspeckit/spectrum/cosmology.py
+++ b/pyspeckit/spectrum/cosmology.py
@@ -18,7 +18,7 @@ from __future__ import print_function
 import numpy as np
 
 try:
-    from scipy.integrate import romberg
+    from scipy.integrate import quad
     scipyOK=True
 except:
     scipyOK=False
@@ -74,9 +74,9 @@ class Cosmology:
         Integrand = lambda z: (1.0 / (1.0 + z) / self.EvolutionFunction(z))
         
         if scipyOK:
-            return (romberg(Integrand, z_i, z_f) / self.HubbleParameterNow)    
-        else: 
-            return 0
+            return (quad(Integrand, z_i, z_f)[0] / self.HubbleParameterNow)
+        else:
+            raise ImportError("scipy is required to compute the lookback time.")
         
     def TimeToRedshiftConverter(self, z_i, dt):
         """
@@ -93,9 +93,9 @@ class Cosmology:
         
         integrand = lambda z: 1. / self.EvolutionFunction(z)
         if scipyOK:
-            return romberg(integrand, z_i, z_f) * c / self.HubbleParameterNow / cm_per_mpc
-        else: 
-            return 0
+            return quad(integrand, z_i, z_f)[0] * c / self.HubbleParameterNow / cm_per_mpc
+        else:
+            raise ImportError("scipy is required to compute the comoving radial distance.")
         
     def LuminosityDistance(self, z_f):
         """

--- a/pyspeckit/spectrum/interactive.py
+++ b/pyspeckit/spectrum/interactive.py
@@ -11,7 +11,6 @@ import numpy
 from . import units
 from astropy import log
 from six.moves import xrange
-from six import iteritems
 
 class Interactive(object):
 
@@ -302,10 +301,21 @@ class Interactive(object):
             self.Spectrum.plotter._active_gui = None
             return
         for eventtype in ('button_press_event','key_press_event'):
-            for key,val in iteritems(self.Spectrum.plotter.figure.canvas.callbacks.callbacks[eventtype]):
-                if hasattr(val, 'func') and "event_manager" in val.func.__name__:
+            callbacks = self.Spectrum.plotter.figure.canvas.callbacks.callbacks.get(eventtype, {})
+            for key,val in list(callbacks.items()):
+                # modern matplotlib stores weakref-like objects
+                # (cbook._StrongRef / weakref.WeakMethod); calling them
+                # returns the underlying function.  Older matplotlib used
+                # proxies with a .func attribute.
+                if hasattr(val, 'func'):
+                    func = val.func
+                elif callable(val):
+                    func = val()
+                else:
+                    func = None
+                if func is not None and "event_manager" in getattr(func, '__name__', ''):
                     cids_to_remove.append(key)
-                    if debug or self._debug: print("Removing CID #%i with attached function %s" % (key,val.func.__name__))
+                    if debug or self._debug: print("Removing CID #%i with attached function %s" % (key,func.__name__))
         for cid in cids_to_remove:
             self.Spectrum.plotter.figure.canvas.mpl_disconnect(cid)
 

--- a/pyspeckit/spectrum/measurements.py
+++ b/pyspeckit/spectrum/measurements.py
@@ -209,7 +209,7 @@ class Measurements(object):
 
         # If lines have multiple components (i.e. spacing much closer than ref lines),
         # delete them from ID list.
-        if np.any(self.odiff) < self.rdmin:
+        if np.any(self.odiff < self.rdmin):
             where = np.ravel(np.argwhere(self.odiff < self.rdmin))
             odiff = np.delete(self.odiff, where)
             multi = True
@@ -255,7 +255,7 @@ class Measurements(object):
                         self.IDresults.append(result)
 
         # Pick best solution
-        best = np.argmin(zip(*self.IDresults)[0])  # Location of best solution
+        best = np.argmin(list(zip(*self.IDresults))[0])  # Location of best solution
         ALLloc = []                                # x-values of best fit lines in reference dictionary
 
         # Determine indices of matched reference lines
@@ -278,14 +278,14 @@ class Measurements(object):
             mpars = self.modelpars.copy()
             merrs = self.modelerrs.copy()
             for line in self.lines:
-                wavelengths = zip(*mpars)[1]
-                i = np.argmin(np.abs(zip(*mpars)[1] - self.lines[line]['modelpars'][1]))
+                wavelengths = np.array(list(zip(*mpars))[1])
+                i = np.argmin(np.abs(wavelengths - self.lines[line]['modelpars'][1]))
                 mpars = np.delete(mpars, i, 0)
                 merrs = np.delete(merrs, i, 0)
 
             # Loop over unmatched modelpars/errs, find name of unmatched line, extend corresponding dict entry
             if self.miscline is None:
-                for i, x in enumerate(zip(*mpars)[1]):
+                for i, x in enumerate(list(zip(*mpars))[1]):
                     self.lines['unknown%i' % i] = {}
                     self.lines['unknown%i' % i]['modelpars'] = mpars[i]
                     self.lines['unknown%i' % i]['modelerrs'] = merrs[i]
@@ -294,7 +294,7 @@ class Measurements(object):
             else:
                 print(self.miscline)
                 for i, miscline in enumerate(self.miscline):
-                    for j, x in enumerate(zip(*mpars)[1]):
+                    for j, x in enumerate(list(zip(*mpars))[1]):
                         if abs(x - miscline['wavelength']) < self.misctol:
                             name = miscline['name']
                         else:
@@ -332,9 +332,9 @@ class Measurements(object):
             modpars = self.lines[key]['modelpars']
             moderrs = self.lines[key]['modelerrs']
             if len(modpars) > 3:
-                modpars2d = np.reshape(modpars, (len(modpars) / 3, 3))
-                moderrs2d = np.reshape(moderrs, (len(moderrs) / 3, 3))
-                sigma = zip(*modpars2d)[2]
+                modpars2d = np.reshape(modpars, (len(modpars) // 3, 3))
+                moderrs2d = np.reshape(moderrs, (len(moderrs) // 3, 3))
+                sigma = list(zip(*modpars2d))[2]
                 minsigma = min(np.abs(sigma))
                 i_narrow = list(np.abs(sigma)).index(minsigma)
             else:
@@ -385,10 +385,8 @@ class Measurements(object):
         Determine luminosity of line (need distance and flux units).
         """
 
-        lum = 0
-        niter = (len(pars) / 3)
-        for i in xrange(int(niter)):
-            lum += self.compute_flux(pars) * 4. * np.pi * self.d**2
+        # compute_flux already sums over all components
+        lum = self.compute_flux(pars) * 4. * np.pi * self.d**2
         return lum
 
     def compute_fwhm(self, pars):
@@ -406,8 +404,8 @@ class Measurements(object):
             start = list(zip(*pars2d))[1][0]                    # start at central wavelength of first component
 
             # If the centroids are exactly the same for all components, we know the peak, and peak position
-            if np.allclose(zip(*pars2d)[1], atol):
-                fmax = np.sum(zip(*pars2d)[0])
+            if np.allclose(list(zip(*pars2d))[1], atol):
+                fmax = np.sum(list(zip(*pars2d))[0])
 
             # Otherwise, we have to figure out where the multicomponent peak is
             else:

--- a/pyspeckit/spectrum/plotters.py
+++ b/pyspeckit/spectrum/plotters.py
@@ -416,7 +416,12 @@ class Plotter(object):
                 self.silent = silent
 
             # if self.xmin and self.xmax:
-            if (reset_xlimits or self.Spectrum.xarr.min().value < self.xmin or self.Spectrum.xarr.max().value > self.xmax):
+            # self.xmin/self.xmax may be None or Quantity; compare plain values
+            xminval = getattr(self.xmin, 'value', self.xmin)
+            xmaxval = getattr(self.xmax, 'value', self.xmax)
+            if (reset_xlimits or xminval is None or xmaxval is None or
+                    self.Spectrum.xarr.min().value < xminval or
+                    self.Spectrum.xarr.max().value > xmaxval):
                 if not self.silent:
                     warn("Resetting X-axis min/max because the plot is out of bounds.")
                 self.xmin = None

--- a/pyspeckit/spectrum/readers/alfalfa.py
+++ b/pyspeckit/spectrum/readers/alfalfa.py
@@ -78,8 +78,8 @@ def read_alfalfa_source(savfile, sourcenumber=0):
         # There are multiple components in each Spectrum, but I think they are not indepedent
         sp.specfit.fittype = 'gaussian'
         sp.specfit.fitter = sp.specfit.Registry.multifitters['gaussian']
-        modelpars = zip(spectra['STON'],spectra['VCEN'],spectra['WIDTH']) 
-        modelerrs = zip(spectra['STON'],spectra['VCENERR_STAT'],spectra['WIDTHERR']) 
+        modelpars = list(zip(spectra['STON'],spectra['VCEN'],spectra['WIDTH']))
+        modelerrs = list(zip(spectra['STON'],spectra['VCENERR_STAT'],spectra['WIDTHERR']))
         sp.specfit.modelpars = modelpars[0] # only use the first fit
         sp.specfit.fitter.mpp = modelpars[0]
         sp.specfit.modelerrs = modelerrs[0]

--- a/pyspeckit/spectrum/readers/galex.py
+++ b/pyspeckit/spectrum/readers/galex.py
@@ -42,11 +42,11 @@ def read_galex(fitsfilename, orderselection='obj'):
 
     # wavelength in angstroms
     wavelength = bintable.zero + np.arange(len(bintable.disp)) * bintable.disp
-    xaxis = units.SpectroscopicAxis(wavelength,units='angstroms')
+    xaxis = units.SpectroscopicAxis(wavelength,unit='angstrom')
 
-    splist = [Spectrum(data=bintable[orderselection][:,ii], error=bintable[orderselection+"err"][:,ii], xarr=xaxis, header=ff[1].header)
+    splist = [classes.Spectrum(data=bintable[orderselection][:,ii], error=bintable[orderselection+"err"][:,ii], xarr=xaxis, header=ff[1].header)
             for ii in xrange(bintable[orderselection].shape[1])]
 
-    galexblock = ObsBlock(splist)
+    galexblock = classes.ObsBlock(splist)
 
     return galexblock

--- a/pyspeckit/spectrum/readers/hdf5_reader.py
+++ b/pyspeckit/spectrum/readers/hdf5_reader.py
@@ -27,13 +27,13 @@ def open_hdf5(filename, xaxkey = 'xarr', datakey = 'data', errkey = 'error'):
 
     f = h5py.File(filename, 'r')
     
-    try: xarr = f[xaxkey].value
+    try: xarr = f[xaxkey][()]
     except KeyError: print('Dataset \'%s\' not found.' % xaxkey)
-    
-    try: data = f[datakey].value
+
+    try: data = f[datakey][()]
     except KeyError: print('Dataset \'%s\' not found.' % datakey)
 
-    try: error = f[errkey].value
+    try: error = f[errkey][()]
     except KeyError: 
         print('Dataset \'%s\' not found.  Assuming uniform errors.' % errkey)
         error = np.ones_like(data)
@@ -66,9 +66,11 @@ def open_hdf5(filename, xaxkey = 'xarr', datakey = 'data', errkey = 'error'):
     except KeyError: 
         ytype = datakey            
         
-    XAxis = units.SpectroscopicAxis(xarr, xunits)    
+    f.close()
+
+    XAxis = units.SpectroscopicAxis(xarr, xunits)
 
     header = {'xunits': xunits, 'xtype': xtype, 'yunits': yunits, 'ytype': ytype}
-    
+
     return data, error, XAxis, header
 

--- a/pyspeckit/spectrum/readers/read_class.py
+++ b/pyspeckit/spectrum/readers/read_class.py
@@ -962,7 +962,7 @@ def read_observation(f, obsid, file_description=None, indices=None,
         nchan = hdr['NCHAN']
     else:
         log.error("No NCHAN in header.  This is not a spectrum.")
-        import ipdb; ipdb.set_trace()
+        raise ValueError("No NCHAN in header.  This is not a spectrum.")
     # There may be a 1-channel offset?  CHECK!!!
     # (changed by 1 pixel - October 14, 2014)
     # (changed back - October 21, 2014 - I think the ends are just bad, but not
@@ -994,7 +994,7 @@ def _read_spectrum(f, position, nchan, my_memmap=None, memmap=True):
 
 def _spectrum_from_header(fileobj, header, memmap=None):
     return _read_spectrum(fileobj, position=header['DATASTART'],
-                          nchan=header['NCHAN'] if 'NCHAN' in hdr else hdr['NPOIN'],
+                          nchan=header['NCHAN'] if 'NCHAN' in header else header['NPOIN'],
                           my_memmap=memmap)
 
 def clean_header(header):
@@ -1327,7 +1327,7 @@ class ClassObject(object):
     def get_spectra(self, progressbar=True, **kwargs):
         selected_indices = self.select_spectra(**kwargs)
 
-        if not any(selected_indices):
+        if len(selected_indices) == 0:
             raise ValueError("Selection yielded empty.")
 
         self._spectra.load(selected_indices, progressbar=progressbar)
@@ -1565,6 +1565,10 @@ def class_to_obsblocks(filename, telescope, line, datatuple=None, source=None,
                     header=H,
                     data=sp))
 
+    # don't forget the last one
+    if spectrumlist is not None:
+        obslist.append(pyspeckit.ObsBlock(spectrumlist))
+
     return obslist
 
 class LazyItem(object):
@@ -1598,7 +1602,7 @@ class LazyItem(object):
             return self.sphdr[key]
         elif isinstance(key, slice):
             return [self[k] for k in xrange(key.start or 0,
-                                            key.end or len(self.parent.allind),
+                                            key.stop or len(self.parent.allind),
                                             key.step or 1)]
         else:
             sphd = read_observation(self.parent._file, key,
@@ -1612,11 +1616,8 @@ class LazyItem(object):
             return sphd
 
     def __iter__(self):
-        return self.next()
-
-    def __next__(self):
-        for k in self.spheader:
-            yield self.spheader[k]
+        for k in self.sphdr:
+            yield self.sphdr[k]
 
     def __contains__(self, key):
         return key in self.sphdr

--- a/pyspeckit/spectrum/readers/read_class_lmv.py
+++ b/pyspeckit/spectrum/readers/read_class_lmv.py
@@ -20,7 +20,7 @@ def read_lmv(fn):
     with open(fn,'rb') as lf:
         # lf for "LMV File"
         filetype = lf.read(12)
-        if filetype != 'GILDAS-IMAGE':
+        if filetype != b'GILDAS-IMAGE':
             raise TypeError("File is not a GILDAS Image file")
 
         # fmt probably matters!  Default is "r4", i.e. float32 data, but could be float64

--- a/pyspeckit/spectrum/readers/tspec_reader.py
+++ b/pyspeckit/spectrum/readers/tspec_reader.py
@@ -40,6 +40,9 @@ def tspec_reader(filename, merged=True, specnum=0, **kwargs):
             header['CDELT1'] = dv
             xconv = lambda v: ((v-p3+1)*dv+v0)
             spec = ma.array(data[1,:],dtype='float64')
+            spec.mask = spec!=spec
+            # IRAF-reduced files carry no error spectrum
+            errspec = ma.masked_array(np.zeros_like(spec))
             xarr = xconv(np.arange(len(spec)))
             wat = dict([s.split("=") for s in header.get('WAT1_001').split()])
             xunits = wat['units']
@@ -66,6 +69,9 @@ def tspec_reader(filename, merged=True, specnum=0, **kwargs):
         header['BUNIT'] = unit
         xtype = 'wavelength'
         
-    XAxis = units.SpectroscopicAxis(xarr,xunits,xtype=xtype)
+    # IRAF WAT headers use plural unit names that modern astropy rejects
+    xunits = {'angstroms': 'angstrom', 'microns': 'micron',
+              'nanometers': 'nanometer'}.get(str(xunits).lower(), xunits)
+    XAxis = units.SpectroscopicAxis(xarr, unit=xunits)
 
     return spec,errspec,XAxis,header

--- a/pyspeckit/spectrum/tests/test_legacy_io_fixes.py
+++ b/pyspeckit/spectrum/tests/test_legacy_io_fixes.py
@@ -1,0 +1,171 @@
+"""
+Regression tests for long-broken legacy I/O, measurement, unit-dict, and
+interactive-handler code paths (see the fix-legacy-io-plotting audit).
+"""
+import warnings
+
+import numpy as np
+import pytest
+
+from .. import Spectrum
+from ..cosmology import Cosmology
+from ..measurements import Measurements
+from ..units import SmartCaseNoSpaceDict
+
+
+def _make_spectrum():
+    x = np.linspace(-50, 50, 101)
+    y = np.exp(-x**2 / (2 * 5.0**2))
+    with warnings.catch_warnings():
+        # ignore warning about creating an empty header
+        warnings.simplefilter('ignore')
+        return Spectrum(xarr=x, data=y, xarrkwargs={'unit': 'km/s'})
+
+
+def test_cosmology_luminosity_distance():
+    """
+    scipy.integrate.romberg was removed in scipy 1.15; cosmology.py must use
+    quad and return a positive luminosity distance in Mpc (previously it
+    crashed on import of romberg, or silently returned 0 without scipy).
+    """
+    cosm = Cosmology()
+    d = cosm.LuminosityDistance(1.0)
+    assert np.isfinite(d)
+    # a z=1 luminosity distance should be several Gpc for any sane cosmology
+    assert 1000 < d < 20000
+    # comoving radial distance must be positive too (quad returns (value, err))
+    assert cosm.ComovingRadialDistance(0., 1.0) > 0
+
+
+def test_smart_case_no_space_dict():
+    """
+    SmartCaseNoSpaceDict.update/fromkeys called __setitem__ with a spurious
+    self argument, pop raised an uncaught KeyError instead of forwarding the
+    default, setdefault dropped the default, and has_key referenced the
+    never-existent dict.has_key__.
+    """
+    d = SmartCaseNoSpaceDict()
+
+    # update must go through __setitem__ (which also stores the
+    # lowercase/no-space alias)
+    d.update({'Foo Bar': 1})
+    assert d['Foo Bar'] == 1
+    assert d['foobar'] == 1
+    assert d['FOO BAR'] == 1
+
+    # setdefault: existing key (case-insensitively) returns existing value
+    assert d.setdefault('FOO BAR', 99) == 1
+    # setdefault: missing key inserts and returns the default
+    assert d.setdefault('New Key', 3) == 3
+    assert d['newkey'] == 3
+
+    # pop with a default must not raise for missing keys
+    assert d.pop('not a key', 'fallback') == 'fallback'
+    # pop falls back to the case-normalized key
+    assert d.pop('NEWKEY') == 3
+
+    # has_key is case-insensitive and must not crash
+    assert d.has_key('foo bar')
+    assert not d.has_key('nope')
+
+    # fromkeys builds a new SmartCaseNoSpaceDict with aliases
+    d2 = d.fromkeys(['A B'], 5)
+    assert isinstance(d2, SmartCaseNoSpaceDict)
+    assert d2['A B'] == 5
+    assert d2['ab'] == 5
+
+
+def test_compute_luminosity_single_count():
+    """
+    compute_luminosity looped over components and added
+    compute_flux(pars) * 4 pi d^2 once *per component*, but compute_flux
+    already sums over all components, so multi-component lines were
+    over-counted by a factor of n_components.
+    """
+    m = Measurements.__new__(Measurements)
+    m.fluxnorm = 1.0
+    m.d = 2.0
+
+    # two gaussian components: (amp, center, width) x 2
+    pars = [1.0, 5000.0, 2.0, 3.0, 5005.0, 1.0]
+    flux = m.compute_flux(pars)
+    expected_flux = np.sqrt(2 * np.pi) * (1.0 * 2.0 + 3.0 * 1.0)
+    assert np.isclose(flux, expected_flux)
+
+    lum = m.compute_luminosity(pars)
+    assert np.isclose(lum, flux * 4. * np.pi * m.d**2)
+
+
+def test_hdf5_writer_overwrite_false_roundtrip(tmp_path):
+    """
+    The overwrite=False branch of hdf5_writer never opened the file, so
+    writing with overwrite=False crashed with NameError ('f' undefined).
+    Also round-trips through the reader, exercising the h5py
+    Dataset.value -> [()] fix.
+    """
+    h5py = pytest.importorskip('h5py')
+    from ..readers.hdf5_reader import open_hdf5
+
+    sp = _make_spectrum()
+    sp.fileprefix = str(tmp_path / 'spec')
+
+    fn = str(tmp_path / 'spec_out.hdf5')
+    sp.write(fn, type='hdf5')
+    assert (tmp_path / 'spec_out.hdf5').exists()
+
+    # second write with overwrite=False must pick a new name and actually
+    # open the file (previously: NameError)
+    sp.write(fn, type='hdf5', overwrite=False)
+    newfile = tmp_path / 'spec_fit(1).hdf5'
+    assert newfile.exists()
+
+    with h5py.File(str(newfile), 'r') as f:
+        np.testing.assert_allclose(f['data'][()], sp.data)
+        np.testing.assert_allclose(f['xarr'][()], sp.xarr.value)
+
+    # reader round-trip (no error dataset -> uniform errors)
+    data, error, xax, header = open_hdf5(str(newfile))
+    np.testing.assert_allclose(data, sp.data)
+    np.testing.assert_allclose(error, np.ones_like(sp.data))
+    np.testing.assert_allclose(np.asarray(xax), sp.xarr.value)
+
+
+def _count_event_manager_callbacks(sp):
+    n = 0
+    cbs = sp.plotter.figure.canvas.callbacks.callbacks
+    for eventtype in ('button_press_event', 'key_press_event'):
+        for key, val in list(cbs.get(eventtype, {}).items()):
+            if hasattr(val, 'func'):
+                func = val.func
+            elif callable(val):
+                func = val()
+            else:
+                func = None
+            if func is not None and 'event_manager' in getattr(func, '__name__', ''):
+                n += 1
+    return n
+
+
+def test_interactive_handlers_do_not_accumulate():
+    """
+    clear_all_connections only recognized callbacks with a .func attribute;
+    matplotlib >= 3 stores weakref-like entries, so event_manager callbacks
+    were never disconnected and every interactive session stacked another
+    set of handlers (interactive selections got out of sync; see issue #346).
+    """
+    sp = _make_spectrum()
+    sp.plotter()
+
+    sp.specfit(interactive=True)
+    n_first = _count_event_manager_callbacks(sp)
+    assert n_first > 0
+
+    # end the session; all event_manager handlers must be disconnected
+    sp.specfit.clear_all_connections()
+    assert _count_event_manager_callbacks(sp) == 0
+
+    # a second session must not accumulate handlers
+    sp.specfit(interactive=True)
+    assert _count_event_manager_callbacks(sp) == n_first
+    sp.specfit.clear_all_connections()
+    assert _count_event_manager_callbacks(sp) == 0

--- a/pyspeckit/spectrum/units.py
+++ b/pyspeckit/spectrum/units.py
@@ -57,11 +57,7 @@ class SmartCaseNoSpaceDict(dict):
 
     def has_key(self, key):
         """ This is deprecated, but we're keeping it around """
-        cased = dict.has_key__(self,key)
-        if cased is False:
-            return dict.has_key__(self, str(key).lower().replace(" ",""))
-        else:
-            return cased
+        return self.__contains__(key)
 
     def get(self, key, def_val=None):
         cased = dict.get(self,key)
@@ -75,29 +71,28 @@ class SmartCaseNoSpaceDict(dict):
         If key is in the dictionary, return its value. If not, insert key with
         a value of default and return default. default defaults to None.
         """
-        cased = dict.setdefault(self,key)
-        if cased is None:
-            return dict.setdefault(self, str(key).lower().replace(" ",""),def_val)
+        if key in self:
+            return self[key]
         else:
-            return cased
+            self[key] = def_val
+            return def_val
 
     def update(self, inputdict):
         for k,v in inputdict.items():
-            # let self.__setitem__ hand the low/upperness
-            self.__setitem__(self, k, v)
+            # let self.__setitem__ handle the low/upperness
+            self.__setitem__(k, v)
 
     def fromkeys(self, iterable, value=None):
         d = SmartCaseNoSpaceDict()
         for k in iterable:
-            self.__setitem__(d, k, value)
+            d[k] = value
         return d
 
     def pop(self, key, def_val=None):
-        cased = dict.pop(self,key)
-        if cased is None:
-            return dict.pop(self, str(key).lower().replace(" ",""),def_val)
-        else:
-            return cased
+        try:
+            return dict.pop(self, key)
+        except KeyError:
+            return dict.pop(self, str(key).lower().replace(" ",""), def_val)
 
 
 length_dict = {'meter':1.0,'m':1.0,

--- a/pyspeckit/spectrum/writers/hdf5_writer.py
+++ b/pyspeckit/spectrum/writers/hdf5_writer.py
@@ -32,6 +32,7 @@ class write_hdf5(Writer):
             while os.path.exists(fn):
                 fn = "{0}_fit({1}).hdf5".format(self.Spectrum.fileprefix, i)
                 i += 1
+            f = h5py.File(fn, 'w')
 
         # By default, write out x-array, spectrum, errors
         xarr = f.create_dataset('xarr', data=self.Spectrum.xarr)

--- a/pyspeckit/spectrum/writers/txt_writer.py
+++ b/pyspeckit/spectrum/writers/txt_writer.py
@@ -24,16 +24,23 @@ class write_txt(object):
             # Print header
             print("# Column 1: {0}".format("x-values"), file=f)
             print("# Column 2: {0}".format("model spectrum"), file=f)
-            for i, element in enumerate(self.Spectrum.specfit.modelcomponents):
+            modelcomponents = self.Spectrum.specfit.modelcomponents
+            if modelcomponents is None:
+                modelcomponents = []
+
+            i = -1
+            for i, element in enumerate(modelcomponents):
                 print("# Column {0}: model spectrum component {1}".format(i + 3, i + 1), file=f)
             print("# Column {0}: residuals".format(i + 4), file=f)
             print("", file=f)
 
-            components = zip(*self.Spectrum.specfit.modelcomponents)
+            components = list(zip(*modelcomponents))
             for i, element in enumerate(self.Spectrum.specfit.model):
-                line = "{0:10}{1:10}".format(self.Spectrum.xarr[self.Spectrum.specfit.gx1:self.Spectrum.specfit.gx2][i],
+                # specfit.xmin/xmax are the pixel indices of the fitted region
+                # (formerly named gx1/gx2)
+                line = "{0:10}{1:10}".format(self.Spectrum.xarr[self.Spectrum.specfit.xmin:self.Spectrum.specfit.xmax][i],
                     round(self.Spectrum.specfit.model[i], 5))
-                for j, component in enumerate(components[i]): line += "{0:10}".format(round(component, 5))
+                for j, component in enumerate(components[i] if components else ()): line += "{0:10}".format(round(component, 5))
                 line += "{0:10}".format(round(self.Spectrum.specfit.residuals[i], 5))
 
                 print(line, file=f)


### PR DESCRIPTION
This graduates the still-unmerged fixes from a local audit branch (`fix-legacy-io-plotting`) that systematically exercised long-untested code paths. Everything here crashed unconditionally under Python 3 / modern numpy / scipy / matplotlib / h5py. Parts of that audit already landed via other PRs and are **not** re-included here (see "Dropped as already merged" below).

## Fixes ported

### Readers
- **hdf5_reader.py**: replace removed h5py `Dataset.value` with `[()]`; close the file after reading
- **read_class.py**: replace `ipdb.set_trace()` with `ValueError` when NCHAN is missing; fix undefined `hdr` in `_spectrum_from_header`; don't treat an index-0-only selection as empty in `get_spectra`; append the final scan's spectrumlist in `class_to_obsblocks`; fix `LazyItem.__iter__` (proper generator over `sphdr`) and slice handling (`key.stop`, not the nonexistent `key.end`)
- **read_class_lmv.py**: compare the GILDAS-IMAGE magic against bytes (every file, valid or not, previously raised TypeError)
- **galex.py**: use `classes.Spectrum`/`classes.ObsBlock` (bare names were NameErrors); fix `SpectroscopicAxis` kwarg (`unit='angstrom'`)
- **alfalfa.py**: list-wrap `zip()` results before indexing
- **tspec_reader.py**: drop the long-removed `xtype=`/positional-units `SpectroscopicAxis` call (filetype='tspec' crashed with TypeError on any modern pyspeckit); map IRAF plural unit names (angstroms/microns/nanometers) to the singular forms astropy requires; define `errspec` in the IRAF-reduced branch (previously NameError). Verified against a real TripleSpec file (BD60596_merged.fits): reads 7278 channels, 0.91-2.47 um.

### Writers
- **txt_writer.py**: list-wrap `zip()`; guard empty/None `modelcomponents`; use `specfit.xmin`/`xmax` (`gx1`/`gx2` no longer exist). Reconciled with the atpy removal from #450 (the atpy import is not reintroduced).
- **hdf5_writer.py**: actually open the file in the `overwrite=False` branch (previously `NameError: 'f'`)

### Measurements
- **measurements.py**: list-wrap py2 `zip()` subscripts; integer division in `separate()`; fix misplaced parenthesis in an `np.any()` comparison (`np.any(a) < b` -> `np.any(a < b)`); remove per-component double-counting in `compute_luminosity` — `compute_flux` already sums over components, so multi-component luminosities were overestimated by a factor of n_components

### Units
- **units.py**: repair `SmartCaseNoSpaceDict.has_key` (`dict.has_key__` never existed), `setdefault`/`pop` default forwarding, and `update`/`fromkeys` `__setitem__` calls that passed a spurious `self` argument

### Cosmology
- **cosmology.py**: `scipy.integrate.romberg` was removed in scipy 1.15; use `quad` instead, and raise `ImportError` instead of silently returning 0 when scipy is unavailable

### Plotting / interactive
- **interactive.py**: `clear_all_connections` only recognized callbacks with a `.func` attribute, but matplotlib >= 3 stores weakref-like entries (`cbook._StrongRef` / `weakref.WeakMethod`), so `event_manager` callbacks were never disconnected and every interactive session stacked another set of handlers, letting interactive selections get out of sync. Resolve the weakrefs to find and disconnect them. This may fix #346.
- **plotters.py**: `reset_limits` handles `self.xmin`/`xmax` being `None` or `Quantity` (previously TypeError)
- **mapplot.py**: drop invalid `linestyle='steps-mid'` (no longer a valid linestyle in matplotlib; the plotter already defaults to `drawstyle='steps-mid'`)

## Dropped as already merged
- **gbt.py**: all of the audit branch's fixes (XOR cal-row selection, `functools.reduce`, list-wrapped zip in `find_matched_freqs`, integer division, `Spectrum.slice` kwarg) landed via #430, which additionally added TRGTLONG/DURATION/FREQRES fallbacks — master kept as-is
- **mapplot.py / speclines** ArtistList removal fixes: merged via #437
- **plotters.py** matplotlib key-handler disconnect/reconnect rework: superseded by the newer mpl >= 3.8-aware implementation on master (#414 work)
- **units.py** `refX_unit` property and relativistic velocity formula: master's newer versions are correct and were kept

## Tests
New `pyspeckit/spectrum/tests/test_legacy_io_fixes.py` with five regression tests: cosmology `LuminosityDistance` returns a positive finite Mpc value via `quad`; `SmartCaseNoSpaceDict` update/pop/setdefault/has_key/fromkeys semantics; `compute_luminosity` single-counting; hdf5 writer `overwrite=False` round-trip (through the reader, also exercising the `.value` -> `[()]` fix); and interactive `event_manager` handlers not accumulating across two start/end `specfit(interactive=True)` sessions (2 handlers while active, 0 after cleanup, both sessions). All five fail before these fixes and pass after.

Full suite (`pyspeckit/spectrum/tests`, `cubes/tests`, `models/tests`, `readers/tests`) is green on both a numpy-1.x and a numpy-2.x environment: 2315 passed / 2304 passed (h5py test skips where h5py is absent), 3 skipped, 3 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv