### PR TITLE
Fix TypeError when npeaks is passed as a keyword to specfit

### DIFF
--- a/pyspeckit/spectrum/fitters.py
+++ b/pyspeckit/spectrum/fitters.py
@@ -716,7 +716,37 @@ class Specfit(interactive.Interactive):
         if len(guesses) < self.Registry.npars[self.fittype]:
             raise ValueError("Too few parameters input.  Need at least %i for %s models" % (self.Registry.npars[self.fittype],self.fittype))
 
-        self.npeaks = len(guesses)//self.Registry.npars[self.fittype]
+        # If npeaks was specified as a keyword, remove it from the kwarg dicts
+        # (it would otherwise be passed a second time - in addition to
+        # npeaks=self.npeaks - to _make_parinfo and the fitter below, raising
+        # a TypeError) and reconcile it with the number of guesses provided.
+        # Note that self.fitkwargs and kwargs may or may not be the same
+        # dictionary object depending on the call path, so both are cleaned.
+        npars = self.Registry.npars[self.fittype]
+        npeaks_kwarg = kwargs.pop('npeaks', None)
+        fitkwargs_npeaks = self.fitkwargs.pop('npeaks', None)
+        if npeaks_kwarg is None:
+            npeaks_kwarg = fitkwargs_npeaks
+
+        self.npeaks = len(guesses)//npars
+
+        if npeaks_kwarg is not None and int(npeaks_kwarg) != self.npeaks:
+            npeaks_kwarg = int(npeaks_kwarg)
+            if len(guesses) == npars and npeaks_kwarg > 1:
+                # a single component's worth of guesses was given; replicate
+                # them for each peak (consistent with the behavior of
+                # make_parinfo when npeaks > 1)
+                guesses = list(guesses) * npeaks_kwarg
+                self.npeaks = npeaks_kwarg
+            else:
+                raise ValueError("npeaks={0} was specified, but {1} guesses "
+                                 "were provided for a model with {2} "
+                                 "parameters per component.  Provide either "
+                                 "{2} guesses (they will be replicated for "
+                                 "each peak) or {2}*npeaks={3} guesses."
+                                 .format(npeaks_kwarg, len(guesses), npars,
+                                         npars*npeaks_kwarg))
+
         self.fitter = self.Registry.multifitters[self.fittype]
         self.vheight = False
         if self.fitter.vheight:

