### PR TITLE
Add cold_ammonia_model_restricted_tex: restricted-tex fitting in terms of tkin

### DIFF
--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -134,6 +134,10 @@ The default is gaussian ('g'), all options are listed below:
 default_Registry = Registry()
 default_Registry.add_fitter('ammonia',models.ammonia_model(),6,key='a')
 default_Registry.add_fitter('cold_ammonia',models.ammonia.cold_ammonia_model(),6)
+default_Registry.add_fitter('ammonia_restricted_tex',
+                            models.ammonia.ammonia_model_restricted_tex(), 7)
+default_Registry.add_fitter('cold_ammonia_restricted_tex',
+                            models.ammonia.cold_ammonia_model_restricted_tex(), 7)
 default_Registry.add_fitter('ammonia_tau',models.ammonia_model_vtau(),6)
 default_Registry.add_fitter('ammonia15n',models.ammonia15n_model(),6)
 # not implemented default_Registry.add_fitter(Registry,'ammonia',models.ammonia_model( ),6, ,key='A')

--- a/pyspeckit/spectrum/models/ammonia.py
+++ b/pyspeckit/spectrum/models/ammonia.py
@@ -290,6 +290,19 @@ def ammonia(xarr, trot=20, tex=None, ntot=14, width=1, xoff_v=0.0, fortho=0.0,
 
     return model_spectrum
 
+def tkin_to_trot(tkin):
+    """
+    Convert kinetic temperature to (1,1)-(2,2) rotational temperature
+    following the scheme of Swift et al 2005
+    (http://esoads.eso.org/abs/2005ApJ...620..823S, eqn A6) and further
+    discussed in Equation 7 of Rosolowsky et al 2008
+    (http://adsabs.harvard.edu/abs/2008ApJS..175..509R)
+    """
+    dT0 = 41.18 # Energy difference between (2,2) and (1,1) in K
+    trot = tkin * (1 + (tkin/dT0)*np.log(1 + 0.6*np.exp(-15.7/tkin)))**-1
+    return trot
+
+
 def cold_ammonia(xarr, tkin, **kwargs):
     """
     Generate a model Ammonia spectrum based on input temperatures, column, and
@@ -307,8 +320,7 @@ def cold_ammonia(xarr, tkin, **kwargs):
         (http://adsabs.harvard.edu/abs/2008ApJS..175..509R)
     """
 
-    dT0 = 41.18 # Energy difference between (2,2) and (1,1) in K
-    trot = tkin * (1 + (tkin/dT0)*np.log(1 + 0.6*np.exp(-15.7/tkin)))**-1
+    trot = tkin_to_trot(tkin)
     log.debug("Cold ammonia turned T_K = {0} into T_rot = {1}".format(tkin,trot))
 
     return ammonia(xarr, trot=trot, **kwargs)
@@ -1238,15 +1250,28 @@ class ammonia_model_restricted_tex(ammonia_model):
     """
     Ammonia model with an explicitly restricted excitation temperature
     such that tex <= trot, set by the "delta" parameter (tex = trot - delta)
-    with delta > 0.  You can choose the ammonia funciton when you initialize
-    it (e.g., ``ammonia_model_restricted_tex(ammonia_func=ammonia)`` or
-    ``ammonia_model_restricted_tex(ammonia_func=cold_ammonia)``)
+    with delta > 0.
+
+    The restriction is enforced through the mpfit ``tied`` mechanism (the
+    default 'tied' string is ``p[0]-p[6]``, i.e., tex = trot - delta), which
+    only works because ``trot`` is itself a fit parameter.  For the
+    `cold_ammonia` variant, where the fitted parameter is the *kinetic*
+    temperature and trot is a nonlinear function of tkin, use
+    `cold_ammonia_model_restricted_tex` instead; passing
+    ``ammonia_func=cold_ammonia`` here will not work.
     """
     def __init__(self,
                  parnames=['trot', 'tex', 'ntot', 'width', 'xoff_v', 'fortho',
                            'delta'],
                  ammonia_func=ammonia,
                  **kwargs):
+        if ammonia_func is cold_ammonia:
+            raise ValueError("ammonia_model_restricted_tex does not support "
+                             "ammonia_func=cold_ammonia: the tex = trot - "
+                             "delta restriction must be applied to the "
+                             "rotational temperature derived (nonlinearly) "
+                             "from tkin.  Use "
+                             "cold_ammonia_model_restricted_tex instead.")
         super(ammonia_model_restricted_tex, self).__init__(npars=7,
                                                            parnames=parnames,
                                                            **kwargs)
@@ -1324,6 +1349,136 @@ class ammonia_model_restricted_tex(ammonia_model):
         'delta' is the difference between tex and trot
         """
         supes = super(ammonia_model_restricted_tex, self)
+        return supes.make_parinfo(params=params, fixed=fixed,
+                                  limitedmax=limitedmax, limitedmin=limitedmin,
+                                  minpars=minpars, maxpars=maxpars, tied=tied,
+                                  **kwargs)
+
+
+# 'tied' string enforcing tex = trot(tkin) - delta for
+# cold_ammonia_model_restricted_tex, where trot(tkin) is the Swift et al 2005
+# conversion (this must stay numerically identical to `tkin_to_trot`).
+# mpfit evaluates 'tied' strings with `exec` in a scope where the `numpy`
+# module is available.  Note that only the bracketed parameter indices
+# (p[0], p[6]) are re-indexed for multi-peak fits by
+# `_increment_string_number`; the numeric constants are left untouched.
+_cold_restricted_tex_tied = ('p[0] * (1 + (p[0]/41.18)'
+                             '*numpy.log(1 + 0.6*numpy.exp(-15.7/p[0])))**-1'
+                             ' - p[6]')
+
+
+class cold_ammonia_model_restricted_tex(ammonia_model):
+    """
+    Cold-ammonia model (kinetic temperature fit parameter, converted to
+    rotational temperature via the Swift et al 2005 approximation as in
+    `cold_ammonia`) with an explicitly restricted excitation temperature
+    such that tex <= trot, set by the "delta" parameter
+    (tex = trot(tkin) - delta) with delta >= 0.
+
+    Because trot is a nonlinear function of tkin, the restriction cannot be
+    expressed as the simple linear 'tied' string used by
+    `ammonia_model_restricted_tex`; instead the default 'tied' string
+    encodes the full tkin->trot conversion, and `n_ammonia` additionally
+    re-enforces tex = trot(tkin) - delta on every model evaluation.
+    (see https://github.com/pyspeckit/pyspeckit/issues/368 and
+    https://github.com/pyspeckit/pyspeckit/issues/307)
+
+    Note that ``tkin >= tkin_min`` and ``delta >= 0`` do not by themselves
+    guarantee ``tex >= TCMB``; if the fitter wanders into a corner of
+    parameter space where trot(tkin) - delta < TCMB, the underlying
+    `ammonia` model may raise an error about the model dropping below zero.
+    Setting an upper limit on delta (``limitedmax``/``maxpars``) such that
+    ``trot(tkin_min) - delta_max >= TCMB`` avoids that corner.
+    """
+    def __init__(self,
+                 parnames=['tkin', 'tex', 'ntot', 'width', 'xoff_v', 'fortho',
+                           'delta'],
+                 **kwargs):
+        super(cold_ammonia_model_restricted_tex, self).__init__(
+            npars=7, parnames=parnames, **kwargs)
+
+        def cold_ammonia_dtex(*args, **kwargs):
+            """
+            Strip out the 'delta' keyword and verify tex = trot(tkin) - delta
+            """
+            # for py2 compatibility, must strip out manually
+            delta = kwargs.pop('delta') if 'delta' in kwargs else None
+            trot = tkin_to_trot(kwargs['tkin'])
+            try:
+                np.testing.assert_allclose(trot - kwargs['tex'], delta)
+            except AssertionError:
+                raise ValueError(
+                    'trot(tkin) - tex != delta, even though that was '
+                    'specified.  If you overrode the default `tied` '
+                    'parameter setting, make sure it enforces '
+                    'tex = trot(tkin) - delta (a linear tie like '
+                    "'p[0]-p[6]' does NOT, because trot is a nonlinear "
+                    'function of tkin).  '
+                    f"tkin={kwargs['tkin']}, trot={trot}, "
+                    f"tex={kwargs['tex']}, delta={delta}, "
+                    f"trot-tex={trot - kwargs['tex']}")
+            return cold_ammonia(*args, **kwargs)
+        self.modelfunc = cold_ammonia_dtex
+
+    def n_ammonia(self, pars=None, parnames=None, **kwargs):
+        if parnames is not None:
+            for ii,pn in enumerate(parnames):
+                if ii % 7 == 1 and 'tex' not in pn:
+                    raise ValueError('bad parameter names')
+                if ii % 7 == 6 and 'delta' not in pn:
+                    raise ValueError('bad parameter names')
+        if pars is not None:
+            assert len(pars) % 7 == 0
+            for ii in range(int(len(pars)/7)):
+                try:
+                    # Case A: they're param objects
+                    # (setting the param directly can result in recursion errors)
+                    pars[1+ii*7].value = (tkin_to_trot(pars[0+ii*7].value)
+                                          - pars[6+ii*7].value)
+                except AttributeError:
+                    # Case B: they're just lists of values
+                    pars[1+ii*7] = tkin_to_trot(pars[0+ii*7]) - pars[6+ii*7]
+
+        supes = super(cold_ammonia_model_restricted_tex, self)
+        return supes.n_ammonia(pars=pars, parnames=parnames, **kwargs)
+
+    def _validate_parinfo(self,
+                          must_be_limited={'tkin': [True,False],
+                                           'tex': [False,False],
+                                           'ntot': [True, False],
+                                           'width': [True, False],
+                                           'xoff_v': [False, False],
+                                           'fortho': [True, True],
+                                           'delta': [True, False],
+                                          },
+                          required_limits={'tkin': [0, None],
+                                           'tex': [None,None],
+                                           'width': [0, None],
+                                           'ntot': [0, None],
+                                           'xoff_v': [None,None],
+                                           'fortho': [0,1],
+                                           'delta': [0, None],
+                                          }):
+        supes = super(cold_ammonia_model_restricted_tex, self)
+        return supes._validate_parinfo(must_be_limited=must_be_limited,
+                                       required_limits=required_limits)
+
+    def make_parinfo(self,
+                     params=(20,20,14,1.0,0.0,0.5,0),
+                     fixed=(False,False,False,False,False,False,False),
+                     limitedmin=(True,True,True,True,False,True,True),
+                     limitedmax=(False,False,False,False,False,True,False),
+                     minpars=(TCMB,TCMB,0,0,0,0,0),
+                     maxpars=(0,0,0,0,0,1,0),
+                     tied=('',_cold_restricted_tex_tied,'','','','',''),
+                     **kwargs
+                     ):
+        """
+        parnames=['tkin', 'tex', 'ntot', 'width', 'xoff_v', 'fortho', 'delta']
+
+        'delta' is the difference between trot (derived from tkin) and tex
+        """
+        supes = super(cold_ammonia_model_restricted_tex, self)
         return supes.make_parinfo(params=params, fixed=fixed,
                                   limitedmax=limitedmax, limitedmin=limitedmin,
                                   minpars=minpars, maxpars=maxpars, tied=tied,

--- a/pyspeckit/spectrum/models/tests/test_ammonia.py
+++ b/pyspeckit/spectrum/models/tests/test_ammonia.py
@@ -222,3 +222,95 @@ def test_ammonia_guessing():
     assert rslt == [3.73*2, 3.73, 15, 'wid1', 'cen1', 0.5,
                     4.73*2, 4.73, 15, 'wid2', 'cen2', 0.5,
                    ]
+
+
+def make_synthspec_cold_restricted(tkin=15., delta=3., column=14.5, width=0.5,
+                                   vcens=(0.0,), lines=('oneone', 'twotwo')):
+    """
+    Synthetic cold-ammonia spectrum with tex = trot(tkin) - delta
+    (regression data for github issues #368 / #307)
+    """
+    trot = ammonia.tkin_to_trot(tkin)
+    velo = u.Quantity(np.linspace(-25, 25, 501), u.km/u.s)
+
+    spectra_list = []
+    for line in lines:
+        cfrq = ammonia_constants.freq_dict[line]*u.Hz
+        frq = velo.to(u.GHz, u.doppler_radio(cfrq))
+        xarr = units.SpectroscopicAxis(frq, refX=cfrq)
+        data = np.zeros(xarr.size)
+        for vcen in vcens:
+            data = data + ammonia.ammonia(xarr, trot=trot, tex=trot-delta,
+                                          width=width, ntot=column,
+                                          xoff_v=vcen)
+        spectra_list.append(Spectrum(xarr=xarr, data=data))
+
+    return Spectra(spectra_list)
+
+
+def test_cold_ammonia_restricted_tex():
+    """
+    Regression test for github issue #368 (and #307): fitting a
+    restricted-tex (tex = trot - delta) model in terms of the kinetic
+    temperature requires the nonlinear Swift tkin->trot conversion inside
+    the tie; a linear 'p[0]-p[6]' tie cannot express it.
+    """
+    tkin, delta = 15., 3.
+    tex = ammonia.tkin_to_trot(tkin) - delta
+
+    spc = make_synthspec_cold_restricted(tkin=tkin, delta=delta)
+    spc.specfit(fittype='cold_ammonia_restricted_tex',
+                guesses=[12, 8, 14.0, 0.6, 0.5, 0.6, 2.0])
+
+    pv = spc.specfit.parinfo.values
+    assert np.isclose(pv[0], tkin, atol=0.05)   # tkin
+    assert np.isclose(pv[6], delta, atol=0.05)  # delta
+    # tex must equal trot(tkin) - delta, NOT tkin - delta
+    assert np.isclose(pv[1], tex, atol=0.05)
+    assert np.isclose(pv[1], ammonia.tkin_to_trot(pv[0]) - pv[6], atol=1e-6)
+
+    # the delta >= 0 limit (tex <= trot) must be in place
+    delta_par = spc.specfit.parinfo['delta0']
+    assert delta_par['limited'][0]
+    assert delta_par['limits'][0] == 0
+    assert delta_par['value'] >= 0
+
+
+def test_cold_ammonia_restricted_tex_twopeak():
+    """
+    Two-peak version of the issue #368 regression test: per-peak tied
+    strings must be re-indexed (p[0]->p[7], p[6]->p[13]) without mangling
+    the numeric constants of the Swift conversion.
+    """
+    tkin, delta = 15., 3.
+    tex = ammonia.tkin_to_trot(tkin) - delta
+
+    spc = make_synthspec_cold_restricted(tkin=tkin, delta=delta,
+                                         vcens=(0.0, 5.0))
+    spc.specfit(fittype='cold_ammonia_restricted_tex',
+                guesses=[12, 8, 14.0, 0.6, 0.5, 0.6, 2.0,
+                         12, 8, 14.0, 0.6, 5.5, 0.6, 2.0])
+
+    pv = spc.specfit.parinfo.values
+    for offset, vcen in zip((0, 7), (0.0, 5.0)):
+        assert np.isclose(pv[offset+0], tkin, atol=0.1)
+        assert np.isclose(pv[offset+6], delta, atol=0.1)
+        assert np.isclose(pv[offset+1], tex, atol=0.1)
+        assert np.isclose(pv[offset+4], vcen, atol=0.1)
+
+
+def test_cold_ammonia_restricted_tex_delta_zero():
+    """
+    A spectrum generated with tex = trot (delta = 0) must be recoverable
+    and the fitted delta must honor the delta >= 0 limit.
+    """
+    tkin = 15.
+
+    spc = make_synthspec_cold_restricted(tkin=tkin, delta=0.)
+    spc.specfit(fittype='cold_ammonia_restricted_tex',
+                guesses=[12, 10, 14.0, 0.6, 0.5, 0.6, 1.0])
+
+    pv = spc.specfit.parinfo.values
+    assert np.isclose(pv[0], tkin, atol=0.05)
+    assert pv[6] >= 0
+    assert np.isclose(pv[6], 0, atol=0.05)

--- a/pyspeckit/spectrum/models/tests/test_regressions.py
+++ b/pyspeckit/spectrum/models/tests/test_regressions.py
@@ -70,6 +70,42 @@ def test_ammonia_restricted_tex_multipeak_tied():
     assert parinfo1.tied == ['', 'p[0]-p[6]', '', '', '', '', '']
 
 
+def test_cold_ammonia_restricted_tex_multipeak_tied():
+    """
+    Issue #368: the cold-ammonia restricted-tex tie encodes the nonlinear
+    Swift tkin->trot conversion, so its 'tied' string contains numeric
+    constants (41.18, 0.6, 15.7).  Multi-peak re-indexing must bump only
+    the bracketed parameter indices, not those constants.
+    """
+    tie0 = ammonia._cold_restricted_tex_tied
+    tie1 = ammonia._increment_string_number(tie0, 7)
+
+    mod = ammonia.cold_ammonia_model_restricted_tex()
+    parinfo = mod.make_parinfo(npeaks=2,
+                               params=(20, 20, 14, 1.0, 0.0, 0.5, 0)*2)
+    assert parinfo.tied == ['', tie0, '', '', '', '', '',
+                            '', tie1, '', '', '', '', '']
+
+    # the second peak ties tex1 to tkin1 (p[7]) and delta1 (p[13]) ...
+    assert 'p[7]' in tie1 and 'p[13]' in tie1
+    # ... and the Swift-conversion constants must be untouched
+    for constant in ('41.18', '0.6', '15.7'):
+        assert constant in tie1
+
+
+def test_ammonia_restricted_tex_rejects_cold_ammonia_func():
+    """
+    Issue #368: ammonia_model_restricted_tex(ammonia_func=cold_ammonia)
+    was advertised by the docstring but could never work (it crashed with
+    TypeError/KeyError deep in the fit); it must now fail up front with a
+    pointer to cold_ammonia_model_restricted_tex.
+    """
+    import pytest
+    with pytest.raises(ValueError) as ex:
+        ammonia.ammonia_model_restricted_tex(ammonia_func=ammonia.cold_ammonia)
+    assert 'cold_ammonia_model_restricted_tex' in str(ex.value)
+
+
 def test_normalized_gaussian_integral():
     """
     The normalized Gaussian used to divide by width**2 instead of width,


### PR DESCRIPTION
## Summary

Issues #368 and #307 both report crashes when combining the restricted-tex ammonia model (`tex = trot - delta`, `delta >= 0`) with the `cold_ammonia` (Swift et al. 2005 tkin→trot) variant:

> ```
> Not equal to tolerance rtol=1e-07, atol=0
> Mismatched elements: 1 / 1 (100%)
>  x: array(1.722286)
>  y: array(2.)
> ```

**Root cause:** the docstring of `ammonia_model_restricted_tex` advertised `ammonia_model_restricted_tex(ammonia_func=cold_ammonia)`, but that crashes immediately (`TypeError: cold_ammonia() missing 1 required positional argument: 'tkin'`, since the parnames stay `trot,...`). The workaround both reporters attempted — renaming the first parameter to `tkin` while keeping the linear tied string `'p[0]-p[6]'` — cannot work either: the tie enforces `tex = tkin - delta`, while the model requires `tex = trot(tkin) - delta`, and trot is a **nonlinear** function of tkin. The internal consistency assertion then fails with exactly the `rtol=1e-07` mismatches quoted in both issues.

## Changes

- Factor the Swift et al. 2005 conversion out of `cold_ammonia` into a module-level `tkin_to_trot` helper.
- Add **`cold_ammonia_model_restricted_tex`** with parnames `(tkin, tex, ntot, width, xoff_v, fortho, delta)`. Its default `tied` string encodes the full nonlinear tkin→trot conversion (mpfit evaluates tied strings with `exec`, with `numpy` in scope), and its `n_ammonia` re-enforces `tex = trot(tkin) - delta` on every model evaluation. Multi-peak re-indexing is safe because `_increment_string_number` (since #425) only increments bracketed parameter indices, leaving the numeric constants (41.18, 0.6, 15.7) of the conversion untouched: `p[0] ... - p[6]` → `p[7] ... - p[13]`.
- Make `ammonia_model_restricted_tex(ammonia_func=cold_ammonia)` fail up front with a `ValueError` pointing at the new class, and correct the misleading docstring.
- Register `'ammonia_restricted_tex'` and `'cold_ammonia_restricted_tex'` in the default fitter `Registry` so `Spectrum.specfit`/`Cube.fiteach` users no longer need to hand-register them (both issue reporters had to).

## Tests

- 1-peak and 2-peak synthetic-spectrum fits recover known `tkin`/`delta` and satisfy `tex == trot(tkin) - delta` (not `tkin - delta`).
- `delta >= 0` limit honored, including a `delta == 0` (LTE-like, tex = trot) spectrum.
- Multi-peak `tied`-string re-indexing of the nonlinear tie.
- The new up-front `ValueError` for `ammonia_func=cold_ammonia`.

Validated in both test environments (numpy 1.x and numpy 2): `pytest pyspeckit/spectrum/models/tests/ pyspeckit/spectrum/tests/ pyspeckit/cubes/tests/ pyspeckit/spectrum/readers/tests/` fully green (2305 passed / 2294 passed respectively, plus 23 cube/reader tests each).

Fixes #368
Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv
