### PR TITLE
Document how to constrain fit parameters (limits, fixed, tied)

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -65,3 +65,20 @@ start your python session with
 
 (I tend to use ``ipython --pylab``, but it's `deprecated
 <https://github.com/ipython/ipython/pull/5593>`_)
+
+
+How do I set limits (boundary conditions) on the fitted parameters?
+--------------------------------------------------------------------
+
+Use the ``limits`` and ``limited`` keywords to ``specfit`` (or the
+``minpars``/``maxpars``/``limitedmin``/``limitedmax`` variants), e.g.:
+
+.. code:: python
+
+   sp.specfit(fittype='gaussian', guesses=[1, 45, 5],
+              limited=[(True, True), (False, False), (True, False)],
+              limits=[(0, 3), (0, 0), (0, 0)])
+
+constrains the amplitude to the range 0-3 and the width to be positive.
+Parameters can also be held ``fixed`` or ``tied`` to one another.  See
+:ref:`constraining-parameters` for complete, runnable examples.

--- a/docs/fitting.rst
+++ b/docs/fitting.rst
@@ -1,6 +1,10 @@
 Model Fitting
 =============
 
+To constrain the fit parameters - impose limits (boundary conditions), hold
+parameters fixed, or tie parameters to one another - see
+:ref:`constraining-parameters` in the :doc:`parameters` documentation.
+
 General documentation for model fitting is below.  There are several multi-component model fitting tools that have been developed based on pyspeckit:
 
  * `Mike Chen's multi-vlsr <https://github.com/mcyc/multi_vlsr>`_

--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -7,55 +7,235 @@ parallel ways.
 The `parinfo` class is built on top of `lmfit-py's parameters
 <https://github.com/lmfit/lmfit-py/blob/master/doc/parameters.rst>`_ for compatibility
 with lmfit-py, but it builds on that.  The code for the parameter overloading is in
-`parinfo.py <https://bitbucket.org/pyspeckit/pyspeckit.bitbucket.org/src/tip/pyspeckit/spectrum/parinfo.py>`_.
+`parinfo.py <https://github.com/pyspeckit/pyspeckit/blob/master/pyspeckit/spectrum/parinfo.py>`_.
 
-Simple Example
---------------
-Start with a simple example: if you want to limit parameters to be within some range, use
-the `limits` and `limited` parameters.
+.. _constraining-parameters:
+
+Constraining fit parameters: limits, fixed, and tied
+----------------------------------------------------
+
+Every call to ``sp.specfit(...)`` accepts, in addition to ``guesses``, a set
+of per-parameter constraint keywords.  Each is a list with one entry per
+parameter (i.e., ``npars * npeaks`` entries; for a two-Gaussian fit, six
+entries in the order amplitude, center, width, amplitude, center, width):
+
+``limits``
+    A list of two-element ``(min, max)`` tuples specifying the lower and
+    upper bounds on each parameter.
+
+``limited``
+    A list of two-element ``(bool, bool)`` tuples that turn the
+    corresponding entries of ``limits`` on or off.  **Entries in ``limits``
+    are ignored unless the matching ``limited`` flag is `True`**; the common
+    combination ``limits=(0,0), limited=(False,False)`` therefore means
+    "unbounded", not "pinned to zero".
+
+``fixed``
+    A list of booleans.  A `True` entry holds that parameter exactly at its
+    input guess during the fit.
+
+``tied``
+    A list of strings.  An empty string means "free"; a non-empty string is
+    an expression evaluated in terms of the other parameters, referred to as
+    ``p[0]``, ``p[1]``, ... (e.g. ``'p[1]+14.38'`` forces this parameter to
+    equal parameter 1 plus a constant offset).
+
+These work with both the default `mpfit` back-end and with lmfit-py
+(``use_lmfit=True``).
+
+Setting parameter limits (boundary conditions)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following is a complete, runnable example.  The synthetic line has a true
+amplitude of 5, but the fit constrains the amplitude to the range ``[0, 3]``,
+so the fitted amplitude pegs at exactly 3.0:
 
 .. code-block:: python
 
+    import numpy as np
+    import pyspeckit
+
+    xaxis = np.linspace(-50., 150., 100)
+    sigma = 10.
+    center = 50.
+    amplitude = 5.
+
+    np.random.seed(0)
+    synth_data = amplitude * np.exp(-(xaxis - center)**2 / (2 * sigma**2))
+    stddev = 0.1
+    noise = np.random.randn(xaxis.size) * stddev
+    error = stddev * np.ones_like(synth_data)
+    data = noise + synth_data
+
+    sp = pyspeckit.Spectrum(data=data, error=error, xarr=xaxis,
+                            xarrkwargs={'unit': 'km/s'},
+                            unit='K')
+
     # define shorthand first:
-    T,F = True,False
+    T, F = True, False
+    sp.specfit(fittype='gaussian', guesses=[1, 45, 5],
+               limited=[(T, T), (F, F), (T, F)],
+               limits=[(0, 3), (0, 0), (0, 0)])
+    print(sp.specfit.parinfo)
+
+The amplitude is bounded on both sides (``limited=(T,T)``) to the range 0-3,
+the center is unconstrained, and the width has only a lower bound of zero
+(``limited=(T,F)``, so the second element of its ``limits`` entry is
+ignored).  The output shows the amplitude clamped at the upper boundary::
+
+    Param #0   AMPLITUDE0 =            3 +/-               0   Range:     [0,3]
+    Param #1       SHIFT0 =      50.0044 +/-        0.183198
+    Param #2       WIDTH0 =      13.2506 +/-        0.149581   Range:   [0,inf)
+
+(A parameter that ends up pegged at a boundary has zero derivative there, so
+its reported error is 0 - a useful hint that the limit is active.)
+
+One-sided limits are useful for forcing a component to be an emission or an
+absorption line:
+
+.. code-block:: python
+
     sp.specfit(fittype='gaussian', guesses=[-1,5,1,0.5,2,1],
         limits=[(0,0), (0,0), (0,0), (0,0), (0,0), (0,0)],
         limited=[(F,T), (F,F), (T,F), (T,F),  (F,F), (T,F)])
 
 In this example, there are two gaussian components being fitted because a
-Gaussian takes 3 parameters, an amplitude, a center, and a width, and there are
-6 parameters in the input guesses.
+Gaussian takes 3 parameters, an amplitude, a center, and a width, and there
+are 6 parameters in the input guesses.
 
-The first line is forced to be an absorption line: its limits are `(0,0)` but
-`limited=(F,T)` so only the 2nd parameter, the upper limit, is respected: the amplitude
-is forced to be :math:`A\leq 0`.  
+The first line is forced to be an absorption line: its limits are ``(0,0)``
+but ``limited=(F,T)`` so only the 2nd element, the upper limit, is respected:
+the amplitude is forced to be :math:`A\leq 0`.
 
-The second line has its amplitude (the 4th parameter in `guesses`) forced
-*positive* since its limits are also `(0,0)` but its `limited=(T,F)`.  
+The second line has its amplitude (the 4th parameter in ``guesses``) forced
+*positive* since its limits are also ``(0,0)`` but its ``limited=(T,F)``.
 
-Both lines have their *widths* forced to be positive, which is true by default:
-there is no meaning to a negative width, since the width enters into the
-equation for a gaussian as :math:`\sigma^2`.
+Both lines have their *widths* forced to be positive, which is true by
+default: there is no meaning to a negative width, since the width enters into
+the equation for a gaussian as :math:`\sigma^2`.
 
-Note that the need to limit parameters is the main reason for the existence of `lmfit-py <https://github.com/lmfit/lmfit-py>`_
-and `mpfit <https://github.com/segasai/astrolibpy/blob/4993aa4e7c1001efe7c00048ec2b9d5ccac83ff7/mpfit/mpfit.py>`_. 
+Note that the need to limit parameters is the main reason for the existence
+of `lmfit-py <https://github.com/lmfit/lmfit-py>`_ and `mpfit
+<https://github.com/segasai/astrolibpy/blob/4993aa4e7c1001efe7c00048ec2b9d5ccac83ff7/mpfit/mpfit.py>`_.
 
-Tying Parameters
-----------------
-It is also possible to explicitly state that one parameter depends on another.
-If, for example, you want to fit two gaussians, but they must be at a fixed
-wavelength separation from one another (e.g., for fitting the [S II] doublet),
-use `tied`:
+Fixing parameters
+^^^^^^^^^^^^^^^^^
+
+To hold a parameter exactly at its input guess, use ``fixed``.  Continuing
+the example above, this fits only the amplitude and center while the width is
+held at 8:
 
 .. code-block:: python
 
-    sp.specfit(fittype='gaussian', guesses=[1,6716,1,0.5,6731,1],
-        tied=['','','','','p[1]',''])
+    sp.specfit(fittype='gaussian', guesses=[4, 45, 8],
+               fixed=[F, F, T])
+    print(sp.specfit.parinfo)
 
-If you use `lmfit-py` by specifying `use_lmfit=True`, you can use the more advanced `mathematical constraints
-<http://lmfit.github.com/lmfit-py/constraints.html>`_ permitted by lmfit-py.
+::
 
-:doc:`example_sdss` shows a more complete example using `tied`.
+    Param #0   AMPLITUDE0 =      5.46492 +/-       0.0377455
+    Param #1       SHIFT0 =      50.0387 +/-       0.0781422
+    Param #2       WIDTH0 =            8 (fixed)  Range:   [0,inf)
+
+Tying parameters
+^^^^^^^^^^^^^^^^
+
+``tied`` expresses one parameter as a function of the others.  For example,
+to fit the [S II] 6716,6731 doublet with the line separation locked to its
+laboratory value:
+
+.. code-block:: python
+
+    xaxis2 = np.linspace(6690., 6760., 200)
+    sigma2 = 1.5
+    synth_data2 = (1.5 * np.exp(-(xaxis2 - 6716.44)**2 / (2 * sigma2**2)) +
+                   1.0 * np.exp(-(xaxis2 - 6730.82)**2 / (2 * sigma2**2)))
+    np.random.seed(1)
+    noise2 = np.random.randn(xaxis2.size) * 0.05
+    error2 = 0.05 * np.ones_like(synth_data2)
+    sp2 = pyspeckit.Spectrum(data=synth_data2 + noise2, error=error2,
+                             xarr=xaxis2,
+                             xarrkwargs={'unit': 'angstrom'},
+                             unit='erg/s/cm2/AA')
+
+    sp2.specfit(fittype='gaussian', guesses=[1, 6716, 1, 1, 6731, 1],
+                tied=['', '', '', '', 'p[1]+14.38', ''])
+    print(sp2.specfit.parinfo)
+
+::
+
+    Param #0   AMPLITUDE0 =      1.48456 +/-       0.0220743
+    Param #1       SHIFT0 =      6716.46 +/-       0.0218963
+    Param #2       WIDTH0 =      1.52732 +/-       0.0262233   Range:   [0,inf)
+    Param #3   AMPLITUDE1 =     0.980497 +/-       0.0220252
+    Param #4       SHIFT1 =      6730.84 +/-               0  Tied: p[1]+14.38
+    Param #5       WIDTH1 =      1.53413 +/-       0.0397928   Range:   [0,inf)
+
+The second component's center is exactly 14.38 Angstroms redward of the
+first, by construction.  Tied parameters can be combined freely with
+``limits``/``limited`` on the other parameters.  :doc:`example_sdss` shows a
+more complete example using ``tied``.
+
+If you use `lmfit-py <https://github.com/lmfit/lmfit-py>`_ by specifying
+``use_lmfit=True``, you can use the more advanced `mathematical constraints
+<https://lmfit.github.io/lmfit-py/constraints.html>`_ permitted by lmfit-py.
+
+Inspecting and reusing the ``parinfo``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+After any fit, ``sp.specfit.parinfo`` is a
+:class:`~pyspeckit.spectrum.parinfo.ParinfoList` holding the fitted values,
+uncertainties, and all of the constraint metadata.  You can index it by
+parameter name or number:
+
+.. code-block:: python
+
+    sp.specfit.parinfo               # pretty-printed table of all parameters
+    sp.specfit.parinfo['WIDTH0']     # a single Parinfo object
+    sp.specfit.parinfo.values        # [5.46, 50.04, 8.0]
+    sp.specfit.parinfo.errors        # [0.038, 0.078, 0.0]
+
+    pi = sp.specfit.parinfo
+    pi['AMPLITUDE0'].value, pi['AMPLITUDE0'].error, pi['AMPLITUDE0'].limits
+
+You can also modify a ``parinfo`` and pass it back in as the starting point
+(and constraint specification) for a new fit, instead of using the keyword
+lists:
+
+.. code-block:: python
+
+    pi = sp.specfit.parinfo
+    pi['AMPLITUDE0'].limited = (True, True)
+    pi['AMPLITUDE0'].limits = (0, 3)
+    pi['AMPLITUDE0'].value = 2.5
+    pi['WIDTH0'].fixed = False
+    sp.specfit(parinfo=pi)
+
+Model-specific keywords: ``minpars``, ``maxpars``, ``limitedmin``, ``limitedmax``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+As an alternative to the tuple-based ``limits``/``limited`` keywords,
+``specfit`` also accepts the split form used by several of the model
+wrappers: ``minpars`` and ``maxpars`` are lists of scalar lower/upper
+bounds, and ``limitedmin``/``limitedmax`` are the corresponding lists of
+booleans.  ``minpars=[0,0,0], limitedmin=[True,False,True]`` is equivalent to
+``limits=[(0,0),(0,0),(0,0)], limited=[(True,False),(False,False),(True,False)]``.
+
+Some models apply sensible physical limits by default.  The ammonia model,
+for example (parameters ``tkin, tex, ntot, width, xoff_v, fortho``), uses
+default constraints equivalent to passing
+
+.. code-block:: python
+
+    limitedmin=(True, True, True, True, False, True),
+    limitedmax=(False, False, True, False, False, True),
+    minpars=(2.7315, 2.7315, 5, 0, 0, 0),
+    maxpars=(0, 0, 25, 0, 0, 1)
+
+i.e., temperatures bounded below by the CMB temperature, log column density
+between 5 and 25, positive linewidth, and ortho fraction between 0 and 1.
+You can override any of these by passing your own values for those keywords
+to ``specfit``.
 
 Making your own `parinfo`
 -------------------------

--- a/pyspeckit/spectrum/tests/test_parameter_constraints.py
+++ b/pyspeckit/spectrum/tests/test_parameter_constraints.py
@@ -1,0 +1,86 @@
+"""
+Tests for the parameter-constraint examples documented in
+docs/parameters.rst ("Constraining fit parameters: limits, fixed, and
+tied").  These mirror the doc code blocks so that the documented behavior
+(issue #321) stays correct.
+"""
+import numpy as np
+
+import pyspeckit
+
+
+def make_gaussian_spectrum(amplitude=5., center=50., sigma=10., stddev=0.1,
+                           seed=0):
+    xaxis = np.linspace(-50., 150., 100)
+    np.random.seed(seed)
+    synth_data = amplitude * np.exp(-(xaxis - center)**2 / (2 * sigma**2))
+    noise = np.random.randn(xaxis.size) * stddev
+    error = stddev * np.ones_like(synth_data)
+    sp = pyspeckit.Spectrum(data=synth_data + noise, error=error, xarr=xaxis,
+                            xarrkwargs={'unit': 'km/s'}, unit='K')
+    return sp
+
+
+def test_amplitude_limit_pegs_at_boundary():
+    # true amplitude is 5, but the fit is constrained to [0, 3]
+    sp = make_gaussian_spectrum()
+    T, F = True, False
+    sp.specfit(fittype='gaussian', guesses=[1, 45, 5],
+               limited=[(T, T), (F, F), (T, F)],
+               limits=[(0, 3), (0, 0), (0, 0)])
+    assert sp.specfit.parinfo['AMPLITUDE0'].value == 3.0
+    # the center is still recovered correctly
+    np.testing.assert_allclose(sp.specfit.parinfo['SHIFT0'].value, 50,
+                               atol=1)
+
+
+def test_fixed_parameter_stays_fixed():
+    sp = make_gaussian_spectrum()
+    F = False
+    sp.specfit(fittype='gaussian', guesses=[4, 45, 8],
+               fixed=[F, F, True])
+    assert sp.specfit.parinfo['WIDTH0'].value == 8.0
+    assert sp.specfit.parinfo['WIDTH0'].fixed
+    assert sp.specfit.parinfo['WIDTH0'].error == 0
+
+
+def test_tied_parameters_fixed_separation():
+    xaxis = np.linspace(6690., 6760., 200)
+    sigma = 1.5
+    synth_data = (1.5 * np.exp(-(xaxis - 6716.44)**2 / (2 * sigma**2)) +
+                  1.0 * np.exp(-(xaxis - 6730.82)**2 / (2 * sigma**2)))
+    np.random.seed(1)
+    noise = np.random.randn(xaxis.size) * 0.05
+    error = 0.05 * np.ones_like(synth_data)
+    sp = pyspeckit.Spectrum(data=synth_data + noise, error=error, xarr=xaxis,
+                            xarrkwargs={'unit': 'angstrom'},
+                            unit='erg/s/cm2/AA')
+    sp.specfit(fittype='gaussian', guesses=[1, 6716, 1, 1, 6731, 1],
+               tied=['', '', '', '', 'p[1]+14.38', ''])
+    separation = (sp.specfit.parinfo['SHIFT1'].value -
+                  sp.specfit.parinfo['SHIFT0'].value)
+    np.testing.assert_allclose(separation, 14.38)
+
+
+def test_modified_parinfo_reuse():
+    sp = make_gaussian_spectrum()
+    sp.specfit(fittype='gaussian', guesses=[4, 45, 8])
+    pi = sp.specfit.parinfo
+    pi['AMPLITUDE0'].limited = (True, True)
+    pi['AMPLITUDE0'].limits = (0, 3)
+    pi['AMPLITUDE0'].value = 2.5
+    sp.specfit(parinfo=pi)
+    assert sp.specfit.parinfo['AMPLITUDE0'].value == 3.0
+    assert len(sp.specfit.parinfo) == 3
+
+
+def test_minpars_maxpars_equivalent_to_limits():
+    sp = make_gaussian_spectrum()
+    sp.specfit(fittype='gaussian', guesses=[1, 45, 5],
+               limitedmin=[True, False, True],
+               limitedmax=[True, False, False],
+               minpars=[0, 0, 0],
+               maxpars=[3, 0, 0])
+    assert sp.specfit.parinfo['AMPLITUDE0'].value == 3.0
+    assert sp.specfit.parinfo['AMPLITUDE0'].limits == (0, 3)
+    assert tuple(sp.specfit.parinfo['AMPLITUDE0'].limited) == (True, True)


### PR DESCRIPTION
Issue #321 asked how to impose boundary conditions on `specfit` parameters. The mechanism has existed all along (`limits=`/`limited=` per-parameter tuples, `minpars`/`maxpars`/`limitedmin`/`limitedmax` in the model wrappers, and direct `parinfo` manipulation) and was verified working in #338, but the documentation was thin. This PR documents it thoroughly.

## What's new

**`docs/parameters.rst`** gains a "Constraining fit parameters: limits, fixed, and tied" section (with a `constraining-parameters` cross-reference label) covering:

- The four per-parameter constraint keywords (`limits`, `limited`, `fixed`, `tied`), their formats, and the explicit convention: **`limits` entries are ignored unless the matching `limited` flag is `True`** — `limits=(0,0), limited=(False,False)` means unbounded, not pinned to zero.
- A complete runnable bounded-fit example: a synthetic Gaussian with true amplitude 5 fit with `limits=[(0,3),(0,0),(0,0)]`, `limited=[(T,T),(F,F),(T,F)]` — the amplitude pegs at exactly 3.0 (with a note that a zero reported error signals an active limit).
- One-sided limits for forcing emission/absorption components (the pre-existing example, folded in).
- Fixing parameters with `fixed=`.
- Tying parameters with `tied=` (doublet with the separation locked via `'p[1]+14.38'`).
- Inspecting `sp.specfit.parinfo` (indexing by name, `.values`, `.errors`, `.limits`) and passing a modified `parinfo` back into `specfit`.
- The `minpars`/`maxpars`/`limitedmin`/`limitedmax` split form and the ammonia model's default physical limits as an example.

The previously overlapping "Simple Example" and "Tying Parameters" sections were folded into the new section (no content lost). `docs/fitting.rst` now points to the new section, and `docs/faq.rst` gains a "How do I set limits (boundary conditions) on the fitted parameters?" entry.

**`pyspeckit/spectrum/tests/test_parameter_constraints.py`** adds 5 tests mirroring the doc code blocks so the documented behavior stays correct (limit pegging at 3.0, fixed width staying exact, tied separation exact, parinfo reuse, minpars/maxpars equivalence).

## Verification

- All doc code blocks were executed as a script (`MPLBACKEND=Agg`); the outputs shown in the docs are the actual outputs (amplitude = 3.0 exactly, width fixed at 8, tied separation = 14.38).
- `python -m pytest pyspeckit/spectrum/tests/test_parameter_constraints.py` -> 5 passed.
- Strict docs build: `sphinx-build -W -b html docs ...` -> build succeeded.

Fixes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGtGYhSakAyzKXz9Wd2QLv