--- a/pyspeckit/spectrum/models/tests/test_ammonia.py
+++ b/pyspeckit/spectrum/models/tests/test_ammonia.py
@@ -207,6 +207,99 @@ spc5.plotter(axis=spc3.plotter.axis, color='r', clear=False)
 spc4.plotter(axis=spc3.plotter.axis, color='b', clear=False)
 """
 
+def make_2comp_synthspec():
+    kwargs = dict(lte=False, tkin=None, lines=('oneone', 'twotwo'))
+    redhot = dict(trot=25, tex=10, column=13, width=1, vcen=1)
+    bluecold = dict(trot=12, tex=7, column=13, width=.2, vcen=-1)
+    redhot.update(kwargs)
+    bluecold.update(kwargs)
+    sp_redhot = make_synthspec(**redhot)
+    sp_bluecold = make_synthspec(**bluecold)
+
+    sp = sp_redhot.copy()
+    sp.data = sp_redhot.data + sp_bluecold.data
+    return sp
+
+def test_ammonia_npeaks_kwarg_replicated_guesses():
+    """
+    Regression test: specfit(fittype='ammonia', npeaks=2, guesses=[...6...])
+    used to crash with "TypeError: _make_parinfo() got multiple values for
+    keyword argument 'npeaks'".  A single component's worth of guesses should
+    be replicated for each peak.
+    """
+    sp = make_2comp_synthspec()
+    sp.specfit(fittype='ammonia', npeaks=2, guesses=[23, 5, 13.1, 1, 0, 0.5],
+               fixed=[False, False, False, False, False, True])
+
+    assert sp.specfit.npeaks == 2
+    assert len(sp.specfit.parinfo) == 12
+    assert all(np.isfinite(sp.specfit.parinfo.values))
+
+def test_ammonia_npeaks_kwarg_full_guesses():
+    """
+    npeaks=2 with a full set of 2*6 guesses must also work and should recover
+    the two input components.
+    """
+    sp = make_2comp_synthspec()
+    sp.specfit(fittype='ammonia', npeaks=2,
+               guesses=[26, 9, 13.1, 0.9, 1.2, 0,
+                        13, 6, 13.1, 0.3, -1.2, 0],
+               fixed=[False, False, False, False, False, True])
+
+    assert sp.specfit.npeaks == 2
+    assert len(sp.specfit.parinfo) == 12
+    np.testing.assert_almost_equal(sp.specfit.parinfo['xoff_v0'].value, 1.0, 2)
+    np.testing.assert_almost_equal(sp.specfit.parinfo['xoff_v1'].value, -1.0, 2)
+    np.testing.assert_almost_equal(sp.specfit.parinfo['width0'].value, 1.0, 2)
+    np.testing.assert_almost_equal(sp.specfit.parinfo['width1'].value, 0.2, 2)
+
+def test_ammonia_npeaks_kwarg_single_peak():
+    """
+    An explicit (redundant) npeaks=1 must not change single-peak behavior.
+    """
+    spc = make_synthspec()
+    spc.specfit(fittype='ammonia', npeaks=1, guesses=[23, 22, 13.1, 1, 0.5, 0],
+                fixed=[False, False, False, False, False, True])
+
+    assert spc.specfit.npeaks == 1
+    assert len(spc.specfit.parinfo) == 6
+    np.testing.assert_almost_equal(spc.specfit.parinfo[0].value, 25, 6)
+    np.testing.assert_almost_equal(spc.specfit.parinfo[4].value, 0.0, 3)
+
+def test_ammonia_npeaks_kwarg_mismatch_raises():
+    """
+    npeaks inconsistent with the number of guesses should be a clear
+    ValueError, not a TypeError.
+    """
+    sp = make_2comp_synthspec()
+    with pytest.raises(ValueError) as ex:
+        sp.specfit(fittype='ammonia', npeaks=3,
+                   guesses=[23, 5, 13.1, 1, 0, 0.5,
+                            23, 5, 13.1, 1, 5, 0.5])
+    assert 'npeaks=3' in str(ex.value)
+
+def test_cold_ammonia_npeaks_kwarg():
+    sp = make_2comp_synthspec()
+    sp.specfit.Registry.add_fitter('cold_ammonia',
+                                   ammonia.cold_ammonia_model(), 6)
+    sp.specfit(fittype='cold_ammonia', npeaks=2,
+               guesses=[23, 5, 13.1, 1, 0, 0.5],
+               fixed=[False, False, False, False, False, True])
+
+    assert sp.specfit.npeaks == 2
+    assert len(sp.specfit.parinfo) == 12
+
+def test_ammonia_restricted_tex_npeaks_kwarg():
+    sp = make_2comp_synthspec()
+    sp.specfit.Registry.add_fitter('ammonia_restricted_tex',
+                                   ammonia.ammonia_model_restricted_tex(), 7)
+    sp.specfit(fittype='ammonia_restricted_tex', npeaks=2,
+               guesses=[23, 5, 13.1, 1, 0, 0.5, 18],
+               fixed=[False, False, False, False, False, True, False])
+
+    assert sp.specfit.npeaks == 2
+    assert len(sp.specfit.parinfo) == 14
+
 def test_ammonia_guessing():
 
     mod = ammonia.ammonia_model()


### PR DESCRIPTION
## Bug

`sp.specfit(fittype='ammonia', npeaks=2, guesses=[23, 5, 14.5, 1, 0, 0.5])` crashes:

```
Traceback (most recent call last):
  File "repro.py", line 22, in <module>
    sp.specfit(fittype='ammonia', npeaks=2, guesses=[23, 5, 14.5, 1, 0, 0.5])
  File "pyspeckit/config.py", line 148, in decorator
    f(self, *args, **new_kwargs)
  File "pyspeckit/spectrum/fitters.py", line 347, in __call__
    self.multifit(show_components=show_components, verbose=verbose,
  File "pyspeckit/spectrum/fitters.py", line 740, in multifit
    pinf_for_scaling, _ = self.fitter._make_parinfo(parvalues=guesses,
TypeError: pyspeckit.spectrum.models.model.SpectralModel._make_parinfo() got multiple values for keyword argument 'npeaks'
```

This is not ammonia-specific: `fittype='gaussian'` with `npeaks=2` crashes identically. Multi-component fits previously only worked by omitting `npeaks=` and passing all `npars*npeaks` guesses. (Discovered during the #457 work.)

## Root cause

`Specfit.__call__` stores all extra keywords — including `npeaks` — in `self.fitkwargs`. `Specfit.multifit` then calls

```python
self.fitter._make_parinfo(parvalues=guesses, npeaks=self.npeaks, **self.fitkwargs)
```

(and later `self.fitter(..., npeaks=self.npeaks, ..., **self.fitkwargs)`), so `npeaks` is passed both explicitly and via `**fitkwargs` → `TypeError`. Additionally, `self.npeaks` was derived solely from `len(guesses) // npars`, so an explicit `npeaks=2` with one component's worth of guesses would have been silently treated as one peak even without the collision.

## Fix

In `Specfit.multifit`, pop `npeaks` from both `kwargs` and `self.fitkwargs` (they may or may not be the same dict depending on the call path) and reconcile it with the number of guesses:

- `npars*npeaks` guesses → accepted as-is (unchanged behavior);
- exactly `npars` guesses with `npeaks > 1` → guesses are replicated per peak, matching the established replication behavior of `ammonia_model.make_parinfo` and `SpectralModel._make_parinfo`;
- anything inconsistent → a clear `ValueError` instead of a `TypeError`.

Single-peak fits and fits that omit `npeaks=` are unaffected.

## Tests

New regression tests in `pyspeckit/spectrum/models/tests/test_ammonia.py` against a synthetic two-component (1-1 + 2-2) spectrum:

- `ammonia` with `npeaks=2` and 6 guesses (replicated) → no TypeError, 12-entry parinfo;
- `ammonia` with `npeaks=2` and 12 guesses → recovers both components' `xoff_v`/`width`;
- explicit `npeaks=1` → single-peak fit unchanged;
- `npeaks=3` with 12 guesses → `ValueError` with a helpful message;
- `cold_ammonia` and `ammonia_model_restricted_tex` with `npeaks=2` → no TypeError (12- and 14-entry parinfo respectively).

## Validation

```
MPLBACKEND=Agg python -m pytest pyspeckit/spectrum/models/tests/ pyspeckit/spectrum/tests/ \
    -p no:cacheprovider -o python_files='test_*.py' -q
```

- mambaforge base python: **2306 passed**, 3 skipped, 3 xfailed, 33 xpassed
- pyspeckit-np2 env (numpy 2): **2295 passed**, 3 skipped, 3 xfailed, 33 xpassed
- `pyspeckit/cubes/tests/` + `pyspeckit/spectrum/readers/tests/`: 23 passed
- Verified `fittype='gaussian'` with `npeaks=2` also works after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv
