### PR TITLE
Use LaTeX \times10^{} notation instead of e-notation in plot annotations

### DIFF
--- a/pyspeckit/spectrum/annotation_format.py
+++ b/pyspeckit/spectrum/annotation_format.py
@@ -1,0 +1,165 @@
+"""
+Helpers for formatting numeric values (and their uncertainties) as
+matplotlib mathtext for use in plot annotations (fit-parameter legends,
+baseline labels, etc.).
+
+The goal is to avoid computer-style exponential notation like ``1.4e+14``
+or ``4.89e-23`` in plot legends and instead render such values as
+:math:`1.4\\times10^{14}`, which is both prettier and less confusing
+(see issue #337).
+
+All returned strings are valid matplotlib mathtext *without* the
+enclosing dollar signs; callers are expected to wrap them in ``$...$``
+themselves.
+"""
+from __future__ import print_function
+
+import math
+
+import numpy as np
+
+__all__ = ['format_mathtext_value']
+
+# Values whose absolute value falls in [READABLE_MIN, READABLE_MAX) are
+# shown in plain fixed-point notation; everything else uses
+# mantissa \times 10^{exponent} notation.
+READABLE_MIN = 1e-3
+READABLE_MAX = 1e5
+
+# never show more than this many digits after the decimal point
+MAX_DECIMALS = 8
+
+
+def _is_readable(value):
+    """Can ``value`` be displayed in fixed-point notation legibly?"""
+    return value == 0 or (READABLE_MIN <= abs(value) < READABLE_MAX)
+
+
+def _exponent(value):
+    """Base-10 exponent of ``value`` (value must be finite & nonzero)."""
+    return int(math.floor(math.log10(abs(value))))
+
+
+def _decimals_for(reference):
+    """
+    Number of digits to display after the decimal point such that
+    ``reference`` (usually an uncertainty) is shown with two significant
+    figures.  Mirrors the historical ``Decimal(...).quantize('%0.2g')``
+    behavior.
+    """
+    if reference == 0 or not np.isfinite(reference):
+        return 2
+    return min(MAX_DECIMALS, max(0, 1 - _exponent(reference)))
+
+
+def _format_sci(value, sigfig=4):
+    """Format a finite, nonzero value as ``m\\times10^{e}`` mathtext."""
+    exponent = _exponent(value)
+    mantissa = value / 10.**exponent
+    mstr = '{0:.{1}g}'.format(mantissa, sigfig)
+    # rounding can push the mantissa to +/-10; renormalize if so
+    if abs(float(mstr)) >= 10:
+        exponent += 1
+        mantissa = value / 10.**exponent
+        mstr = '{0:.{1}g}'.format(mantissa, sigfig)
+    return '{0}\\times10^{{{1}}}'.format(mstr, exponent)
+
+
+def _format_single(value):
+    """Format a single value (no uncertainty) as mathtext."""
+    if value is None:
+        return '\\mathrm{None}'
+    value = float(value)
+    if np.isnan(value):
+        return '\\mathrm{NaN}'
+    if np.isinf(value):
+        return '\\infty' if value > 0 else '-\\infty'
+    if _is_readable(value):
+        return '{0:.6g}'.format(value)
+    return _format_sci(value)
+
+
+def format_mathtext_value(value, error=None):
+    r"""
+    Format a value and optional symmetric uncertainty as matplotlib
+    mathtext (without enclosing ``$``).
+
+    Values in the "readable" range (``1e-3 <= |v| < 1e5``, or exactly 0)
+    are rendered in fixed-point notation; other values are rendered as
+    ``mantissa\times10^{exponent}``.  When both a value and an error are
+    given and the value requires exponential notation, the shared-exponent
+    form ``(m\pm e)\times10^{exp}`` is used, with the error scaled to the
+    value's exponent.
+
+    Parameters
+    ----------
+    value : float or None
+        The value to format.
+    error : float or None
+        The symmetric 1-sigma uncertainty.  ``None`` or ``0`` means "do
+        not display an uncertainty".
+
+    Returns
+    -------
+    str
+        A valid matplotlib mathtext fragment (no ``$`` delimiters).
+
+    Examples
+    --------
+    >>> print(format_mathtext_value(1.4e14, 5e12))
+    (1.400\pm0.050)\times10^{14}
+    >>> print(format_mathtext_value(0.001423))
+    0.001423
+    >>> print(format_mathtext_value(1.4e-3, 5e-5))
+    0.001400\pm0.000050
+    """
+    if value is None or (np.isscalar(value) and not np.isfinite(value)):
+        # NaN / inf / None values: show them literally; append the error
+        # if one is meaningful
+        valstr = _format_single(value)
+        if error in (None, 0):
+            return valstr
+        return '{0}\\pm{1}'.format(valstr, _format_single(abs(error)))
+
+    value = float(value)
+
+    if error in (None, 0):
+        return _format_single(value)
+
+    error = abs(float(error))
+
+    if not np.isfinite(error):
+        return '{0}\\pm{1}'.format(_format_single(value),
+                                   _format_single(error))
+
+    if _is_readable(value):
+        # the error may be displayed in fixed-point notation even if it is
+        # below READABLE_MIN, as long as it doesn't require more than
+        # MAX_DECIMALS digits after the decimal point
+        error_fixed_ok = (10.**(1 - MAX_DECIMALS) <= error < READABLE_MAX)
+        if error_fixed_ok:
+            # fixed-point for both; the number of displayed digits is set
+            # by the smaller of |value|, error (historical behavior)
+            ref = min(abs(value), error) or max(abs(value), error)
+            dv = _decimals_for(ref)
+            de = _decimals_for(error)
+            return '{0:.{1}f}\\pm{2:.{3}f}'.format(value, dv, error, de)
+        else:
+            # error requires exponential notation but value does not
+            return '{0}\\pm{1}'.format(_format_single(value),
+                                       _format_single(error))
+
+    # value requires exponential notation: use the shared-exponent form
+    # (m \pm e) x 10^{exp} with the error scaled to the value's exponent
+    exponent = _exponent(value)
+    scaled_value = value / 10.**exponent
+    scaled_error = error / 10.**exponent
+    decimals = _decimals_for(scaled_error)
+    # rounding may push the mantissa to +/-10; renormalize if so
+    if abs(round(scaled_value, decimals)) >= 10:
+        exponent += 1
+        scaled_value = value / 10.**exponent
+        scaled_error = error / 10.**exponent
+        decimals = _decimals_for(scaled_error)
+    return '({0:.{2}f}\\pm{1:.{2}f})\\times10^{{{3}}}'.format(
+        scaled_value, scaled_error, decimals, exponent)

--- a/pyspeckit/spectrum/baseline.py
+++ b/pyspeckit/spectrum/baseline.py
@@ -457,13 +457,19 @@ class Baseline(interactive.Interactive):
             print("Baseline wasn't subtracted; not unsubtracting.")
 
     def annotate(self, loc='upper left', fontsize=10):
+        from .annotation_format import format_mathtext_value
         if self.powerlaw:
-            bltext = "bl: $y=%6.3g\\times(x)^{-%6.3g}$" % (self.baselinepars[0],
-                                                           self.baselinepars[1])
+            bltext = "bl: $y=%s\\times(x)^{-%s}$" % (
+                format_mathtext_value(self.baselinepars[0]),
+                format_mathtext_value(self.baselinepars[1]))
         elif self.spline:
             bltext = "bl: spline"
         else:
-            bltext = "bl: $y=$"+"".join(["$%+6.3gx^{%i}$" % (f,self.order-i)
+            def _signed(v):
+                s = format_mathtext_value(v)
+                return s if s.startswith('-') else '+' + s
+            bltext = "bl: $y=$"+"".join(["$%sx^{%i}$" % (_signed(f),
+                                                         self.order-i)
                                          for i,f in
                                          enumerate(self.baselinepars)])
         #self.blleg = text(xloc,yloc     ,bltext,transform = self.Spectrum.plotter.axis.transAxes)

--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -18,6 +18,7 @@ from ..specwarnings import warn
 from . import interactive
 from . import history
 from . import widgets
+from .annotation_format import format_mathtext_value
 
 from pyspeckit.spectrum.units import SpectroscopicAxis
 
@@ -516,11 +517,11 @@ class Specfit(interactive.Interactive):
             self.EQW_plots.append(self.Spectrum.plotter.axis.fill_between(
                 [midpt-eqw/2.0,midpt+eqw/2.0], [0,0],
                 [midpt_level,midpt_level], color=plotcolor, alpha=alpha,
-                label='EQW: %0.3g' % eqw))
+                label='EQW: $%s$' % format_mathtext_value(eqw)))
             if annotate:
                 self.Spectrum.plotter.axis.legend(
                         [(matplotlib.collections.CircleCollection([0],facecolors=[plotcolor],edgecolors=[plotcolor]))],
-                        [('EQW: %0.3g' % eqw)],
+                        [('EQW: $%s$' % format_mathtext_value(eqw))],
                         markerscale=0.01, borderpad=0.1, handlelength=0.1,
                         handletextpad=0.1, loc=loc)
             if self.Spectrum.plotter.autorefresh:

--- a/pyspeckit/spectrum/models/ammonia.py
+++ b/pyspeckit/spectrum/models/ammonia.py
@@ -828,26 +828,22 @@ class ammonia_model(model.SpectralModel):
         return [20,10, 15, 1.0, 0.0, 1.0]
 
     def annotations(self):
-        from decimal import Decimal # for formatting
+        from ..annotation_format import format_mathtext_value
         tex_key = {'trot':'T_R', 'tkin': 'T_K', 'tex':'T_{ex}', 'ntot':'N',
                    'fortho':'F_o', 'width':'\\sigma', 'xoff_v':'v',
                    'logdens':'\\log_{10} n',
                    'fillingfraction':'FF', 'tau':'\\tau_{1-1}',
                    'background_tb':'T_{BG}', 'delta':'T_R-T_{ex}'}
-        # small hack below: don't quantize if error > value.  We want to see the values.
         label_list = []
         for pinfo in self.parinfo:
             parname = tex_key[pinfo['parname'].strip("0123456789").lower()]
             parnum = int(pinfo['parname'][-1])
             if pinfo['fixed']:
-                formatted_value = "%s" % pinfo['value']
-                pm = ""
-                formatted_error=""
+                formatted = format_mathtext_value(pinfo['value'])
             else:
-                formatted_value = Decimal("%g" % pinfo['value']).quantize(Decimal("%0.2g" % (min(pinfo['error'],pinfo['value']))))
-                pm = "$\\pm$"
-                formatted_error = Decimal("%g" % pinfo['error']).quantize(Decimal("%0.2g" % pinfo['error']))
-            label = "$%s(%i)$=%8s %s %8s" % (parname, parnum, formatted_value, pm, formatted_error)
+                formatted = format_mathtext_value(pinfo['value'],
+                                                  pinfo['error'])
+            label = "$%s(%i)$=$%s$" % (parname, parnum, formatted)
             label_list.append(label)
         labels = tuple(mpcb.flatten(label_list))
         return labels

--- a/pyspeckit/spectrum/models/gaussfitter.py
+++ b/pyspeckit/spectrum/models/gaussfitter.py
@@ -220,10 +220,11 @@ class gaussian_fitter(model.SpectralModel):
         return mpp,self.n_gaussian(pars=mpp)(xax),mpperr,chi2
 
     def annotations(self):
+        from ..annotation_format import format_mathtext_value
         label_list = [(
-                "$A(%i)$=%6.4g $\\pm$ %6.4g" % (jj,self.mpp[0+jj*self.npars],self.mpperr[0+jj*self.npars]),
-                "$x(%i)$=%6.4g $\\pm$ %6.4g" % (jj,self.mpp[1+jj*self.npars],self.mpperr[1+jj*self.npars]),
-                "$\\sigma(%i)$=%6.4g $\\pm$ %6.4g" % (jj,self.mpp[2+jj*self.npars],self.mpperr[2+jj*self.npars])
+                "$A(%i)$=$%s$" % (jj, format_mathtext_value(self.mpp[0+jj*self.npars], self.mpperr[0+jj*self.npars])),
+                "$x(%i)$=$%s$" % (jj, format_mathtext_value(self.mpp[1+jj*self.npars], self.mpperr[1+jj*self.npars])),
+                "$\\sigma(%i)$=$%s$" % (jj, format_mathtext_value(self.mpp[2+jj*self.npars], self.mpperr[2+jj*self.npars]))
                           ) for jj in range(self.npeaks)]
         labels = tuple(mpcb.flatten(label_list))
         return labels

--- a/pyspeckit/spectrum/models/model.py
+++ b/pyspeckit/spectrum/models/model.py
@@ -683,7 +683,7 @@ class SpectralModel(fitter.SimpleFitter):
         >>> # Annotate a Gaussian
         >>> sp.specfit.annotate(shortvarnames=['A','\\Delta x','\\sigma'])
         """
-        from decimal import Decimal # for formatting
+        from ..annotation_format import format_mathtext_value
         svn = self.shortvarnames if shortvarnames is None else shortvarnames
         # if pars need to be replicated....
         if len(svn) < self.npeaks*self.npars:
@@ -705,12 +705,11 @@ class SpectralModel(fitter.SimpleFitter):
             if None in (value, error):
                 label = "{0}({1})=None".format(varname, varnumber)
             elif fixed or error==0:
-                label = ("$%s(%i)$=%8s" % (varname, varnumber,
-                        Decimal("%g" % value).quantize(Decimal("%0.6g" % (value)))))
+                label = ("$%s(%i)$=$%s$" % (varname, varnumber,
+                                            format_mathtext_value(value)))
             else:
-                label = ("$%s(%i)$=%8s $\\pm$ %8s" % (varname, varnumber,
-                    Decimal("%g" % value).quantize(Decimal("%0.2g" % (min(np.abs([value,error]))))),
-                    Decimal("%g" % error).quantize(Decimal("%0.2g" % (error))),))
+                label = ("$%s(%i)$=$%s$" % (varname, varnumber,
+                                            format_mathtext_value(value, error)))
             label_list.append(label)
 
         labels = tuple(mpcb.flatten(label_list))

--- a/pyspeckit/spectrum/tests/test_annotation_format.py
+++ b/pyspeckit/spectrum/tests/test_annotation_format.py
@@ -1,0 +1,193 @@
+"""
+Tests for the mathtext annotation formatter (issue #337): plot legends
+should show 1.4\\times10^{14} instead of 1.4e+14.
+"""
+import matplotlib
+matplotlib.use('Agg')
+
+import re
+
+import numpy as np
+import pytest
+from astropy import units as u
+
+from ..annotation_format import format_mathtext_value
+from ..classes import Spectrum, units as spunits
+from ..models import ammonia, ammonia_constants
+
+# matches computer-style exponents like 'e+14', 'E-23', 'e5'
+E_NOTATION = re.compile(r'[eE][-+]?\d')
+
+
+def assert_no_e_notation(text):
+    assert not E_NOTATION.search(text), \
+        "found e-notation in {0!r}".format(text)
+
+
+class TestFormatMathtextValue(object):
+
+    def test_readable_value_stays_fixed_point(self):
+        assert format_mathtext_value(3.05) == '3.05'
+        assert format_mathtext_value(0.001423) == '0.001423'
+        assert format_mathtext_value(99999.0) == '99999'
+        assert format_mathtext_value(0) == '0'
+        assert format_mathtext_value(-42.5) == '-42.5'
+
+    def test_large_value_uses_times_ten(self):
+        out = format_mathtext_value(1.4e14)
+        assert out == '1.4\\times10^{14}'
+        assert_no_e_notation(out)
+
+    def test_small_value_uses_times_ten(self):
+        out = format_mathtext_value(4.89e-23)
+        assert out == '4.89\\times10^{-23}'
+        assert_no_e_notation(out)
+
+    def test_negative_value_uses_times_ten(self):
+        out = format_mathtext_value(-4.95e-19)
+        assert out == '-4.95\\times10^{-19}'
+        assert_no_e_notation(out)
+
+    def test_shared_exponent_error_form(self):
+        out = format_mathtext_value(1.4e14, 5e12)
+        assert out == '(1.400\\pm0.050)\\times10^{14}'
+        assert_no_e_notation(out)
+
+    def test_shared_exponent_negative_value(self):
+        out = format_mathtext_value(-1.4e14, 5e12)
+        assert out == '(-1.400\\pm0.050)\\times10^{14}'
+        assert_no_e_notation(out)
+
+    def test_readable_value_with_error(self):
+        out = format_mathtext_value(4.9, 0.3)
+        # two significant figures on the uncertainty
+        assert out == '4.90\\pm0.30'
+        assert_no_e_notation(out)
+
+    def test_error_none_and_zero(self):
+        assert format_mathtext_value(1.4e14, None) == '1.4\\times10^{14}'
+        assert format_mathtext_value(1.4e14, 0) == '1.4\\times10^{14}'
+        assert format_mathtext_value(5.0, None) == '5'
+        assert format_mathtext_value(5.0, 0) == '5'
+
+    def test_value_none(self):
+        assert format_mathtext_value(None) == '\\mathrm{None}'
+
+    def test_nan_inf_do_not_crash(self):
+        for v in (np.nan, np.inf, -np.inf):
+            out = format_mathtext_value(v)
+            assert isinstance(out, str)
+            out = format_mathtext_value(v, 1.0)
+            assert isinstance(out, str)
+        out = format_mathtext_value(1.0, np.nan)
+        assert isinstance(out, str)
+        out = format_mathtext_value(1.0, np.inf)
+        assert isinstance(out, str)
+
+    def test_mantissa_rounds_to_ten(self):
+        # 9.999e4 -> rounding pushes the mantissa to 10; must renormalize
+        out = format_mathtext_value(9.99999e5)
+        assert out == '1\\times10^{6}'
+        assert_no_e_notation(out)
+
+    @pytest.mark.parametrize('value,error',
+                             [(1.4e14, 5e12), (4.89e-23, 1e-25),
+                              (-4.95e-19, 3e-21), (3.05e-15, None),
+                              (0.0, 0.1), (12.5, 0.02), (np.nan, 1.0),
+                              (1e7, 250.), (-99999.0, 1e-7)])
+    def test_output_is_valid_mathtext(self, value, error):
+        """every output must parse as matplotlib mathtext"""
+        from matplotlib.mathtext import MathTextParser
+        parser = MathTextParser('agg')
+        out = format_mathtext_value(value, error)
+        assert_no_e_notation(out)
+        parser.parse('$' + out + '$', dpi=72)
+
+
+def get_legend_texts(sp):
+    texts = []
+    for legend in sp.plotter.axis.findobj(matplotlib.legend.Legend):
+        texts += [t.get_text() for t in legend.get_texts()]
+    return texts
+
+
+def test_gaussian_annotation_renders():
+    """
+    Fit a Gaussian with a huge amplitude, annotate, and force a draw:
+    matplotlib raises on invalid mathtext at draw time.
+    """
+    import matplotlib.pyplot as plt
+    plt.close('all')
+
+    np.random.seed(42)
+    x = np.linspace(-50, 50, 201)
+    amp = 1.4e14
+    data = amp * np.exp(-x**2 / (2 * 5.0**2)) + np.random.randn(201) * amp/100
+
+    sp = Spectrum(xarr=spunits.SpectroscopicAxis(x, unit='km/s'), data=data)
+    sp.plotter()
+    sp.specfit(fittype='gaussian', guesses=[amp, 0, 5], annotate=True)
+    sp.plotter.figure.canvas.draw()
+
+    texts = get_legend_texts(sp)
+    assert len(texts) > 0
+    joined = "\n".join(texts)
+    assert '\\times10^{' in joined
+    assert 'e+' not in joined and 'E+' not in joined
+    assert_no_e_notation(joined)
+    plt.close('all')
+
+
+def test_ammonia_annotation_renders():
+    """
+    ammonia_model.annotations is a separate implementation; make sure it
+    also produces drawable, e-notation-free labels.
+    """
+    import matplotlib.pyplot as plt
+    plt.close('all')
+
+    velo = u.Quantity(np.linspace(-25, 25, 251), u.km/u.s)
+    cfrq = ammonia_constants.freq_dict['oneone'] * u.Hz
+    frq = velo.to(u.GHz, u.doppler_radio(cfrq))
+    xarr = spunits.SpectroscopicAxis(frq, refX=cfrq)
+    data = ammonia.ammonia(xarr, tex=25, trot=25, width=0.5, ntot=13,
+                           xoff_v=0.0)
+    sp = Spectrum(xarr=xarr, data=data)
+    sp.plotter()
+    sp.specfit(fittype='ammonia', guesses=[23, 22, 13.1, 1, 0.5, 0],
+               fixed=[False, False, False, False, False, True],
+               annotate=True)
+    sp.plotter.figure.canvas.draw()
+
+    texts = get_legend_texts(sp)
+    assert len(texts) > 0
+    joined = "\n".join(texts)
+    assert 'e+' not in joined and 'E+' not in joined
+    assert_no_e_notation(joined)
+    plt.close('all')
+
+
+def test_baseline_annotation_renders():
+    """
+    The issue #337 screenshot came from the baseline annotation
+    (y=+4.89e-23x^2...); make sure it now renders as \\times10^{} form.
+    """
+    import matplotlib.pyplot as plt
+    plt.close('all')
+
+    np.random.seed(0)
+    # frequency-like x axis with huge values -> tiny polynomial coefficients
+    x = np.linspace(2.15e9, 2.35e9, 200)
+    data = 4.89e-23*x**2 - 4.95e-19*x + 3.05e-15 + np.random.randn(200)*1e-6
+
+    sp = Spectrum(xarr=spunits.SpectroscopicAxis(x, unit='Hz'), data=data)
+    sp.plotter()
+    sp.baseline(order=2, annotate=True, subtract=False)
+    sp.plotter.figure.canvas.draw()
+
+    texts = get_legend_texts(sp)
+    joined = "\n".join(texts)
+    assert '\\times10^{' in joined
+    assert 'e+' not in joined and 'E+' not in joined
+    assert_no_e_notation(joined)
+    plt.close('all')


### PR DESCRIPTION
Plot legend annotations previously used computer-style scientific notation ('1.402E+14', '+4.89e-23') inside mathtext labels, which is what prompted the confusion in #337 (the reporter couldn't parse `y=+4.89e-23x^2-4.95e-19x^1+3.05e-15x^0`).

## What changed

New shared helper `pyspeckit/spectrum/annotation_format.py::format_mathtext_value(value, error=None)`:

- values in a readable range (`1e-3 <= |v| < 1e5`, and 0) stay fixed-point
- other values render as `mantissa\times10^{exponent}`
- value+error pairs needing exponential notation use the shared-exponent form `(1.402\pm0.052)\times10^{14}`
- `None`, zero error, negatives, NaN, and inf are handled without crashing; every output is valid matplotlib mathtext (no `e+`/`E+` ever)

Wired into every annotation-formatting site:

- `SpectralModel.annotations` (`models/model.py`)
- `ammonia_model.annotations` (`models/ammonia.py`)
- legacy `gaussian_fitter.annotations` (`models/gaussfitter.py`)
- `Baseline.annotate` (`baseline.py` — the site shown in the issue screenshot)
- EQW legend labels (`fitters.py`)

## Before / after

Gaussian amplitude annotation:

| before | after |
|---|---|
| `$A(0)$=1.402E+14 $\pm$  5.2E+12` | `$A(0)$=$(1.402\pm0.052)\times10^{14}$` |

Baseline polynomial annotation (the issue #337 label):

| before | after |
|---|---|
| `bl: $y=$$+4.89e-23x^{2}$$-4.95e-19x^{1}$$+3.05e-15x^{0}$` | `bl: $y=$$+4.89\times10^{-23}x^{2}$$-4.95\times10^{-19}x^{1}$$+3.05\times10^{-15}x^{0}$` |

## Testing

`pyspeckit/spectrum/tests/test_annotation_format.py` (23 tests): unit tests of the helper (readable range, shared-exponent form, None/0/negative/NaN/inf, mantissa-rounds-to-10 renormalization, mathtext parser validation of every output), plus end-to-end Agg-backend tests that fit a Gaussian with amplitude ~1.4e14, an ammonia synthetic spectrum, and a polynomial baseline with ~1e-23 coefficients, call annotate, force `canvas.draw()` (matplotlib raises on invalid mathtext at draw), and assert the legend texts contain `\times10^{` and no `e+`/`E+`.

Full `pyspeckit/spectrum/tests/` + `pyspeckit/spectrum/models/tests/` suites pass on both numpy 1.x and numpy 2 environments (2323 passed / 2312 passed), and `cubes`/`readers` tests pass.

Fixes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv
